### PR TITLE
feat: Prompt Injection Mechanism

### DIFF
--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -6,7 +6,7 @@ export const config: PlasmoCSConfig = {
   run_at: "document_start"
 }
 
-const DEBUG_MODE = true // Temporarily enabled for debugging
+const DEBUG_MODE = false
 
 function getPromptFromContainer(img: HTMLImageElement): string {
   // Strategy 1: Look for common container under #pageScroll (User provided selector)
@@ -144,8 +144,6 @@ function processImage(img: HTMLImageElement) {
   img.style.cursor = "grab"
 
   img.addEventListener("dragstart", (e) => {
-    console.log("Style Atelier: Drag start detected", img.src)
-    
     // Attempt to extract prompt
     let prompt = getPromptFromContainer(img)
     
@@ -172,13 +170,10 @@ function processImage(img: HTMLImageElement) {
       source: "midjourney-web"
     }
 
-    console.log("Style Atelier: Extracted payload", payload)
-
     if (e.dataTransfer) {
       try {
         // Attach custom data for the extension side panel
         e.dataTransfer.setData("application/json", JSON.stringify(payload))
-        console.log("Style Atelier: Data attached to DataTransfer")
       } catch (err) {
         console.error("Style Atelier: Failed to attach data", err)
       }

--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -6,7 +6,7 @@ export const config: PlasmoCSConfig = {
   run_at: "document_start"
 }
 
-const DEBUG_MODE = false
+const DEBUG_MODE = true // Temporarily enabled for debugging
 
 function getPromptFromContainer(img: HTMLImageElement): string {
   // Strategy 1: Look for common container under #pageScroll (User provided selector)
@@ -144,6 +144,8 @@ function processImage(img: HTMLImageElement) {
   img.style.cursor = "grab"
 
   img.addEventListener("dragstart", (e) => {
+    console.log("Style Atelier: Drag start detected", img.src)
+    
     // Attempt to extract prompt
     let prompt = getPromptFromContainer(img)
     
@@ -170,10 +172,13 @@ function processImage(img: HTMLImageElement) {
       source: "midjourney-web"
     }
 
+    console.log("Style Atelier: Extracted payload", payload)
+
     if (e.dataTransfer) {
       try {
         // Attach custom data for the extension side panel
         e.dataTransfer.setData("application/json", JSON.stringify(payload))
+        console.log("Style Atelier: Data attached to DataTransfer")
       } catch (err) {
         console.error("Style Atelier: Failed to attach data", err)
       }

--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -246,8 +246,12 @@ function injectPrompt(prompt: string) {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  console.log("Style Atelier: Message received", message)
   if (message.type === "INJECT_PROMPT" && message.prompt) {
       injectPrompt(message.prompt)
+      sendResponse({ status: "success" })
+  } else {
+      sendResponse({ status: "unknown_message" })
   }
 })
 

--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -204,25 +204,20 @@ function injectPrompt(prompt: string) {
   console.log("Style Atelier: Attempting to inject prompt:", prompt)
   
   // Try to find the input area
-  // Priority 1: Specific ID or aria-label often used in chat apps
-  // Note: MJ Alpha/Beta site structure may vary
+  // Expanded selectors for better compatibility
   let input = document.getElementById("prompt-textarea") || 
               document.querySelector('[aria-label="Imagine a prompt"]') ||
               document.querySelector('[aria-label="Prompt text"]') ||
               document.querySelector('[data-testid="prompt-input"]') ||
               document.querySelector('[role="textbox"]') ||
+              document.querySelector('div[contenteditable="true"]') || 
+              document.querySelector('textarea[placeholder*="Imagine"]') ||
               document.querySelector('textarea')
 
   if (input) {
       // Handle contenteditable div
       if (input.isContentEditable) {
           input.focus()
-          // Select all existing text if any? Or just append?
-          // For now, let's append or replace. Typically users want to use this prompt.
-          // Let's replace for simplicity as per "insert its prompt" usually implies setting the prompt.
-          // However, if we want to append, we'd need to check existing content.
-          // Let's try inserting at cursor or replacing.
-          
           // Using execCommand is deprecated but often works for contenteditable
           document.execCommand('selectAll', false, undefined)
           document.execCommand('insertText', false, prompt)
@@ -237,11 +232,12 @@ function injectPrompt(prompt: string) {
           }
           
           input.dispatchEvent(new Event('input', { bubbles: true }));
+          input.dispatchEvent(new Event('change', { bubbles: true }));
           input.focus()
       }
       console.log("Style Atelier: Prompt injected successfully")
   } else {
-      console.error("Style Atelier: Could not find chat input area")
+      console.error("Style Atelier: Could not find chat input area. Checked selectors: #prompt-textarea, [aria-label], [role=textbox], contenteditable, textarea")
   }
 }
 

--- a/src/sidepanel.tsx
+++ b/src/sidepanel.tsx
@@ -63,6 +63,25 @@ function SidePanel() {
     }
   }
 
+  const handleCardClick = (prompt: string) => {
+    // Send message to active tab to inject prompt
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const activeTab = tabs[0]
+      if (activeTab?.id) {
+        chrome.tabs.sendMessage(activeTab.id, {
+          type: "INJECT_PROMPT",
+          prompt: prompt
+        }).catch(err => {
+            // Ignore connection errors if content script isn't ready or on a different page
+            addLog(`Note: ${err.message || 'Could not send to tab'}`)
+        })
+        addLog(`Sent prompt: ${prompt.substring(0, 20)}...`)
+      } else {
+          addLog("No active tab found")
+      }
+    })
+  }
+
   return (
     <div 
         className={`w-full h-screen flex flex-col font-sans transition-colors ${isDragging ? 'bg-blue-50' : 'bg-slate-50'}`}
@@ -128,7 +147,11 @@ function SidePanel() {
              ) : (
                  <div className="grid grid-cols-2 gap-3">
                      {styleCards.map(card => (
-                         <div key={card.id} className="group relative bg-white border border-slate-200 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
+                         <div 
+                            key={card.id} 
+                            onClick={() => handleCardClick(card.prompt)}
+                            className="group relative bg-white border border-slate-200 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+                         >
                              <div className="aspect-square bg-slate-100 overflow-hidden">
                                  <img src={card.imageUrl} alt="Style" className="w-full h-full object-cover transition-transform group-hover:scale-105" />
                              </div>


### PR DESCRIPTION
Implements the functionality to inject prompts from the side panel into Midjourney's web interface chat input.

**Changes:**
- src/sidepanel.tsx: Added click handler to style cards to send message to active tab.
- src/contents/mj-web-observer.ts: Added message listener for 'INJECT_PROMPT' and logic to find and populate the chat input area.

Closes #9