### PR TITLE
refactor: Split mj-web-observer.ts into services and domain logic (#22)

### DIFF
--- a/src/contents/domain/actions/PromptInjector.ts
+++ b/src/contents/domain/actions/PromptInjector.ts
@@ -1,0 +1,49 @@
+import type { IActionHandler } from "../interfaces"
+
+export class PromptInjector implements IActionHandler {
+  async handle(prompt: any): Promise<void> {
+    if (typeof prompt !== "string") {
+        console.error("Style Atelier: Invalid prompt format")
+        return
+    }
+
+    console.log("Style Atelier: Attempting to inject prompt:", prompt)
+    
+    // Try to find the input area
+    // Expanded selectors for better compatibility
+    let input = document.getElementById("prompt-textarea") || 
+                document.querySelector('[aria-label="Imagine a prompt"]') ||
+                document.querySelector('[aria-label="Prompt text"]') ||
+                document.querySelector('[data-testid="prompt-input"]') ||
+                document.querySelector('[role="textbox"]') ||
+                document.querySelector('div[contenteditable="true"]') || 
+                document.querySelector('textarea[placeholder*="Imagine"]') ||
+                document.querySelector('textarea')
+
+    if (input) {
+        // Handle contenteditable div
+        if (input.isContentEditable) {
+            (input as HTMLElement).focus()
+            // Using execCommand is deprecated but often works for contenteditable
+            document.execCommand('selectAll', false, undefined)
+            document.execCommand('insertText', false, prompt)
+        } else {
+            // Handle textarea/input
+            // React override hack for input values
+            const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+            if (nativeInputValueSetter) {
+                nativeInputValueSetter.call(input, prompt);
+            } else {
+                (input as HTMLTextAreaElement).value = prompt;
+            }
+            
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            input.dispatchEvent(new Event('change', { bubbles: true }));
+            (input as HTMLElement).focus()
+        }
+        console.log("Style Atelier: Prompt injected successfully")
+    } else {
+        console.error("Style Atelier: Could not find chat input area. Checked selectors: #prompt-textarea, [aria-label], [role=textbox], contenteditable, textarea")
+    }
+  }
+}

--- a/src/contents/domain/extractors/WebDataExtractor.ts
+++ b/src/contents/domain/extractors/WebDataExtractor.ts
@@ -1,0 +1,156 @@
+import type { IExtractor, IMJElementData } from "../interfaces"
+
+export class WebDataExtractor implements IExtractor {
+  extract(element: HTMLElement): IMJElementData | null {
+    const img = element as HTMLImageElement
+    if (img.tagName !== "IMG") return null
+
+    // Attempt to extract prompt
+    let prompt = this.getPromptFromContainer(img)
+    
+    // Fallback logic: If extracted prompt seems missing parameters (no '--') 
+    // but alt text has them, prefer alt text.
+    if ((!prompt || !prompt.includes('--')) && img.alt && img.alt.includes('--')) {
+        prompt = img.alt
+    } else if (!prompt) {
+        prompt = img.alt || ""
+    }
+    
+    // Attempt to extract Job ID from parent link
+    let jobId = ""
+    const parentLink = img.closest("a")
+    if (parentLink && parentLink.href) {
+        const match = parentLink.href.match(/jobs\/([a-f0-9-]{36})/)
+        if (match) jobId = match[1]
+    }
+
+    return {
+      src: img.src,
+      prompt: prompt,
+      jobId: jobId,
+      source: "midjourney-web"
+    }
+  }
+
+  private getPromptFromContainer(img: HTMLImageElement): string {
+    // Strategy 1: Look for common container under #pageScroll (User provided selector)
+    const unitContainer = img.closest("#pageScroll > div") || img.closest(".absolute") || img.closest(".group")
+    
+    if (unitContainer) {
+        const breakWordDiv = unitContainer.querySelector(".break-word")
+        
+        if (breakWordDiv) {
+            let fullText = ""
+
+            // 1. Get Prompt Text (Clean prompt without buttons/params)
+            // Clone spans to safely remove button elements (parameters) before extracting text
+            const spans = Array.from(breakWordDiv.querySelectorAll(":scope > span"))
+            spans.forEach(span => {
+                if (span.querySelector("img")) return // Skip thumbnail
+
+                const clone = span.cloneNode(true) as HTMLElement
+                // Remove buttons (parameters) to get pure prompt text
+                const buttons = clone.querySelectorAll("button")
+                buttons.forEach(b => b.remove())
+                
+                const text = clone.textContent?.trim()
+                if (text) fullText += text + " "
+            })
+
+            fullText = fullText.trim()
+
+            // 2. Get Parameters from Buttons (Structure based extraction)
+            // Search in the common parent to cover both responsive layouts
+            const parent = breakWordDiv.closest('.overflow-clip') || breakWordDiv.closest('.group') || breakWordDiv.parentElement
+            if (parent) {
+                const allButtons = parent.querySelectorAll("button")
+                allButtons.forEach(btn => {
+                    // Midjourney parameter buttons typically have this structure:
+                    // span.opacity-80 (Label: --ar)
+                    // span.line-clamp-2 (Value: 16:9)
+                    const labelSpan = btn.querySelector("span.opacity-80") || btn.querySelector("span.text-light-500") // Fallback class
+                    const valueSpan = btn.querySelector("span.line-clamp-2")
+                    
+                    if (labelSpan && valueSpan) {
+                        const label = labelSpan.textContent?.trim()
+                        const value = valueSpan.textContent?.trim()
+                        if (label && value) {
+                            // Clean up label (remove -- if duplicated, though usually it's correct)
+                            fullText += ` ${label} ${value}`
+                        }
+                    } else {
+                        // Fallback: Try to extract parameter from button text if structure doesn't match
+                        // This handles cases like --sref where the structure might be different
+                        const rawText = btn.textContent?.trim() || ""
+                        // Simple heuristic: if it contains "--", treat it as a parameter
+                        if (rawText.includes('--')) {
+                            // Remove newlines and excessive spaces
+                            const cleanText = rawText.replace(/\s+/g, ' ').trim()
+                            // Avoid duplicates if we can, but appending is safer than missing it
+                            if (!fullText.includes(cleanText)) {
+                                fullText += ` ${cleanText}`
+                            }
+                        }
+                    }
+                })
+            }
+
+            if (fullText) return fullText.trim()
+        }
+    }
+
+    // Strategy 2: Traverse up 5 levels (Fallback)
+    let current: HTMLElement | null = img.parentElement
+    for (let i = 0; i < 5; i++) {
+        if (!current) break
+        const breakWordDiv = current.querySelector(".break-word")
+        if (breakWordDiv) {
+            let fullText = ""
+            
+            const spans = Array.from(breakWordDiv.querySelectorAll(":scope > span"))
+            spans.forEach(span => {
+                if (span.querySelector("img")) return
+
+                const clone = span.cloneNode(true) as HTMLElement
+                const buttons = clone.querySelectorAll("button")
+                buttons.forEach(b => b.remove())
+                
+                const text = clone.textContent?.trim()
+                if (text) fullText += text + " "
+            })
+
+            fullText = fullText.trim()
+
+            const parent = breakWordDiv.closest('.overflow-clip') || breakWordDiv.closest('.group') || breakWordDiv.parentElement
+            if (parent) {
+                const allButtons = parent.querySelectorAll("button")
+                allButtons.forEach(btn => {
+                    const labelSpan = btn.querySelector("span.opacity-80") || btn.querySelector("span.text-light-500")
+                    const valueSpan = btn.querySelector("span.line-clamp-2")
+                    
+                    if (labelSpan && valueSpan) {
+                        const label = labelSpan.textContent?.trim()
+                        const value = valueSpan.textContent?.trim()
+                        if (label && value) {
+                            fullText += ` ${label} ${value}`
+                        }
+                    } else {
+                        // Fallback for Strategy 2
+                        const rawText = btn.textContent?.trim() || ""
+                        if (rawText.includes('--')) {
+                            const cleanText = rawText.replace(/\s+/g, ' ').trim()
+                            if (!fullText.includes(cleanText)) {
+                                fullText += ` ${cleanText}`
+                            }
+                        }
+                    }
+                })
+            }
+
+            if (fullText) return fullText.trim()
+        }
+        current = current.parentElement
+    }
+    return ""
+  }
+}

--- a/src/contents/domain/interfaces.ts
+++ b/src/contents/domain/interfaces.ts
@@ -1,0 +1,23 @@
+export interface IMJElementData {
+  src: string
+  prompt: string
+  jobId?: string
+  source: string
+}
+
+export interface IProcessor {
+  process(element: HTMLElement): void
+}
+
+export interface IExtractor {
+  extract(element: HTMLElement): IMJElementData | null
+}
+
+export interface IActionHandler {
+  handle(payload: any): Promise<void> | void
+}
+
+export interface IService {
+  start(): void
+  stop(): void
+}

--- a/src/contents/domain/processors/ImageProcessor.ts
+++ b/src/contents/domain/processors/ImageProcessor.ts
@@ -1,0 +1,43 @@
+import type { IExtractor, IProcessor } from "../interfaces"
+
+export class ImageProcessor implements IProcessor {
+  private extractor: IExtractor
+  private debugMode: boolean
+
+  constructor(extractor: IExtractor, debugMode: boolean = false) {
+    this.extractor = extractor
+    this.debugMode = debugMode
+  }
+
+  process(element: HTMLElement): void {
+    const img = element as HTMLImageElement
+    if (img.tagName !== "IMG") return
+
+    // Prevent duplicate observation
+    if (img.dataset.saObserved) return
+    img.dataset.saObserved = "true"
+
+    if (this.debugMode) {
+      img.style.outline = "2px solid #00ff00"
+      img.style.outlineOffset = "-2px"
+    }
+
+    // Ensure draggable is enabled for interaction
+    img.draggable = true
+    img.style.cursor = "grab"
+
+    img.addEventListener("dragstart", (e) => {
+      const data = this.extractor.extract(img)
+      if (!data) return
+
+      if (e.dataTransfer) {
+        try {
+          // Attach custom data for the extension side panel
+          e.dataTransfer.setData("application/json", JSON.stringify(data))
+        } catch (err) {
+          console.error("Style Atelier: Failed to attach data", err)
+        }
+      }
+    }, { capture: true })
+  }
+}

--- a/src/contents/mj-web-observer.ts
+++ b/src/contents/mj-web-observer.ts
@@ -1,4 +1,9 @@
 import type { PlasmoCSConfig } from "plasmo"
+import { WebDataExtractor } from "./domain/extractors/WebDataExtractor"
+import { ImageProcessor } from "./domain/processors/ImageProcessor"
+import { PromptInjector } from "./domain/actions/PromptInjector"
+import { GalleryObserver } from "./services/GalleryObserver"
+import { CommandListener } from "./services/CommandListener"
 
 export const config: PlasmoCSConfig = {
   matches: ["https://midjourney.com/*", "https://*.midjourney.com/*"],
@@ -8,253 +13,31 @@ export const config: PlasmoCSConfig = {
 
 const DEBUG_MODE = false
 
-function getPromptFromContainer(img: HTMLImageElement): string {
-  // Strategy 1: Look for common container under #pageScroll (User provided selector)
-  const unitContainer = img.closest("#pageScroll > div") || img.closest(".absolute") || img.closest(".group")
-  
-  if (unitContainer) {
-      const breakWordDiv = unitContainer.querySelector(".break-word")
-      
-      if (breakWordDiv) {
-          let fullText = ""
+function main() {
+  console.log("Style Atelier: Initializing...")
 
-          // 1. Get Prompt Text (Clean prompt without buttons/params)
-          // Clone spans to safely remove button elements (parameters) before extracting text
-          const spans = Array.from(breakWordDiv.querySelectorAll(":scope > span"))
-          spans.forEach(span => {
-              if (span.querySelector("img")) return // Skip thumbnail
+  // Initialize Domain Logic
+  const extractor = new WebDataExtractor()
+  const processor = new ImageProcessor(extractor, DEBUG_MODE)
+  const injector = new PromptInjector()
 
-              const clone = span.cloneNode(true) as HTMLElement
-              // Remove buttons (parameters) to get pure prompt text
-              const buttons = clone.querySelectorAll("button")
-              buttons.forEach(b => b.remove())
-              
-              const text = clone.textContent?.trim()
-              if (text) fullText += text + " "
-          })
+  // Initialize Services
+  const galleryObserver = new GalleryObserver(processor)
+  const commandListener = new CommandListener(injector)
 
-          fullText = fullText.trim()
-
-          // 2. Get Parameters from Buttons (Structure based extraction)
-          // Search in the common parent to cover both responsive layouts
-          const parent = breakWordDiv.closest('.overflow-clip') || breakWordDiv.closest('.group') || breakWordDiv.parentElement
-          if (parent) {
-              const allButtons = parent.querySelectorAll("button")
-              allButtons.forEach(btn => {
-                  // Midjourney parameter buttons typically have this structure:
-                  // span.opacity-80 (Label: --ar)
-                  // span.line-clamp-2 (Value: 16:9)
-                  const labelSpan = btn.querySelector("span.opacity-80") || btn.querySelector("span.text-light-500") // Fallback class
-                  const valueSpan = btn.querySelector("span.line-clamp-2")
-                  
-                  if (labelSpan && valueSpan) {
-                      const label = labelSpan.textContent?.trim()
-                      const value = valueSpan.textContent?.trim()
-                      if (label && value) {
-                          // Clean up label (remove -- if duplicated, though usually it's correct)
-                          fullText += ` ${label} ${value}`
-                      }
-                  } else {
-                      // Fallback: Try to extract parameter from button text if structure doesn't match
-                      // This handles cases like --sref where the structure might be different
-                      const rawText = btn.textContent?.trim() || ""
-                      // Simple heuristic: if it contains "--", treat it as a parameter
-                      if (rawText.includes('--')) {
-                          // Remove newlines and excessive spaces
-                          const cleanText = rawText.replace(/\s+/g, ' ').trim()
-                          // Avoid duplicates if we can, but appending is safer than missing it
-                          if (!fullText.includes(cleanText)) {
-                              fullText += ` ${cleanText}`
-                          }
-                      }
-                  }
-              })
-          }
-
-          if (fullText) return fullText.trim()
-      }
-  }
-
-  // Strategy 2: Traverse up 5 levels (Fallback)
-  let current: HTMLElement | null = img.parentElement
-  for (let i = 0; i < 5; i++) {
-      if (!current) break
-      const breakWordDiv = current.querySelector(".break-word")
-      if (breakWordDiv) {
-          let fullText = ""
-          
-          const spans = Array.from(breakWordDiv.querySelectorAll(":scope > span"))
-          spans.forEach(span => {
-              if (span.querySelector("img")) return
-
-              const clone = span.cloneNode(true) as HTMLElement
-              const buttons = clone.querySelectorAll("button")
-              buttons.forEach(b => b.remove())
-              
-              const text = clone.textContent?.trim()
-              if (text) fullText += text + " "
-          })
-
-          fullText = fullText.trim()
-
-          const parent = breakWordDiv.closest('.overflow-clip') || breakWordDiv.closest('.group') || breakWordDiv.parentElement
-          if (parent) {
-              const allButtons = parent.querySelectorAll("button")
-              allButtons.forEach(btn => {
-                  const labelSpan = btn.querySelector("span.opacity-80") || btn.querySelector("span.text-light-500")
-                  const valueSpan = btn.querySelector("span.line-clamp-2")
-                  
-                  if (labelSpan && valueSpan) {
-                      const label = labelSpan.textContent?.trim()
-                      const value = valueSpan.textContent?.trim()
-                      if (label && value) {
-                          fullText += ` ${label} ${value}`
-                      }
-                  } else {
-                      // Fallback for Strategy 2
-                      const rawText = btn.textContent?.trim() || ""
-                      if (rawText.includes('--')) {
-                          const cleanText = rawText.replace(/\s+/g, ' ').trim()
-                          if (!fullText.includes(cleanText)) {
-                              fullText += ` ${cleanText}`
-                          }
-                      }
-                  }
-              })
-          }
-
-          if (fullText) return fullText.trim()
-      }
-      current = current.parentElement
-  }
-  return ""
-}
-
-function processImage(img: HTMLImageElement) {
-  if (img.dataset.saObserved) return
-  img.dataset.saObserved = "true"
-
-  if (DEBUG_MODE) {
-    img.style.outline = "2px solid #00ff00"
-    img.style.outlineOffset = "-2px"
-  }
-
-  // Ensure draggable is enabled for interaction
-  img.draggable = true
-  img.style.cursor = "grab"
-
-  img.addEventListener("dragstart", (e) => {
-    // Attempt to extract prompt
-    let prompt = getPromptFromContainer(img)
-    
-    // Fallback logic: If extracted prompt seems missing parameters (no '--') 
-    // but alt text has them, prefer alt text.
-    if ((!prompt || !prompt.includes('--')) && img.alt && img.alt.includes('--')) {
-        prompt = img.alt
-    } else if (!prompt) {
-        prompt = img.alt || ""
-    }
-    
-    // Attempt to extract Job ID from parent link
-    let jobId = ""
-    const parentLink = img.closest("a")
-    if (parentLink && parentLink.href) {
-        const match = parentLink.href.match(/jobs\/([a-f0-9-]{36})/)
-        if (match) jobId = match[1]
-    }
-
-    const payload = {
-      src: img.src,
-      prompt: prompt,
-      jobId: jobId,
-      source: "midjourney-web"
-    }
-
-    if (e.dataTransfer) {
-      try {
-        // Attach custom data for the extension side panel
-        e.dataTransfer.setData("application/json", JSON.stringify(payload))
-      } catch (err) {
-        console.error("Style Atelier: Failed to attach data", err)
-      }
-    }
-  }, { capture: true })
-}
-
-function observeDOM() {
-  const observer = new MutationObserver((mutations) => {
-    mutations.forEach((mutation) => {
-      mutation.addedNodes.forEach((node) => {
-        if (node instanceof HTMLElement) {
-          if (node.tagName === "IMG") processImage(node as HTMLImageElement)
-          node.querySelectorAll("img").forEach(processImage)
-        }
-      })
-    })
-  })
-
-  observer.observe(document.body, { childList: true, subtree: true })
-  
-  // Initial scan
-  document.querySelectorAll("img").forEach(processImage)
-}
-
-// === Message Listener for Prompt Injection ===
-function injectPrompt(prompt: string) {
-  console.log("Style Atelier: Attempting to inject prompt:", prompt)
-  
-  // Try to find the input area
-  // Expanded selectors for better compatibility
-  let input = document.getElementById("prompt-textarea") || 
-              document.querySelector('[aria-label="Imagine a prompt"]') ||
-              document.querySelector('[aria-label="Prompt text"]') ||
-              document.querySelector('[data-testid="prompt-input"]') ||
-              document.querySelector('[role="textbox"]') ||
-              document.querySelector('div[contenteditable="true"]') || 
-              document.querySelector('textarea[placeholder*="Imagine"]') ||
-              document.querySelector('textarea')
-
-  if (input) {
-      // Handle contenteditable div
-      if (input.isContentEditable) {
-          input.focus()
-          // Using execCommand is deprecated but often works for contenteditable
-          document.execCommand('selectAll', false, undefined)
-          document.execCommand('insertText', false, prompt)
-      } else {
-          // Handle textarea/input
-          // React override hack for input values
-          const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
-          if (nativeInputValueSetter) {
-              nativeInputValueSetter.call(input, prompt);
-          } else {
-              (input as HTMLTextAreaElement).value = prompt;
-          }
-          
-          input.dispatchEvent(new Event('input', { bubbles: true }));
-          input.dispatchEvent(new Event('change', { bubbles: true }));
-          input.focus()
-      }
-      console.log("Style Atelier: Prompt injected successfully")
+  // Start Services
+  // Ensure DOM is ready before starting observer
+  if (document.readyState === "loading") {
+    window.addEventListener("DOMContentLoaded", () => galleryObserver.start())
   } else {
-      console.error("Style Atelier: Could not find chat input area. Checked selectors: #prompt-textarea, [aria-label], [role=textbox], contenteditable, textarea")
+    galleryObserver.start()
   }
+  
+  // Start command listener immediately
+  commandListener.start()
+  
+  // Ensure observer runs after full load as well for late injections
+  window.addEventListener("load", () => galleryObserver.start())
 }
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  console.log("Style Atelier: Message received", message)
-  if (message.type === "INJECT_PROMPT" && message.prompt) {
-      injectPrompt(message.prompt)
-      sendResponse({ status: "success" })
-  } else {
-      sendResponse({ status: "unknown_message" })
-  }
-})
-
-if (document.readyState === "loading") {
-    window.addEventListener("DOMContentLoaded", observeDOM)
-} else {
-    observeDOM()
-}
-// Ensure it runs after full load as well for late injections
-window.addEventListener("load", observeDOM)
+main()

--- a/src/contents/services/CommandListener.ts
+++ b/src/contents/services/CommandListener.ts
@@ -1,0 +1,37 @@
+import type { IService, IActionHandler } from "../domain/interfaces"
+
+export class CommandListener implements IService {
+  private handler: IActionHandler
+  private listener: ((message: any, sender: chrome.runtime.MessageSender, sendResponse: (response?: any) => void) => void) | null = null
+
+  constructor(handler: IActionHandler) {
+    this.handler = handler
+  }
+
+  start(): void {
+    if (this.listener) return
+
+    this.listener = (message, sender, sendResponse) => {
+      console.log("Style Atelier: Message received", message)
+      if (message.type === "INJECT_PROMPT" && message.prompt) {
+          this.handler.handle(message.prompt)
+          sendResponse({ status: "success" })
+      } else {
+          sendResponse({ status: "unknown_message" })
+      }
+      // Return true to indicate we wish to send a response asynchronously (if needed in future)
+      return false
+    }
+
+    chrome.runtime.onMessage.addListener(this.listener)
+    console.log("Style Atelier: Command Listener started")
+  }
+
+  stop(): void {
+    if (this.listener) {
+      chrome.runtime.onMessage.removeListener(this.listener)
+      this.listener = null
+      console.log("Style Atelier: Command Listener stopped")
+    }
+  }
+}

--- a/src/contents/services/GalleryObserver.ts
+++ b/src/contents/services/GalleryObserver.ts
@@ -1,0 +1,47 @@
+import type { IService, IProcessor } from "../domain/interfaces"
+
+export class GalleryObserver implements IService {
+  private observer: MutationObserver | null = null
+  private processor: IProcessor
+
+  constructor(processor: IProcessor) {
+    this.processor = processor
+  }
+
+  start(): void {
+    if (this.observer) return
+
+    this.observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (node instanceof HTMLElement) {
+            if (node.tagName === "IMG") {
+                this.processor.process(node as HTMLElement)
+            }
+            // Check children for images as well
+            node.querySelectorAll("img").forEach((img) => {
+                this.processor.process(img as HTMLElement)
+            })
+          }
+        })
+      })
+    })
+
+    this.observer.observe(document.body, { childList: true, subtree: true })
+    
+    // Initial scan
+    document.querySelectorAll("img").forEach((img) => {
+        this.processor.process(img as HTMLElement)
+    })
+    
+    console.log("Style Atelier: Gallery Observer started")
+  }
+
+  stop(): void {
+    if (this.observer) {
+      this.observer.disconnect()
+      this.observer = null
+      console.log("Style Atelier: Gallery Observer stopped")
+    }
+  }
+}


### PR DESCRIPTION
## Why
Previously, \mj-web-observer.ts\ handled multiple responsibilities including DOM observation, prompt data extraction, and user action injection. This concentration of duties made the code fragile and prone to regressions, especially when the Midjourney UI structure changed.
To address this (Issue #22), we needed to refactor the code based on the Single Responsibility Principle (SRP).

## What
Refactored the architecture into a service-based model:

- **Bootstrap**: \mj-web-observer.ts\ now solely initializes and starts the services.
- **Service Layer**:
  - \GalleryObserver\: Manages DOM observation cycles.
  - \CommandListener\: Manages extension message handling.
- **Domain Layer**:
  - \WebDataExtractor\: Encapsulates logic for parsing Midjourney's DOM structure.
  - \ImageProcessor\: Handles attaching drag events to images.
  - \PromptInjector\: Handles injecting text into the chat input.

## Result
The codebase is now modular. Changes to DOM selectors are confined to \WebDataExtractor\, and new features can be added as new processors or actions without modifying the core observer logic.