### PR TITLE
feat: improve card evolution logic #33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "MJ-Style-Atelier",
+  "name": "ml-style-atelier",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "temp-init",
+      "name": "ml-style-atelier",
       "version": "0.0.1",
       "dependencies": {
         "budoux": "^0.7.0",

--- a/src/components/organisms/HandBar.tsx
+++ b/src/components/organisms/HandBar.tsx
@@ -1,18 +1,18 @@
 import React from "react"
 import { useHand } from "../../hooks/useHand"
+import { useWorkbenchContext } from "../../contexts/WorkbenchContext"
 import { RARITY_CONFIG } from "../../lib/rarity-config"
 import { Button } from "../atoms/Button"
 import { CardThumbnail } from "../molecules/CardThumbnail"
 
 export function HandBar() {
   const { pinnedCards, unpinCard, clearHand } = useHand()
+  const { selectedCardIds, toggleCardSelection } = useWorkbenchContext()
 
   // Always render the container, but hide content if empty
   // This helps confirm DOM existence during debugging
   if (pinnedCards.length === 0) return <div id="handbar-root" />
-
-  console.log("any hand");
-  
+ 
   return (
     <div id="handbar-root" className="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-sm border-t border-slate-200 shadow-lg z-50 transition-all">
       <div className="max-w-md mx-auto p-2">
@@ -30,16 +30,27 @@ export function HandBar() {
         <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
           {pinnedCards.map((card) => {
             const config = RARITY_CONFIG[card.tier]
+            const isSelected = selectedCardIds.includes(card.id)
             return (
-              <CardThumbnail
+              <div
                 key={card.id}
-                imageUrl={card.thumbnailData}
-                alt={card.name}
-                tier={card.tier}
-                size="sm"
-                onDeleteClick={() => unpinCard(card.id)}
-                className={`flex-shrink-0 border-2 ${config.borderClass}`}
-              />
+                onClick={() => toggleCardSelection(card.id)}
+                className="cursor-pointer"
+              >
+                <CardThumbnail
+                  imageUrl={card.thumbnailData}
+                  alt={card.name}
+                  tier={card.tier}
+                  size="sm"
+                  onDeleteClick={(e) => {
+                    e.stopPropagation()
+                    unpinCard(card.id)
+                  }}
+                  className={`flex-shrink-0 border-2 transition-all ${
+                    isSelected ? "border-blue-500 scale-110 ring-2 ring-blue-200" : config.borderClass
+                  }`}
+                />
+              </div>
             )
           })}
           {/* Action Button: To Workbench (Future) */}

--- a/src/components/organisms/Workbench.tsx
+++ b/src/components/organisms/Workbench.tsx
@@ -5,7 +5,7 @@ import { CardThumbnail } from "../molecules/CardThumbnail";
 import { RarityBadge } from "../atoms/RarityBadge";
 import { Button } from "../atoms/Button";
 import { Sparkles, FlaskConical, X, Send } from "lucide-react";
-import { buildPromptString } from "../../lib/prompt-utils";
+import { buildPromptString, mergePromptSegments } from "../../lib/prompt-utils";
 import { PromptBubbleEditor } from "./PromptBubbleEditor";
 import type { PromptSegment } from "../../lib/db-schema";
 
@@ -22,9 +22,8 @@ export const Workbench: React.FC = () => {
 
   useEffect(() => {
     if (isMixingMode) {
-      const merged = workbenchCards.flatMap((c, i) =>
-        i > 0 ? [{ type: "text" as const, value: ", " }, ...c.promptSegments] : c.promptSegments
-      );
+      const allSegments = workbenchCards.flatMap(c => c.promptSegments);
+      const merged = mergePromptSegments(allSegments);
       setEditedSegments(merged);
     } else if (isEvolutionMode && targetCard) {
       setEditedSegments(targetCard.promptSegments);

--- a/src/components/organisms/Workbench.tsx
+++ b/src/components/organisms/Workbench.tsx
@@ -1,0 +1,155 @@
+import React, { useState, useEffect } from "react";
+import { useWorkbench } from "../../hooks/useWorkbench";
+import { useEvolution } from "../../hooks/useEvolution";
+import { CardThumbnail } from "../molecules/CardThumbnail";
+import { RarityBadge } from "../atoms/RarityBadge";
+import { Button } from "../atoms/Button";
+import { Sparkles, FlaskConical, X, Send } from "lucide-react";
+import { buildPromptString } from "../../lib/prompt-utils";
+import { PromptBubbleEditor } from "./PromptBubbleEditor";
+import type { PromptSegment } from "../../lib/db-schema";
+
+export const Workbench: React.FC = () => {
+  const { workbenchCards, toggleCardSelection, clearWorkbench } = useWorkbench();
+  const { canEvolve, evolveCard } = useEvolution();
+  
+  const [editedSegments, setEditedSegments] = useState<PromptSegment[]>([]);
+
+  const isEvolutionMode = workbenchCards.length === 1;
+  const isMixingMode = workbenchCards.length >= 2;
+  const targetCard = workbenchCards[0];
+  const canEvolveTarget = targetCard && canEvolve(targetCard);
+
+  useEffect(() => {
+    if (isMixingMode) {
+      const merged = workbenchCards.flatMap((c, i) =>
+        i > 0 ? [{ type: "text" as const, value: ", " }, ...c.promptSegments] : c.promptSegments
+      );
+      setEditedSegments(merged);
+    } else if (isEvolutionMode && targetCard) {
+      setEditedSegments(targetCard.promptSegments);
+    } else {
+      setEditedSegments([]);
+    }
+  }, [workbenchCards, isMixingMode, isEvolutionMode, targetCard]);
+
+  const handleInjectPrompt = () => {
+    if (workbenchCards.length === 0) return;
+
+    const mergedParams: any = { ...workbenchCards[0].parameters };
+    if (isMixingMode) {
+      workbenchCards.slice(1).forEach((parent) => {
+        if (parent.parameters.sref) {
+          mergedParams.sref = Array.from(new Set([...(mergedParams.sref || []), ...parent.parameters.sref]));
+        }
+      });
+    }
+
+    const fullPrompt = buildPromptString(editedSegments, mergedParams);
+    
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const activeTab = tabs[0];
+      if (activeTab?.id) {
+        chrome.tabs.sendMessage(activeTab.id, {
+          type: "INJECT_PROMPT",
+          prompt: fullPrompt,
+        });
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-white text-slate-900 p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold flex items-center gap-2 text-slate-800">
+          <FlaskConical className="w-5 h-5 text-blue-500" />
+          Workbench
+        </h2>
+        {workbenchCards.length > 0 && (
+          <Button variant="ghost" size="sm" onClick={clearWorkbench} className="text-slate-400 hover:text-slate-600">
+            Clear All
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 bg-slate-50 p-4 rounded-xl border-2 border-dashed border-slate-200 min-h-[160px]">
+        {workbenchCards.map((card) => (
+          <div key={card.id} className="relative group animate-in zoom-in-95 duration-200">
+            <CardThumbnail imageUrl={card.thumbnailData} alt={card.name} tier={card.tier} className="w-full aspect-square" />
+            <button
+              onClick={() => toggleCardSelection(card.id)}
+              className="absolute -top-2 -right-2 bg-red-500 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity z-10"
+            >
+              <X className="w-3 h-3 text-white" />
+            </button>
+          </div>
+        ))}
+        {workbenchCards.length < 2 && (
+          <div className="border-2 border-dashed border-slate-700 rounded-lg flex items-center justify-center aspect-square text-slate-500 text-xs text-center p-2">
+            Select cards from Hand
+          </div>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {(isEvolutionMode || isMixingMode) && (
+          <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2">
+            <div className="bg-slate-50 border border-slate-200 p-4 rounded-lg space-y-3">
+              <div className="flex items-center justify-between">
+                 <h3 className="text-sm font-bold text-slate-700">
+                  {isEvolutionMode ? "Evolution" : "Variation Recipe"}
+                </h3>
+                {isEvolutionMode && targetCard && <RarityBadge tier={targetCard.tier} />}
+              </div>
+
+              <div className="bg-white rounded-lg border border-slate-200 overflow-hidden">
+                <PromptBubbleEditor 
+                  initialSegments={editedSegments} 
+                  onChange={setEditedSegments} 
+                  tier={isEvolutionMode ? targetCard?.tier : "Common"} 
+                />
+              </div>
+
+              {isEvolutionMode && targetCard && (
+                <div className="pt-2 border-t border-slate-100">
+                   <div className="flex justify-between items-center text-xs mb-2">
+                    <span className="text-slate-500">Usage Progress</span>
+                    <span className="font-mono font-bold text-blue-600">{targetCard.usageCount} uses</span>
+                  </div>
+                  {canEvolveTarget ? (
+                    <Button
+                      className="w-full bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-md"
+                      onClick={() => evolveCard(targetCard.id)}
+                    >
+                      <Sparkles className="w-4 h-4 mr-2" /> Evolve to Next Tier
+                    </Button>
+                  ) : (
+                    <p className="text-[10px] text-slate-400 italic text-center">
+                      Need more uses to evolve this card
+                    </p>
+                  )}
+                </div>
+              )}
+
+              <Button
+                className="w-full bg-blue-600 hover:bg-blue-700 text-white shadow-sm shadow-blue-200"
+                onClick={handleInjectPrompt}
+              >
+                <Send className="w-4 h-4 mr-2" />
+                Try on Midjourney
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {!isEvolutionMode && !isMixingMode && (
+          <div className="text-center py-12 px-6 bg-slate-50/50 rounded-xl border border-slate-100 border-dashed">
+            <FlaskConical className="w-8 h-8 text-slate-200 mx-auto mb-3" />
+            <p className="text-sm font-medium text-slate-400 mb-1">Workbench is Empty</p>
+            <p className="text-xs text-slate-300">Select cards from your Hand below.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/templates/SidePanelLayout.tsx
+++ b/src/components/templates/SidePanelLayout.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-
-type Tab = "history" | "library" | "decks"
+import { Tab } from "../../hooks/useTabs"
 
 interface SidePanelLayoutProps {
   activeTab: Tab
@@ -61,6 +60,16 @@ export function SidePanelLayout({
               }`}
             >
               Decks
+            </button>
+            <button
+              onClick={() => onTabChange("workbench")}
+              className={`whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${
+                activeTab === "workbench"
+                  ? "border-blue-500 text-blue-600"
+                  : "border-transparent text-slate-500 hover:text-slate-700"
+              }`}
+            >
+              Workbench
             </button>
           </nav>
         </div>

--- a/src/contexts/WorkbenchContext.tsx
+++ b/src/contexts/WorkbenchContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useState, useCallback } from "react";
+
+interface WorkbenchContextType {
+  selectedCardIds: string[];
+  toggleCardSelection: (cardId: string) => void;
+  clearWorkbench: () => void;
+}
+
+const WorkbenchContext = createContext<WorkbenchContextType | undefined>(undefined);
+
+export const WorkbenchProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
+
+  const toggleCardSelection = useCallback((cardId: string) => {
+    setSelectedCardIds((prev) =>
+      prev.includes(cardId) ? prev.filter((id) => id !== cardId) : [...prev, cardId]
+    );
+  }, []);
+
+  const clearWorkbench = useCallback(() => {
+    setSelectedCardIds([]);
+  }, []);
+
+  return (
+    <WorkbenchContext.Provider value={{ selectedCardIds, toggleCardSelection, clearWorkbench }}>
+      {children}
+    </WorkbenchContext.Provider>
+  );
+};
+
+export const useWorkbenchContext = () => {
+  const context = useContext(WorkbenchContext);
+  if (context === undefined) {
+    throw new Error("useWorkbenchContext must be used within a WorkbenchProvider");
+  }
+  return context;
+};

--- a/src/hooks/useEvolution.ts
+++ b/src/hooks/useEvolution.ts
@@ -1,0 +1,107 @@
+import { db } from "../lib/db";
+import type { StyleCard, PromptSegment } from "../lib/db-schema";
+import { UPGRADE_THRESHOLDS, RarityTier } from "../lib/rarity-config";
+import { mergePromptSegments } from "../lib/prompt-utils";
+
+export function useEvolution() {
+  const getNextTier = (currentTier: RarityTier): RarityTier | null => {
+    switch (currentTier) {
+      case "Common":
+        return "Rare";
+      case "Rare":
+        return "Epic";
+      case "Epic":
+        return "Legendary";
+      default:
+        return null;
+    }
+  };
+
+  const canEvolve = (card: StyleCard): boolean => {
+    const nextTier = getNextTier(card.tier);
+    if (!nextTier) return false;
+    const threshold = UPGRADE_THRESHOLDS[card.tier as keyof typeof UPGRADE_THRESHOLDS];
+    return card.usageCount >= threshold;
+  };
+
+  const evolveCard = async (cardId: string) => {
+    const card = await db.styleCards.get(cardId);
+    if (!card) throw new Error("Card not found");
+    if (!canEvolve(card)) throw new Error("Evolution requirements not met");
+
+    const nextTier = getNextTier(card.tier);
+    if (!nextTier) throw new Error("Already at maximum tier");
+
+    await db.styleCards.update(cardId, {
+      tier: nextTier,
+      updatedAt: Date.now(),
+      genealogy: {
+        ...card.genealogy,
+        mutationNote: `${card.genealogy.mutationNote || ""}\nEvolved from ${card.tier} to ${nextTier} at ${new Date().toLocaleString()}`.trim(),
+      },
+      // TODO: Add evolution animation flag if needed for UI
+    });
+
+    return nextTier;
+  };
+
+  const createVariation = async (parentCards: StyleCard[], variationName: string, thumbnailData: string): Promise<string> => {
+    if (parentCards.length === 0) throw new Error("At least one parent card is required");
+
+    const mainParent = parentCards[0];
+
+    // プロンプトの統合（重複排除を適用）
+    const allSegments = parentCards.flatMap(p => p.promptSegments);
+    const mergedSegments = mergePromptSegments(allSegments);
+
+    // パラメータの統合
+    const mergedParams: StyleCard["parameters"] = { ...mainParent.parameters };
+    parentCards.slice(1).forEach(parent => {
+      // srefのマージ (最大5枚、最新優先)
+      if (parent.parameters.sref) {
+        const combinedSref = [...(parent.parameters.sref || []), ...(mergedParams.sref || [])];
+        mergedParams.sref = Array.from(new Set(combinedSref)).slice(0, 5);
+      }
+      // crefのマージ (最新優先)
+      if (parent.parameters.cref) {
+        const combinedCref = [...(parent.parameters.cref || []), ...(mergedParams.cref || [])];
+        mergedParams.cref = Array.from(new Set(combinedCref)).slice(0, 5);
+      }
+      // 他のパラメータも必要に応じてマージ
+    });
+
+    const newCard: StyleCard = {
+      id: crypto.randomUUID(),
+      name: variationName,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      promptSegments: mergedSegments,
+      parameters: mergedParams,
+      masking: { ...mainParent.masking },
+      tier: "Common",
+      isFavorite: false,
+      isPinned: false,
+      usageCount: 0,
+      tags: Array.from(new Set(parentCards.flatMap(p => p.tags))),
+      dominantColor: mainParent.dominantColor,
+      thumbnailData,
+      frameId: "default",
+      genealogy: {
+        generation: Math.max(...parentCards.map(p => p.genealogy.generation)) + 1,
+        parentIds: parentCards.map(p => p.id),
+        originCreatorId: mainParent.genealogy.originCreatorId,
+        mutationNote: `Combined from ${parentCards.map(p => p.name).join(" and ")}`,
+      },
+    };
+
+    await db.styleCards.add(newCard);
+    return newCard.id;
+  };
+
+  return {
+    canEvolve,
+    evolveCard,
+    createVariation,
+    getNextTier,
+  };
+}

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -1,6 +1,6 @@
 import { useState } from "react"
 
-type Tab = "history" | "library" | "decks"
+export type Tab = "history" | "library" | "decks" | "workbench"
 
 export function useTabs() {
   const [activeTab, setActiveTab] = useState<Tab>("history")

--- a/src/hooks/useWorkbench.ts
+++ b/src/hooks/useWorkbench.ts
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "../lib/db";
+import type { StyleCard } from "../lib/db-schema";
+import { buildPromptString } from "../lib/prompt-utils";
+import { useWorkbenchContext } from "../contexts/WorkbenchContext";
+
+export function useWorkbench() {
+  const { selectedCardIds, toggleCardSelection, clearWorkbench } = useWorkbenchContext();
+  
+  // 手札（Hand）にあるカードを取得
+  const handCards = useLiveQuery(() => db.styleCards.filter(c => !!c.isPinned).toArray());
+
+  // ワークベンチに配置されたカード
+  const workbenchCards = useMemo(() => {
+    if (!handCards) return [];
+    return selectedCardIds
+      .map(id => handCards.find(c => c.id === id))
+      .filter((c): c is StyleCard => !!c);
+  }, [handCards, selectedCardIds]);
+
+  // 統合されたプロンプト文字列の生成
+  const mergedPrompt = useMemo(() => {
+    if (workbenchCards.length === 0) return "";
+    
+    // 単純な結合ロジック
+    const promptParts = workbenchCards.map(card => {
+        const maskedKeys: (keyof StyleCard["parameters"])[] = [];
+        if (card.masking.isSrefHidden) maskedKeys.push("sref");
+        if (card.masking.isPHidden) maskedKeys.push("p");
+        return buildPromptString(card.promptSegments, card.parameters, maskedKeys);
+    });
+
+    return promptParts.join(", ");
+  }, [workbenchCards]);
+
+  return {
+    handCards: handCards || [],
+    workbenchCards,
+    selectedCardIds,
+    toggleCardSelection,
+    clearWorkbench,
+    mergedPrompt,
+  };
+}

--- a/src/lib/prompt-utils.test.ts
+++ b/src/lib/prompt-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildPromptString, parsePrompt } from './prompt-utils';
+import { buildPromptString, parsePrompt, mergePromptSegments } from './prompt-utils';
 import type { PromptSegment, StyleCard } from './db-schema';
 
 describe('buildPromptString', () => {
@@ -43,5 +43,32 @@ describe('parsePrompt', () => {
     const { parameters } = parsePrompt(prompt);
     expect(parameters.p).toBe('pcd78d7 owipony');
     expect(parameters.ar).toBe('16:9');
+  });
+});
+
+describe('mergePromptSegments', () => {
+  it('should remove duplicate text segments', () => {
+    const segments: PromptSegment[] = [
+      { type: 'text', value: 'a cat' },
+      { type: 'text', value: 'a cat' },
+      { type: 'text', value: 'A CAT ' },
+      { type: 'text', value: 'a dog' },
+    ];
+    const merged = mergePromptSegments(segments);
+    expect(merged).toHaveLength(2);
+    expect(merged[0].value).toBe('a cat');
+    expect(merged[1].value).toBe('a dog');
+  });
+
+  it('should keep non-text segments', () => {
+    const segments: PromptSegment[] = [
+      { type: 'text', value: 'a cat' },
+      { type: 'slot', label: 'animal', id: '1' },
+      { type: 'text', value: 'a cat' },
+    ];
+    const merged = mergePromptSegments(segments);
+    expect(merged).toHaveLength(2);
+    expect(merged[0].value).toBe('a cat');
+    expect(merged[1].type).toBe('slot');
   });
 });

--- a/src/lib/prompt-utils.ts
+++ b/src/lib/prompt-utils.ts
@@ -6,12 +6,11 @@ export const parsePrompt = (fullCommand: string): { promptSegments: PromptSegmen
   const parameters: StyleCard['parameters'] = {};
   let promptText = fullCommand;
 
-  // Extract parameters
   const matches = [...fullCommand.matchAll(PARAM_REGEX)];
   matches.forEach(match => {
     const key = match[1].trim();
     const value = match[2] ? match[2].trim() : '';
-    promptText = promptText.replace(match[0], ''); // Remove param from prompt text
+    promptText = promptText.replace(match[0], '');
 
     switch (key) {
       case 'ar':
@@ -50,15 +49,12 @@ export const parsePrompt = (fullCommand: string): { promptSegments: PromptSegmen
     }
   });
 
-  // Create prompt segments from the remaining text
   const promptSegments: PromptSegment[] = promptText
     .split(/,/)
     .map(s => s.trim())
     .filter(s => s.length > 0)
     .map(value => ({ type: 'text', value }));
   
-  // TODO: Implement slot and chip parsing in the future
-
   return { promptSegments, parameters };
 };
 
@@ -69,11 +65,12 @@ export const buildPromptString = (segments: PromptSegment[], params: StyleCard['
         case 'text':
           return seg.value;
         case 'slot':
-          return `{{${seg.label}}}`; // or seg.default
+          return `{{${seg.label}}}`;
         case 'chip':
-          return ``; // chips are handled as params
+          return ``;
       }
     })
+    .filter(val => !!val && val.trim() !== '')
     .join(', ');
 
   const paramParts: string[] = [];

--- a/src/lib/prompt-utils.ts
+++ b/src/lib/prompt-utils.ts
@@ -89,3 +89,23 @@ export const buildPromptString = (segments: PromptSegment[], params: StyleCard['
   
   return `${segmentString} ${paramParts.join(' ')}`.trim();
 };
+
+export const mergePromptSegments = (allSegments: PromptSegment[]): PromptSegment[] => {
+  const seen = new Set<string>();
+  const merged: PromptSegment[] = [];
+
+  allSegments.forEach(seg => {
+    if (seg.type === 'text') {
+      const normalized = seg.value.toLowerCase().trim();
+      if (!seen.has(normalized) && normalized.length > 0) {
+        seen.add(normalized);
+        merged.push(seg);
+      }
+    } else {
+      // For slots/chips, we might want different logic later, but for now just include them
+      merged.push(seg);
+    }
+  });
+
+  return merged;
+};

--- a/src/lib/rarity-config.ts
+++ b/src/lib/rarity-config.ts
@@ -33,4 +33,10 @@ export const RARITY_CONFIG = {
   },
 } as const;
 
+export const UPGRADE_THRESHOLDS: Record<Exclude<RarityTier, 'Legendary'>, number> = {
+  Common: 5,    // 5 uses to reach Rare
+  Rare: 15,    // 15 uses to reach Epic
+  Epic: 40,    // 40 uses to reach Legendary
+};
+
 export type RarityTier = keyof typeof RARITY_CONFIG;

--- a/src/pages/SidePanel.tsx
+++ b/src/pages/SidePanel.tsx
@@ -4,11 +4,13 @@ import { SidePanelLayout } from "../components/templates/SidePanelLayout"
 import { HistoryTab } from "../components/organisms/HistoryTab"
 import { LibraryTab } from "../components/organisms/LibraryTab"
 import { DecksTab } from "../components/organisms/DecksTab"
+import { Workbench } from "../components/organisms/Workbench"
 import { MintingView } from "../components/organisms/MintingView"
 import { HandBar } from "../components/organisms/HandBar"
 import { useTabs } from "../hooks/useTabs"
 import { useDragAndDrop } from "../hooks/useDragAndDrop"
 import { useMinting } from "../hooks/useMinting"
+import { WorkbenchProvider } from "../contexts/WorkbenchContext"
 
 function SidePanelPage() {
   const [logs, setLogs] = useState<string[]>([])
@@ -18,6 +20,7 @@ function SidePanelPage() {
   const { isDragging, droppedItem, handleDragOver, handleDragLeave, handleDrop } = useDragAndDrop(addLog)
   const {
     mintingItem,
+    variationBase,
     editedSegments,
     setEditedSegments,
     isSrefHidden,
@@ -25,8 +28,10 @@ function SidePanelPage() {
     isPHidden,
     setIsPHidden,
     handleStartMinting,
+    handleStartVariationMinting,
     handleSaveMintedCard,
     setMintingItem,
+    setVariationBase,
     selectedRarity,
     setSelectedRarity,
     suggestedKeywords,
@@ -49,45 +54,52 @@ function SidePanelPage() {
 
   return (
     <div onDragOver={handleDragOver} onDragLeave={handleDragLeave} onDrop={handleDrop} className="h-full relative overflow-hidden">
-      <SidePanelLayout
-        activeTab={activeTab}
-        onTabChange={(tab) => {
-          setActiveTab(tab)
-          setMintingItem(null)
-        }}
-        isDragging={isDragging}
-        logs={logs}
-        onClearLogs={handleClearLogs}
-        onResetDb={handleResetDb}
-        droppedItem={droppedItem}
-      >
-        {mintingItem && (
-      <MintingView
-        mintingItem={mintingItem}
-        editedSegments={editedSegments}
-        setEditedSegments={setEditedSegments}
-        isSrefHidden={isSrefHidden}
-        setIsSrefHidden={setIsSrefHidden}
-        isPHidden={isPHidden}
-        setIsPHidden={setIsPHidden}
-        onCancelMinting={() => setMintingItem(null)}
-        onSaveMintedCard={handleSaveMintedCard}
-        selectedRarity={selectedRarity}
-        setSelectedRarity={setSelectedRarity}
-        suggestedKeywords={suggestedKeywords}
-            selectedKeywords={selectedKeywords}
-            setSelectedKeywords={setSelectedKeywords}
-            customName={customName}
-            setCustomName={setCustomName}
-          />
-        )}
-        {activeTab === "history" && <HistoryTab onStartMinting={handleStartMinting} />}
-        {activeTab === "library" && <LibraryTab addLog={addLog} />}
-        {activeTab === "decks" && <DecksTab addLog={addLog} />}
-        
-        {/* HandBar is now inside SidePanelLayout children to ensure it stays in same context */}
-        <HandBar />
-      </SidePanelLayout>
+      <WorkbenchProvider>
+        <SidePanelLayout
+          activeTab={activeTab}
+          onTabChange={(tab) => {
+            setActiveTab(tab)
+            setMintingItem(null)
+            setVariationBase(null)
+          }}
+          isDragging={isDragging}
+          logs={logs}
+          onClearLogs={handleClearLogs}
+          onResetDb={handleResetDb}
+          droppedItem={droppedItem}
+        >
+          {(mintingItem || variationBase) && (
+            <MintingView
+              mintingItem={mintingItem}
+              editedSegments={editedSegments}
+              setEditedSegments={setEditedSegments}
+              isSrefHidden={isSrefHidden}
+              setIsSrefHidden={setIsSrefHidden}
+              isPHidden={isPHidden}
+              setIsPHidden={setIsPHidden}
+              onCancelMinting={() => {
+                setMintingItem(null)
+                setVariationBase(null)
+              }}
+              onSaveMintedCard={handleSaveMintedCard}
+              selectedRarity={selectedRarity}
+              setSelectedRarity={setSelectedRarity}
+              suggestedKeywords={suggestedKeywords}
+              selectedKeywords={selectedKeywords}
+              setSelectedKeywords={setSelectedKeywords}
+              customName={customName}
+              setCustomName={setCustomName}
+            />
+          )}
+          {activeTab === "history" && <HistoryTab onStartMinting={handleStartMinting} />}
+          {activeTab === "library" && <LibraryTab addLog={addLog} />}
+          {activeTab === "decks" && <DecksTab addLog={addLog} />}
+          {activeTab === "workbench" && <Workbench onStartVariationMinting={handleStartVariationMinting} />}
+
+          {/* HandBar is now inside SidePanelLayout children to ensure it stays in same context */}
+          <HandBar />
+        </SidePanelLayout>
+      </WorkbenchProvider>
     </div>
   )
 }


### PR DESCRIPTION
This PR improves the card evolution logic as part of #33.

Key changes:
- Implemented prompt segment merging with duplicate removal in prompt-utils.ts.
- Enhanced useEvolution.ts to use the new merging logic.
- Added sref/cref merging with a limit of 5 URLs (latest prioritized).
- Updated genealogy to record evolution history in mutationNote.
- Added unit tests for prompt segment merging.