### PR TITLE
feat: MJ Image Capture & Drag-and-Drop

### DIFF
--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -13,14 +13,15 @@ function getPromptFromContainer(img: HTMLImageElement): string {
   const unitContainer = img.closest("#pageScroll > div") || img.closest(".absolute") || img.closest(".group")
   
   if (unitContainer) {
-      // User provided HTML shows the prompt is in a span with "word-break: break-word" style
-      // or class "inline align-baseline" inside the .break-word container.
-      // The first span might be an image thumbnail wrapper.
-      const promptSpan = unitContainer.querySelector('.break-word span[style*="word-break"]') || 
-                         unitContainer.querySelector('.break-word span.align-baseline')
-      
-      if (promptSpan && promptSpan.textContent) {
-          return promptSpan.textContent.trim()
+      // Robust strategy: Find .break-word container, then find the span that is NOT the thumbnail
+      const breakWordDiv = unitContainer.querySelector(".break-word")
+      if (breakWordDiv) {
+          const spans = Array.from(breakWordDiv.querySelectorAll(":scope > span"))
+          // The prompt span usually doesn't contain the thumbnail image directly
+          const targetSpan = spans.find(span => !span.querySelector("img") && span.textContent?.trim())
+          if (targetSpan && targetSpan.textContent) {
+              return targetSpan.textContent.trim()
+          }
       }
   }
 
@@ -28,10 +29,13 @@ function getPromptFromContainer(img: HTMLImageElement): string {
   let current: HTMLElement | null = img.parentElement
   for (let i = 0; i < 5; i++) {
       if (!current) break
-      const promptEl = current.querySelector('.break-word span[style*="word-break"]') || 
-                       current.querySelector('.break-word span.align-baseline')
-      if (promptEl && promptEl.textContent) {
-          return promptEl.textContent.trim()
+      const breakWordDiv = current.querySelector(".break-word")
+      if (breakWordDiv) {
+          const spans = Array.from(breakWordDiv.querySelectorAll(":scope > span"))
+          const targetSpan = spans.find(span => !span.querySelector("img") && span.textContent?.trim())
+          if (targetSpan && targetSpan.textContent) {
+              return targetSpan.textContent.trim()
+          }
       }
       current = current.parentElement
   }

--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -26,14 +26,17 @@ function getPromptFromContainer(img: HTMLImageElement): string {
           }
 
           // 2. Get Parameters (Sref etc) from sibling container
-          const parent = breakWordDiv.parentElement
+          // Use closest to find common parent reliably (e.g. .overflow-clip or .group)
+          const parent = breakWordDiv.closest('.overflow-clip') || breakWordDiv.closest('.group') || breakWordDiv.parentElement
+          
           if (parent) {
               // Debug logs
-              console.log("[SA Debug] Prompt Parent:", parent)
+              console.log("[SA Debug] Common Parent:", parent)
               console.log("[SA Debug] Parent Classes:", parent.className)
 
               // Try to find the parameter container with various strategies
               // User reported: div.gap-3.flex.flex-col...
+              // Search specifically for container with gap-3 that is likely to hold buttons
               const paramContainer = parent.querySelector("div.gap-3") || 
                                      parent.querySelector('div[class*="gap-3"]')
               

--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -13,14 +13,14 @@ function getPromptFromContainer(img: HTMLImageElement): string {
   const unitContainer = img.closest("#pageScroll > div") || img.closest(".absolute") || img.closest(".group")
   
   if (unitContainer) {
-      // Robust strategy: Find .break-word container, then find the span that is NOT the thumbnail
+      // Robust strategy: Find .break-word container, then collect text from all spans that are NOT the thumbnail
       const breakWordDiv = unitContainer.querySelector(".break-word")
       if (breakWordDiv) {
           const spans = Array.from(breakWordDiv.querySelectorAll(":scope > span"))
-          // The prompt span usually doesn't contain the thumbnail image directly
-          const targetSpan = spans.find(span => !span.querySelector("img") && span.textContent?.trim())
-          if (targetSpan && targetSpan.textContent) {
-              return targetSpan.textContent.trim()
+          // Collect text from all valid spans (prompt text + parameters might be split)
+          const validSpans = spans.filter(span => !span.querySelector("img") && span.textContent?.trim())
+          if (validSpans.length > 0) {
+              return validSpans.map(s => s.textContent).join(" ").trim()
           }
       }
   }
@@ -32,9 +32,9 @@ function getPromptFromContainer(img: HTMLImageElement): string {
       const breakWordDiv = current.querySelector(".break-word")
       if (breakWordDiv) {
           const spans = Array.from(breakWordDiv.querySelectorAll(":scope > span"))
-          const targetSpan = spans.find(span => !span.querySelector("img") && span.textContent?.trim())
-          if (targetSpan && targetSpan.textContent) {
-              return targetSpan.textContent.trim()
+          const validSpans = spans.filter(span => !span.querySelector("img") && span.textContent?.trim())
+          if (validSpans.length > 0) {
+              return validSpans.map(s => s.textContent).join(" ").trim()
           }
       }
       current = current.parentElement

--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -13,7 +13,12 @@ function getPromptFromContainer(img: HTMLImageElement): string {
   const unitContainer = img.closest("#pageScroll > div") || img.closest(".absolute") || img.closest(".group")
   
   if (unitContainer) {
-      const promptSpan = unitContainer.querySelector(".break-word span")
+      // User provided HTML shows the prompt is in a span with "word-break: break-word" style
+      // or class "inline align-baseline" inside the .break-word container.
+      // The first span might be an image thumbnail wrapper.
+      const promptSpan = unitContainer.querySelector('.break-word span[style*="word-break"]') || 
+                         unitContainer.querySelector('.break-word span.align-baseline')
+      
       if (promptSpan && promptSpan.textContent) {
           return promptSpan.textContent.trim()
       }
@@ -23,7 +28,8 @@ function getPromptFromContainer(img: HTMLImageElement): string {
   let current: HTMLElement | null = img.parentElement
   for (let i = 0; i < 5; i++) {
       if (!current) break
-      const promptEl = current.querySelector(".break-word span")
+      const promptEl = current.querySelector('.break-word span[style*="word-break"]') || 
+                       current.querySelector('.break-word span.align-baseline')
       if (promptEl && promptEl.textContent) {
           return promptEl.textContent.trim()
       }

--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -1,0 +1,102 @@
+import type { PlasmoCSConfig } from "plasmo"
+
+export const config: PlasmoCSConfig = {
+  matches: ["https://midjourney.com/*", "https://*.midjourney.com/*"],
+  all_frames: true,
+  run_at: "document_start"
+}
+
+const DEBUG_MODE = false
+
+function getPromptFromContainer(img: HTMLImageElement): string {
+  // Strategy 1: Look for common container under #pageScroll (User provided selector)
+  const unitContainer = img.closest("#pageScroll > div") || img.closest(".absolute") || img.closest(".group")
+  
+  if (unitContainer) {
+      const promptSpan = unitContainer.querySelector(".break-word span")
+      if (promptSpan && promptSpan.textContent) {
+          return promptSpan.textContent.trim()
+      }
+  }
+
+  // Strategy 2: Traverse up 5 levels (Fallback)
+  let current: HTMLElement | null = img.parentElement
+  for (let i = 0; i < 5; i++) {
+      if (!current) break
+      const promptEl = current.querySelector(".break-word span")
+      if (promptEl && promptEl.textContent) {
+          return promptEl.textContent.trim()
+      }
+      current = current.parentElement
+  }
+  return ""
+}
+
+function processImage(img: HTMLImageElement) {
+  if (img.dataset.saObserved) return
+  img.dataset.saObserved = "true"
+
+  if (DEBUG_MODE) {
+    img.style.outline = "2px solid #00ff00"
+    img.style.outlineOffset = "-2px"
+  }
+
+  // Ensure draggable is enabled for interaction
+  img.draggable = true
+  img.style.cursor = "grab"
+
+  img.addEventListener("dragstart", (e) => {
+    // Attempt to extract prompt
+    const prompt = getPromptFromContainer(img) || img.alt || ""
+    
+    // Attempt to extract Job ID from parent link
+    let jobId = ""
+    const parentLink = img.closest("a")
+    if (parentLink && parentLink.href) {
+        const match = parentLink.href.match(/jobs\/([a-f0-9-]{36})/)
+        if (match) jobId = match[1]
+    }
+
+    const payload = {
+      src: img.src,
+      prompt: prompt,
+      jobId: jobId,
+      source: "midjourney-web"
+    }
+
+    if (e.dataTransfer) {
+      try {
+        // Attach custom data for the extension side panel
+        e.dataTransfer.setData("application/json", JSON.stringify(payload))
+      } catch (err) {
+        console.error("Style Atelier: Failed to attach data", err)
+      }
+    }
+  }, { capture: true })
+}
+
+function observeDOM() {
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (node instanceof HTMLElement) {
+          if (node.tagName === "IMG") processImage(node as HTMLImageElement)
+          node.querySelectorAll("img").forEach(processImage)
+        }
+      })
+    })
+  })
+
+  observer.observe(document.body, { childList: true, subtree: true })
+  
+  // Initial scan
+  document.querySelectorAll("img").forEach(processImage)
+}
+
+if (document.readyState === "loading") {
+    window.addEventListener("DOMContentLoaded", observeDOM)
+} else {
+    observeDOM()
+}
+// Ensure it runs after full load as well for late injections
+window.addEventListener("load", observeDOM)

--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -6,15 +6,15 @@ export const config: PlasmoCSConfig = {
   run_at: "document_start"
 }
 
-const DEBUG_MODE = false
+const DEBUG_MODE = true // Re-enable for debugging
 
 function getPromptFromContainer(img: HTMLImageElement): string {
   // Strategy 1: Look for common container under #pageScroll (User provided selector)
   const unitContainer = img.closest("#pageScroll > div") || img.closest(".absolute") || img.closest(".group")
   
   if (unitContainer) {
-      // Robust strategy: Find .break-word container (Prompt) AND .gap-3 container (Parameters)
       const breakWordDiv = unitContainer.querySelector(".break-word")
+      
       if (breakWordDiv) {
           let fullText = ""
 
@@ -26,14 +26,25 @@ function getPromptFromContainer(img: HTMLImageElement): string {
           }
 
           // 2. Get Parameters (Sref etc) from sibling container
-          // Selector hint: #pageScroll ... > div.gap-3 ...
           const parent = breakWordDiv.parentElement
           if (parent) {
-              const paramContainer = parent.querySelector("div.gap-3")
+              // Debug logs
+              console.log("[SA Debug] Prompt Parent:", parent)
+              console.log("[SA Debug] Parent Classes:", parent.className)
+
+              // Try to find the parameter container with various strategies
+              // User reported: div.gap-3.flex.flex-col...
+              const paramContainer = parent.querySelector("div.gap-3") || 
+                                     parent.querySelector('div[class*="gap-3"]')
+              
+              console.log("[SA Debug] Param Container Candidate:", paramContainer)
+
               if (paramContainer && paramContainer.textContent) {
-                  // Only append if it looks like parameters (starts with --) or just append everything safely
                   const params = paramContainer.textContent.trim()
+                  console.log("[SA Debug] Param Text Found:", params)
                   if (params) fullText += " " + params
+              } else {
+                  console.warn("[SA Debug] Param Container NOT found or empty")
               }
           }
 

--- a/src/sidepanel.tsx
+++ b/src/sidepanel.tsx
@@ -2,20 +2,135 @@ import { useState } from "react"
 import "./style.css"
 
 function SidePanel() {
-  const [count, setCount] = useState(0)
+  const [isDragging, setIsDragging] = useState(false)
+  const [droppedData, setDroppedData] = useState<{src: string, prompt?: string, jobId?: string} | null>(null)
+  const [logs, setLogs] = useState<string[]>([])
+
+  const addLog = (msg: string) => setLogs(prev => [msg, ...prev].slice(0, 20))
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragging(true)
+  }
+
+  const handleDragLeave = () => {
+    setIsDragging(false)
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragging(false)
+    addLog("Drop event received")
+
+    // Priority 1: Custom JSON Data (from Content Script)
+    const jsonData = e.dataTransfer.getData("application/json")
+    if (jsonData) {
+      try {
+        const data = JSON.parse(jsonData)
+        addLog(`JSON received: ${data.src?.substring(0, 30)}...`)
+        if (data.src) {
+            setDroppedData(data)
+            return
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    }
+
+    // Priority 2: Standard URL (Fallback for job links)
+    const url = e.dataTransfer.getData("text/uri-list") || e.dataTransfer.getData("text/plain")
+    if (url) {
+        addLog(`URL received: ${url.substring(0, 30)}...`)
+        
+        // Check if it is a Job URL
+        if (url.includes("/jobs/")) {
+            const match = url.match(/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/)
+            if (match) {
+                const jobId = match[1]
+                const imageUrl = `https://cdn.midjourney.com/${jobId}/0_0.webp`
+                addLog(`Resolved Job ID: ${jobId}`)
+                setDroppedData({
+                    src: imageUrl,
+                    jobId: jobId,
+                    prompt: "Prompt not available from URL"
+                })
+                return
+            }
+        }
+
+        // Direct Image URL
+        if (url.match(/\.(webp|png|jpg|jpeg|gif)$/i) || url.includes("cdn.midjourney.com")) {
+             setDroppedData({ src: url })
+             return
+        }
+
+        addLog("URL format not recognized as MJ image or job")
+    } else {
+        addLog("No URL found in drop data")
+    }
+  }
 
   return (
-    <div className="w-full h-screen p-4 bg-slate-50 flex flex-col items-center justify-center font-sans">
-      <h1 className="text-2xl font-bold text-slate-900 mb-4">
-        Style Atelier
-      </h1>
-      <p className="mb-4 text-slate-600">Side Panel Initialized</p>
-      <button
-        onClick={() => setCount((c) => c + 1)}
-        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
-      >
-        Count: {count}
-      </button>
+    <div 
+        className={`w-full h-screen p-4 flex flex-col items-center font-sans transition-colors ${isDragging ? 'bg-blue-100' : 'bg-slate-50'}`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+    >
+      <h1 className="text-xl font-bold text-slate-900 mb-4">Style Atelier</h1>
+      
+      {droppedData ? (
+        <div className="flex-1 w-full overflow-y-auto mb-4">
+            <div className="p-3 border rounded bg-white shadow-sm w-full animate-in fade-in zoom-in">
+                <p className="text-xs text-slate-500 mb-2 font-bold uppercase tracking-wider">Captured Asset</p>
+                <div className="relative aspect-square w-full mb-3 bg-slate-100 rounded overflow-hidden">
+                    <img src={droppedData.src} alt="Dropped" className="w-full h-full object-contain" />
+                </div>
+                
+                {droppedData.prompt && (
+                    <div className="mb-3">
+                        <p className="text-[10px] text-slate-400 uppercase font-bold mb-1">Prompt</p>
+                        <p className="text-xs text-slate-700 bg-slate-50 p-2 rounded border border-slate-100 leading-relaxed max-h-32 overflow-y-auto">
+                            {droppedData.prompt}
+                        </p>
+                    </div>
+                )}
+                
+                {droppedData.jobId && (
+                     <div className="mb-3">
+                        <p className="text-[10px] text-slate-400 uppercase font-bold mb-1">Job ID</p>
+                        <code className="text-[10px] bg-slate-100 px-1 py-0.5 rounded text-slate-600 block truncate">
+                            {droppedData.jobId}
+                        </code>
+                    </div>
+                )}
+
+                <button 
+                    onClick={() => setDroppedData(null)}
+                    className="mt-2 w-full text-xs text-red-500 hover:bg-red-50 p-2 rounded transition-colors border border-transparent hover:border-red-100"
+                >
+                    Clear
+                </button>
+            </div>
+        </div>
+      ) : (
+        <div className="flex-1 flex items-center justify-center w-full mb-4">
+            <div className="p-8 border-2 border-dashed border-slate-300 rounded-lg text-slate-400 text-center w-full h-64 flex flex-col items-center justify-center gap-2">
+                <svg className="w-8 h-8 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                <p className="text-sm">Drop MJ Image Here</p>
+            </div>
+        </div>
+      )}
+
+      <div className="w-full">
+          <div className="flex justify-between items-center mb-1">
+             <p className="text-[10px] text-slate-500 uppercase font-bold">Debug Logs</p>
+             <button onClick={() => setLogs([])} className="text-[10px] text-slate-400 hover:text-slate-600">Clear</button>
+          </div>
+          <div className="bg-slate-900 text-green-400 p-2 rounded text-[10px] font-mono h-24 overflow-y-auto whitespace-pre-wrap shadow-inner">
+            {logs.length === 0 ? <span className="text-slate-600 opacity-50">Waiting for events...</span> : logs.map((log, i) => <div key={i} className="mb-1 border-b border-green-900/30 pb-0.5 last:border-0">{`> ${log}`}</div>)}
+          </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Implements Content Script to observe MJ generated images on midjourney.com and allow dragging them to the Side Panel with prompt data.

## Key Changes
- Added \src/contents/mj-web-observer.ts\: Content Script for image detection and prompt extraction.
- Updated \src/sidepanel.tsx\: Added drop zone and data handling logic.
- Supported both custom JSON data transfer (primary) and Job URL parsing (fallback).

## Verification
- Verified on midjourney.com.
- Confirmed image and prompt extraction via Drag and Drop.
- Confirmed fallback to Job URL parsing when custom data is unavailable.