### PR TITLE
feature: Allow multiple images to be associated with a single Job Card (#25)

### DIFF
--- a/src/components/atoms/IconButton.tsx
+++ b/src/components/atoms/IconButton.tsx
@@ -13,7 +13,7 @@ interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> 
   children: React.ReactNode
   rounded?: boolean
   size?: "xs" | "sm" | "md" | "lg"
-  variant?: "slate" | "white" | "indigo" | "danger" | "yellow"
+  variant?: "slate" | "white" | "indigo" | "danger" | "yellow" | "blue"
 }
 
 export function IconButton({
@@ -40,6 +40,7 @@ export function IconButton({
     indigo: "bg-indigo-600 text-white hover:bg-indigo-700",
     danger: "bg-red-500 text-white hover:bg-red-600",
     yellow: "bg-yellow-400 text-white hover:bg-yellow-500",
+    blue: "bg-blue-600 text-white hover:bg-blue-700",
   }
 
   return (

--- a/src/components/molecules/CardThumbnail.test.tsx
+++ b/src/components/molecules/CardThumbnail.test.tsx
@@ -36,6 +36,48 @@ describe("CardThumbnail", () => {
     expect(imgs[1].getAttribute("alt")).toBe("Test Card - Thumbnail 2")
   })
 
+  it("renders three thumbnails in column-split layout when thumbnailImages has 3 images", () => {
+    const images = ["https://example.com/one.png", "https://example.com/two.png", "https://example.com/three.png"]
+    render(
+      <CardThumbnail
+        thumbnailImages={images}
+        alt="Test Card"
+        tier="Rare"
+      />
+    )
+
+    const imgs = screen.getAllByRole("img")
+    expect(imgs).toHaveLength(3)
+    expect(imgs[0].getAttribute("src")).toBe("https://example.com/one.png")
+    expect(imgs[0].getAttribute("alt")).toBe("Test Card - Thumbnail 1")
+    expect(imgs[1].getAttribute("src")).toBe("https://example.com/two.png")
+    expect(imgs[1].getAttribute("alt")).toBe("Test Card - Thumbnail 2")
+    expect(imgs[2].getAttribute("src")).toBe("https://example.com/three.png")
+    expect(imgs[2].getAttribute("alt")).toBe("Test Card - Thumbnail 3")
+  })
+
+  it("renders four thumbnails in 2x2 grid layout when thumbnailImages has 4 images", () => {
+    const images = ["https://example.com/one.png", "https://example.com/two.png", "https://example.com/three.png", "https://example.com/four.png"]
+    render(
+      <CardThumbnail
+        thumbnailImages={images}
+        alt="Test Card"
+        tier="Rare"
+      />
+    )
+
+    const imgs = screen.getAllByRole("img")
+    expect(imgs).toHaveLength(4)
+    expect(imgs[0].getAttribute("src")).toBe("https://example.com/one.png")
+    expect(imgs[0].getAttribute("alt")).toBe("Test Card - Thumbnail 1")
+    expect(imgs[1].getAttribute("src")).toBe("https://example.com/two.png")
+    expect(imgs[1].getAttribute("alt")).toBe("Test Card - Thumbnail 2")
+    expect(imgs[2].getAttribute("src")).toBe("https://example.com/three.png")
+    expect(imgs[2].getAttribute("alt")).toBe("Test Card - Thumbnail 3")
+    expect(imgs[3].getAttribute("src")).toBe("https://example.com/four.png")
+    expect(imgs[3].getAttribute("alt")).toBe("Test Card - Thumbnail 4")
+  })
+
   it("falls back to single imageUrl if thumbnailImages has only 1 image", () => {
     const images = ["https://example.com/one.png"]
     render(

--- a/src/components/molecules/CardThumbnail.test.tsx
+++ b/src/components/molecules/CardThumbnail.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { CardThumbnail } from "./CardThumbnail"
+
+describe("CardThumbnail", () => {
+  it("renders a single thumbnail when imageUrl is provided", () => {
+    render(
+      <CardThumbnail
+        imageUrl="https://example.com/one.png"
+        alt="Test Card"
+        tier="Common"
+      />
+    )
+
+    const img = screen.getByRole("img")
+    expect(img).toBeDefined()
+    expect(img.getAttribute("src")).toBe("https://example.com/one.png")
+    expect(img.getAttribute("alt")).toBe("Test Card")
+  })
+
+  it("renders two thumbnails side-by-side when thumbnailImages has 2 images", () => {
+    const images = ["https://example.com/one.png", "https://example.com/two.png"]
+    render(
+      <CardThumbnail
+        thumbnailImages={images}
+        alt="Test Card"
+        tier="Rare"
+      />
+    )
+
+    const imgs = screen.getAllByRole("img")
+    expect(imgs).toHaveLength(2)
+    expect(imgs[0].getAttribute("src")).toBe("https://example.com/one.png")
+    expect(imgs[0].getAttribute("alt")).toBe("Test Card - Thumbnail 1")
+    expect(imgs[1].getAttribute("src")).toBe("https://example.com/two.png")
+    expect(imgs[1].getAttribute("alt")).toBe("Test Card - Thumbnail 2")
+  })
+
+  it("falls back to single imageUrl if thumbnailImages has only 1 image", () => {
+    const images = ["https://example.com/one.png"]
+    render(
+      <CardThumbnail
+        imageUrl="https://example.com/fallback.png"
+        thumbnailImages={images}
+        alt="Test Card"
+        tier="Common"
+      />
+    )
+
+    const img = screen.getByRole("img")
+    expect(img).toBeDefined()
+    expect(img.getAttribute("src")).toBe("https://example.com/one.png")
+  })
+
+  it("calls onPinClick when pin button is clicked", () => {
+    const mockOnPinClick = vi.fn()
+    render(
+      <CardThumbnail
+        imageUrl="https://example.com/one.png"
+        alt="Test Card"
+        tier="Epic"
+        isPinned={false}
+        onPinClick={mockOnPinClick}
+      />
+    )
+
+    const buttons = screen.getAllByRole("button")
+    // Find the pin button (the only button in this case since onDeleteClick and onInjectClick are undefined)
+    expect(buttons).toHaveLength(1)
+    fireEvent.click(buttons[0])
+    expect(mockOnPinClick).toHaveBeenCalled()
+  })
+
+  it("calls onInjectClick when inject button is clicked", () => {
+    const mockOnInjectClick = vi.fn()
+    render(
+      <CardThumbnail
+        imageUrl="https://example.com/one.png"
+        alt="Test Card"
+        tier="Legendary"
+        onInjectClick={mockOnInjectClick}
+      />
+    )
+
+    const buttons = screen.getAllByRole("button")
+    expect(buttons).toHaveLength(1)
+    fireEvent.click(buttons[0])
+    expect(mockOnInjectClick).toHaveBeenCalled()
+  })
+})

--- a/src/components/molecules/CardThumbnail.tsx
+++ b/src/components/molecules/CardThumbnail.tsx
@@ -17,23 +17,27 @@ import { RarityTier } from "../../lib/rarity-config"
  * @param {string} [props.className=''] - 追加のカスタムクラス
  */
 interface CardThumbnailProps {
-  imageUrl: string
+  imageUrl?: string
+  thumbnailImages?: string[]
   alt: string
   tier: RarityTier
   isPinned?: boolean
   onPinClick?: (e: React.MouseEvent) => void
   onDeleteClick?: (e: React.MouseEvent) => void
+  onInjectClick?: (e: React.MouseEvent) => void
   size?: "sm" | "md" | "lg"
   className?: string
 }
 
 export function CardThumbnail({
   imageUrl,
+  thumbnailImages,
   alt,
   tier,
   isPinned,
   onPinClick,
   onDeleteClick,
+  onInjectClick,
   size = "md",
   className = "",
 }: CardThumbnailProps) {
@@ -43,19 +47,53 @@ export function CardThumbnail({
     lg: "w-full h-48",
   }
 
+  const imagesToRender = thumbnailImages && thumbnailImages.length > 0
+    ? thumbnailImages.slice(0, 2)
+    : [imageUrl].filter(Boolean) as string[]
+
   return (
     <div className={`relative overflow-hidden rounded-lg group ${sizeClasses[size]} ${className}`}>
-      <img
-        src={imageUrl}
-        alt={alt}
-        className="w-full h-full object-cover transition-transform group-hover:scale-110"
-      />
+      {imagesToRender.length >= 2 ? (
+        <div className="flex w-full h-full">
+          <img
+            src={imagesToRender[0]}
+            alt={`${alt} - Thumbnail 1`}
+            className="w-1/2 h-full object-cover border-r border-white/20 transition-transform group-hover:scale-105"
+          />
+          <img
+            src={imagesToRender[1]}
+            alt={`${alt} - Thumbnail 2`}
+            className="w-1/2 h-full object-cover transition-transform group-hover:scale-105"
+          />
+        </div>
+      ) : (
+        <img
+          src={imagesToRender[0] || "assets/icon.png"}
+          alt={alt}
+          className="w-full h-full object-cover transition-transform group-hover:scale-110"
+        />
+      )}
       
       {/* Rarity Badge */}
       <RarityBadge tier={tier} className="absolute top-1 right-1" />
       
       {/* Actions */}
       <div className="absolute bottom-1 right-1 flex gap-1">
+        {onInjectClick && (
+          <IconButton
+            variant="blue"
+            size="sm"
+            onClick={onInjectClick}
+            className="shadow-md"
+            title="Inject Prompt"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="22" y1="2" x2="11" y2="13"></line>
+              <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+            </svg>
+          </IconButton>
+        )}
+
         {onPinClick && (
           <IconButton
             variant={isPinned ? "yellow" : "white"}

--- a/src/components/molecules/CardThumbnail.tsx
+++ b/src/components/molecules/CardThumbnail.tsx
@@ -48,12 +48,57 @@ export function CardThumbnail({
   }
 
   const imagesToRender = thumbnailImages && thumbnailImages.length > 0
-    ? thumbnailImages.slice(0, 2)
+    ? thumbnailImages.slice(0, 4)
     : [imageUrl].filter(Boolean) as string[]
 
   return (
     <div className={`relative overflow-hidden rounded-lg group ${sizeClasses[size]} ${className}`}>
-      {imagesToRender.length >= 2 ? (
+      {imagesToRender.length === 4 ? (
+        <div className="grid grid-cols-2 grid-rows-2 w-full h-full">
+          <img
+            src={imagesToRender[0]}
+            alt={`${alt} - Thumbnail 1`}
+            className="w-full h-full object-cover border-r border-b border-white/20 transition-transform group-hover:scale-105"
+          />
+          <img
+            src={imagesToRender[1]}
+            alt={`${alt} - Thumbnail 2`}
+            className="w-full h-full object-cover border-b border-white/20 transition-transform group-hover:scale-105"
+          />
+          <img
+            src={imagesToRender[2]}
+            alt={`${alt} - Thumbnail 3`}
+            className="w-full h-full object-cover border-r border-white/20 transition-transform group-hover:scale-105"
+          />
+          <img
+            src={imagesToRender[3]}
+            alt={`${alt} - Thumbnail 4`}
+            className="w-full h-full object-cover transition-transform group-hover:scale-105"
+          />
+        </div>
+      ) : imagesToRender.length === 3 ? (
+        <div className="grid grid-cols-3 w-full h-full">
+          <div className="col-span-2 h-full">
+            <img
+              src={imagesToRender[0]}
+              alt={`${alt} - Thumbnail 1`}
+              className="w-full h-full object-cover border-r border-white/20 transition-transform group-hover:scale-105"
+            />
+          </div>
+          <div className="grid grid-rows-2 h-full">
+            <img
+              src={imagesToRender[1]}
+              alt={`${alt} - Thumbnail 2`}
+              className="w-full h-full object-cover border-b border-white/20 transition-transform group-hover:scale-105"
+            />
+            <img
+              src={imagesToRender[2]}
+              alt={`${alt} - Thumbnail 3`}
+              className="w-full h-full object-cover transition-transform group-hover:scale-105"
+            />
+          </div>
+        </div>
+      ) : imagesToRender.length === 2 ? (
         <div className="flex w-full h-full">
           <img
             src={imagesToRender[0]}

--- a/src/components/organisms/CardDetailView.test.tsx
+++ b/src/components/organisms/CardDetailView.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { CardDetailView } from "./CardDetailView"
+import { useHand } from "../../hooks/useHand"
+import type { StyleCard } from "../../lib/db-schema"
+
+vi.mock("../../hooks/useHand", () => ({
+  useHand: vi.fn(),
+}))
+
+vi.mock("../../lib/db", () => ({
+  db: {
+    styleCards: {
+      update: vi.fn(),
+    },
+  },
+}))
+
+// Mock chrome API
+global.chrome = {
+  tabs: {
+    query: vi.fn(),
+    sendMessage: vi.fn(),
+  },
+} as any
+
+const mockCard: StyleCard = {
+  id: "card-uuid-1",
+  name: "Cyber Punk Cyberpunk Style",
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  promptSegments: [
+    { type: "text", value: "a neon cyber punk cat" },
+  ],
+  parameters: { ar: "16:9" },
+  masking: { isSrefHidden: false, isPHidden: false },
+  tier: "Epic",
+  isFavorite: false,
+  usageCount: 0,
+  tags: ["cyber", "neon"],
+  dominantColor: "#ffffff",
+  thumbnailData: "https://example.com/thumb.png",
+  images: ["https://example.com/thumb.png", "https://example.com/image2.png", "https://example.com/image3.png"],
+  selectedThumbnails: ["https://example.com/thumb.png"],
+  frameId: "default",
+  genealogy: { generation: 1, parentIds: [] },
+}
+
+describe("CardDetailView", () => {
+  const defaultProps = {
+    card: mockCard,
+    onClose: vi.fn(),
+    onInject: vi.fn(),
+    onSave: vi.fn(),
+    setAlertType: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useHand).mockReturnValue({
+      pinnedCards: [],
+      unpinCard: vi.fn(),
+      clearHand: vi.fn(),
+    })
+  })
+
+  it("renders with style card info", () => {
+    render(<CardDetailView {...defaultProps} />)
+
+    expect(screen.getByText("Card Details")).toBeDefined()
+    expect(screen.getByPlaceholderText("Card Name")).toBeDefined()
+    expect(screen.getByDisplayValue("Cyber Punk Cyberpunk Style")).toBeDefined()
+    expect(screen.getByText("cyber")).toBeDefined()
+    expect(screen.getByText("neon")).toBeDefined()
+  })
+
+  it("toggles and limits thumbnail selection to max 2 in queue order", () => {
+    render(<CardDetailView {...defaultProps} />)
+
+    const images = screen.getAllByRole("img")
+    // Note: prompt editor bubbles or badges might also have images or we find them by tag name.
+    // Let's filter image elements with alt tag matching "Card Image"
+    const cardImages = images.filter((img) => img.getAttribute("alt")?.includes("Card Image"))
+    expect(cardImages).toHaveLength(3)
+
+    // Image 1 is currently selected ("1st")
+    expect(screen.getByText("1st")).toBeDefined()
+
+    // Click Image 2 to select it
+    fireEvent.click(cardImages[1])
+    expect(screen.getByText("2nd")).toBeDefined()
+
+    // Click Image 3: since 1 and 2 are selected, 1 will be deselected, 2 becomes 1st, 3 becomes 2nd
+    fireEvent.click(cardImages[2])
+    
+    // Let's check selection markers
+    // Images selected now should be Image 2 ("1st") and Image 3 ("2nd")
+    // Wait, the state updates locally inside component, let's verify if we see 1st and 2nd on correct index
+    // Or we click Save and check the mock handler call args
+    const saveButton = screen.getByText("Save")
+    fireEvent.click(saveButton)
+
+    expect(defaultProps.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedThumbnails: ["https://example.com/image2.png", "https://example.com/image3.png"],
+      })
+    )
+  })
+
+  it("adds and removes tags correctly", () => {
+    render(<CardDetailView {...defaultProps} />)
+
+    // Add tag
+    const tagInput = screen.getByPlaceholderText("Add new tag...")
+    fireEvent.change(tagInput, { target: { value: "futuristic" } })
+    fireEvent.submit(tagInput)
+
+    // Remove tag
+    const removeButtons = screen.getAllByText("×")
+    fireEvent.click(removeButtons[0]) // remove first tag ("cyber")
+
+    const saveButton = screen.getByText("Save")
+    fireEvent.click(saveButton)
+
+    expect(defaultProps.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: ["neon", "futuristic"],
+      })
+    )
+  })
+
+  it("triggers prompt injection on inject click", () => {
+    render(<CardDetailView {...defaultProps} />)
+
+    const injectButton = screen.getByText("Inject")
+    fireEvent.click(injectButton)
+
+    expect(defaultProps.onInject).toHaveBeenCalledWith("a neon cyber punk cat --ar 16:9")
+  })
+})

--- a/src/components/organisms/CardDetailView.test.tsx
+++ b/src/components/organisms/CardDetailView.test.tsx
@@ -40,7 +40,13 @@ const mockCard: StyleCard = {
   tags: ["cyber", "neon"],
   dominantColor: "#ffffff",
   thumbnailData: "https://example.com/thumb.png",
-  images: ["https://example.com/thumb.png", "https://example.com/image2.png", "https://example.com/image3.png"],
+  images: [
+    "https://example.com/thumb.png",
+    "https://example.com/image2.png",
+    "https://example.com/image3.png",
+    "https://example.com/image4.png",
+    "https://example.com/image5.png"
+  ],
   selectedThumbnails: ["https://example.com/thumb.png"],
   frameId: "default",
   genealogy: { generation: 1, parentIds: [] },
@@ -74,35 +80,39 @@ describe("CardDetailView", () => {
     expect(screen.getByText("neon")).toBeDefined()
   })
 
-  it("toggles and limits thumbnail selection to max 2 in queue order", () => {
+  it("toggles and limits thumbnail selection to max 4 in queue order", () => {
     render(<CardDetailView {...defaultProps} />)
 
     const images = screen.getAllByRole("img")
-    // Note: prompt editor bubbles or badges might also have images or we find them by tag name.
-    // Let's filter image elements with alt tag matching "Card Image"
     const cardImages = images.filter((img) => img.getAttribute("alt")?.includes("Card Image"))
-    expect(cardImages).toHaveLength(3)
+    expect(cardImages).toHaveLength(5)
 
     // Image 1 is currently selected ("1st")
     expect(screen.getByText("1st")).toBeDefined()
 
-    // Click Image 2 to select it
-    fireEvent.click(cardImages[1])
-    expect(screen.getByText("2nd")).toBeDefined()
-
-    // Click Image 3: since 1 and 2 are selected, 1 will be deselected, 2 becomes 1st, 3 becomes 2nd
-    fireEvent.click(cardImages[2])
+    // Click Image 2, 3, 4 to select them
+    fireEvent.click(cardImages[1]) // becomes 2nd
+    fireEvent.click(cardImages[2]) // becomes 3rd
+    fireEvent.click(cardImages[3]) // becomes 4th
     
-    // Let's check selection markers
-    // Images selected now should be Image 2 ("1st") and Image 3 ("2nd")
-    // Wait, the state updates locally inside component, let's verify if we see 1st and 2nd on correct index
-    // Or we click Save and check the mock handler call args
+    expect(screen.getByText("2nd")).toBeDefined()
+    expect(screen.getByText("3rd")).toBeDefined()
+    expect(screen.getByText("4th")).toBeDefined()
+
+    // Click Image 5: since 1, 2, 3, 4 are selected, 1 will be deselected, 2 becomes 1st, 3 becomes 2nd, 4 becomes 3rd, 5 becomes 4th
+    fireEvent.click(cardImages[4])
+    
     const saveButton = screen.getByText("Save")
     fireEvent.click(saveButton)
 
     expect(defaultProps.onSave).toHaveBeenCalledWith(
       expect.objectContaining({
-        selectedThumbnails: ["https://example.com/image2.png", "https://example.com/image3.png"],
+        selectedThumbnails: [
+          "https://example.com/image2.png",
+          "https://example.com/image3.png",
+          "https://example.com/image4.png",
+          "https://example.com/image5.png"
+        ],
       })
     )
   })

--- a/src/components/organisms/CardDetailView.tsx
+++ b/src/components/organisms/CardDetailView.tsx
@@ -75,11 +75,11 @@ export function CardDetailView({
       // Remove it
       setSelectedThumbs(selectedThumbs.filter((url) => url !== imgUrl))
     } else {
-      // Add it. If already 2 selected, shift the queue
-      if (selectedThumbs.length < 2) {
+      // Add it. If already 4 selected, shift the queue
+      if (selectedThumbs.length < 4) {
         setSelectedThumbs([...selectedThumbs, imgUrl])
       } else {
-        setSelectedThumbs([selectedThumbs[1], imgUrl])
+        setSelectedThumbs([...selectedThumbs.slice(1), imgUrl])
       }
     }
   }
@@ -193,17 +193,19 @@ export function CardDetailView({
           <div className="flex justify-between items-center">
             <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500">Associated Images ({images.length})</h3>
             <span className="text-[10px] text-blue-500 font-bold bg-blue-50 px-2 py-0.5 rounded-full">
-              Selected: {selectedThumbs.length} / 2
+              Selected: {selectedThumbs.length} / 4
             </span>
           </div>
           <p className="text-[11px] text-slate-400">
-            Click on images to toggle their use as the card's thumbnail (up to two). The selection order determines display layout.
+            Click on images to toggle their use as the card's thumbnail (up to four). The selection order determines display layout.
           </p>
 
           <div className="grid grid-cols-2 gap-3">
             {images.map((imgUrl, index) => {
               const selectedIdx = selectedThumbs.indexOf(imgUrl)
               const isSelected = selectedIdx !== -1
+              const orderLabels = ["1st", "2nd", "3rd", "4th"]
+              const orderLabel = orderLabels[selectedIdx] || `${selectedIdx + 1}th`
               return (
                 <div
                   key={index}
@@ -216,7 +218,7 @@ export function CardDetailView({
                   {isSelected && (
                     <div className="absolute top-1.5 left-1.5 bg-blue-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded shadow flex items-center gap-1">
                       <CheckCircle2 className="w-3 h-3" />
-                      <span>{selectedIdx === 0 ? "1st" : "2nd"}</span>
+                      <span>{orderLabel}</span>
                     </div>
                   )}
                 </div>

--- a/src/components/organisms/CardDetailView.tsx
+++ b/src/components/organisms/CardDetailView.tsx
@@ -1,0 +1,305 @@
+import React, { useState, useEffect } from "react"
+import type { StyleCard, PromptSegment } from "../../lib/db-schema"
+import { PromptBubbleEditor } from "./PromptBubbleEditor"
+import { ParameterEditor } from "./ParameterEditor"
+import { RaritySelector } from "../molecules/RaritySelector"
+import { Button } from "../atoms/Button"
+import { Input } from "../atoms/Input"
+import { useHand } from "../../hooks/useHand"
+import { db } from "../../lib/db"
+import { buildPromptString } from "../../lib/prompt-utils"
+import { X, Send, Save, Trash2, CheckCircle2 } from "lucide-react"
+import type { AlertType } from "../molecules/ConnectionAlert"
+
+interface CardDetailViewProps {
+  card: StyleCard
+  onClose: () => void
+  onInject: (prompt: string) => Promise<void>
+  onSave: (updatedCard: StyleCard) => Promise<void>
+  setAlertType: (type: AlertType) => void
+}
+
+export function CardDetailView({
+  card,
+  onClose,
+  onInject,
+  onSave,
+  setAlertType,
+}: CardDetailViewProps) {
+  const { pinnedCards } = useHand()
+  const hasPinnedCards = pinnedCards.length > 0
+
+  const [name, setName] = useState(card.name)
+  const [tier, setTier] = useState(card.tier)
+  const [promptSegments, setPromptSegments] = useState<PromptSegment[]>(card.promptSegments || [])
+  const [parameters, setParameters] = useState<StyleCard["parameters"]>(card.parameters || {})
+  const [isSrefHidden, setIsSrefHidden] = useState(card.masking?.isSrefHidden || false)
+  const [isPHidden, setIsPHidden] = useState(card.masking?.isPHidden || false)
+  
+  // Tags editing state
+  const [tags, setTags] = useState<string[]>(card.tags || [])
+  const [newTagInput, setNewTagInput] = useState("")
+
+  // Image and Thumbnail Selection state
+  const images = card.images && card.images.length > 0 ? card.images : [card.thumbnailData].filter(Boolean)
+  const [selectedThumbs, setSelectedThumbs] = useState<string[]>(card.selectedThumbnails || (card.thumbnailData ? [card.thumbnailData] : []))
+
+  // Sync state if card changes
+  useEffect(() => {
+    setName(card.name)
+    setTier(card.tier)
+    setPromptSegments(card.promptSegments || [])
+    setParameters(card.parameters || {})
+    setIsSrefHidden(card.masking?.isSrefHidden || false)
+    setIsPHidden(card.masking?.isPHidden || false)
+    setTags(card.tags || [])
+    const initialImages = card.images && card.images.length > 0 ? card.images : [card.thumbnailData].filter(Boolean)
+    setSelectedThumbs(card.selectedThumbnails || (card.thumbnailData ? [card.thumbnailData] : []))
+  }, [card])
+
+  const handleAddTag = (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = newTagInput.trim().toLowerCase()
+    if (trimmed && !tags.includes(trimmed)) {
+      setTags([...tags, trimmed])
+    }
+    setNewTagInput("")
+  }
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setTags(tags.filter((t) => t !== tagToRemove))
+  }
+
+  const handleToggleThumbnail = (imgUrl: string) => {
+    if (selectedThumbs.includes(imgUrl)) {
+      // Remove it
+      setSelectedThumbs(selectedThumbs.filter((url) => url !== imgUrl))
+    } else {
+      // Add it. If already 2 selected, shift the queue
+      if (selectedThumbs.length < 2) {
+        setSelectedThumbs([...selectedThumbs, imgUrl])
+      } else {
+        setSelectedThumbs([selectedThumbs[1], imgUrl])
+      }
+    }
+  }
+
+  const handleSaveChanges = async () => {
+    // Fallback thumbnail data for older fields compatibility
+    const primaryThumb = selectedThumbs[0] || images[0] || "assets/icon.png"
+
+    const updatedCard: StyleCard = {
+      ...card,
+      name,
+      tier,
+      promptSegments,
+      parameters,
+      tags,
+      images,
+      selectedThumbnails: selectedThumbs,
+      thumbnailData: primaryThumb,
+      masking: {
+        isSrefHidden,
+        isPHidden,
+      },
+      updatedAt: Date.now(),
+    }
+
+    try {
+      await onSave(updatedCard)
+    } catch (err) {
+      console.error("Failed to save style card updates:", err)
+    }
+  }
+
+  const handleTryOnMidjourney = async () => {
+    const maskedKeys: (keyof StyleCard["parameters"])[] = []
+    if (isSrefHidden) maskedKeys.push("sref")
+    if (isPHidden) maskedKeys.push("p")
+
+    const fullPrompt = buildPromptString(promptSegments, parameters, maskedKeys)
+    await onInject(fullPrompt)
+  }
+
+  return (
+    <div
+      data-testid="card-detail-view-container"
+      className={`absolute inset-0 bg-slate-50 z-20 flex flex-col ${hasPinnedCards ? "pb-[110px]" : ""}`}
+    >
+      {/* Header */}
+      <div className="p-4 bg-white shadow-sm flex items-center justify-between border-b">
+        <h2 className="text-lg font-bold text-slate-800">Card Details</h2>
+        <Button variant="ghost" size="xs" onClick={onClose} className="text-slate-400 hover:text-slate-600">
+          <X className="w-5 h-5" />
+        </Button>
+      </div>
+
+      {/* Main Content Area */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-6">
+        {/* Card Metadata Section */}
+        <div className="p-4 bg-white border rounded-lg shadow-sm space-y-4">
+          <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500">Identity</h3>
+          <div>
+            <label className="block text-xs font-medium text-slate-500 mb-1">Card Name</label>
+            <Input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Card Name"
+              className="font-bold text-slate-800 text-sm"
+            />
+          </div>
+
+          {/* Tags Editor */}
+          <div>
+            <label className="block text-xs font-medium text-slate-500 mb-1">Tags</label>
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              {tags.map((t, idx) => (
+                <span
+                  key={idx}
+                  className="inline-flex items-center gap-1 bg-slate-100 text-slate-700 px-2 py-0.5 rounded text-[11px] font-medium border border-slate-200"
+                >
+                  {t}
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveTag(t)}
+                    className="text-slate-400 hover:text-red-500 text-[10px]"
+                  >
+                    &times;
+                  </button>
+                </span>
+              ))}
+              {tags.length === 0 && (
+                <span className="text-xs text-slate-400 italic">No tags added yet.</span>
+              )}
+            </div>
+            <form onSubmit={handleAddTag} className="flex gap-2">
+              <Input
+                type="text"
+                value={newTagInput}
+                onChange={(e) => setNewTagInput(e.target.value)}
+                placeholder="Add new tag..."
+                className="text-xs py-1"
+              />
+              <Button type="submit" size="xs" variant="slate">
+                Add
+              </Button>
+            </form>
+          </div>
+        </div>
+
+        {/* Gallery & Thumbnail Selector Section */}
+        <div className="p-4 bg-white border rounded-lg shadow-sm space-y-4">
+          <div className="flex justify-between items-center">
+            <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500">Associated Images ({images.length})</h3>
+            <span className="text-[10px] text-blue-500 font-bold bg-blue-50 px-2 py-0.5 rounded-full">
+              Selected: {selectedThumbs.length} / 2
+            </span>
+          </div>
+          <p className="text-[11px] text-slate-400">
+            Click on images to toggle their use as the card's thumbnail (up to two). The selection order determines display layout.
+          </p>
+
+          <div className="grid grid-cols-2 gap-3">
+            {images.map((imgUrl, index) => {
+              const selectedIdx = selectedThumbs.indexOf(imgUrl)
+              const isSelected = selectedIdx !== -1
+              return (
+                <div
+                  key={index}
+                  onClick={() => handleToggleThumbnail(imgUrl)}
+                  className={`relative aspect-square cursor-pointer overflow-hidden rounded-lg border-2 transition-all ${
+                    isSelected ? "border-blue-500 ring-2 ring-blue-100 shadow-md" : "border-slate-200 hover:border-slate-400"
+                  }`}
+                >
+                  <img src={imgUrl} className="w-full h-full object-cover" alt={`Card Image ${index + 1}`} />
+                  {isSelected && (
+                    <div className="absolute top-1.5 left-1.5 bg-blue-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded shadow flex items-center gap-1">
+                      <CheckCircle2 className="w-3 h-3" />
+                      <span>{selectedIdx === 0 ? "1st" : "2nd"}</span>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Prompt segments bubble editor */}
+        <div className="p-4 bg-white border rounded-lg shadow-sm space-y-3">
+          <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500">Prompt Recipe</h3>
+          <PromptBubbleEditor
+            initialSegments={promptSegments}
+            onChange={setPromptSegments}
+            tier={tier}
+          />
+        </div>
+
+        {/* Parameters editor */}
+        <div className="p-4 bg-white border rounded-lg shadow-sm space-y-3">
+          <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500">Parameters</h3>
+          <ParameterEditor parameters={parameters} onChange={setParameters} />
+        </div>
+
+        {/* Sealing options */}
+        <div className="p-4 bg-white border rounded-lg shadow-sm space-y-3">
+          <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500">Sealing Options</h3>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="detail-hide-sref"
+                checked={isSrefHidden}
+                onChange={(e) => setIsSrefHidden(e.target.checked)}
+              />
+              <label htmlFor="detail-hide-sref" className="text-xs text-slate-600">
+                Hide --sref when sharing
+              </label>
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="detail-hide-p"
+                checked={isPHidden}
+                onChange={(e) => setIsPHidden(e.target.checked)}
+              />
+              <label htmlFor="detail-hide-p" className="text-xs text-slate-600">
+                Hide --p when sharing
+              </label>
+            </div>
+          </div>
+        </div>
+
+        {/* Rarity selector */}
+        <div className="p-4 bg-white border rounded-lg shadow-sm space-y-3">
+          <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500">Rarity & Frame</h3>
+          <RaritySelector selected={tier} onSelect={setTier} />
+        </div>
+      </div>
+
+      {/* Footer Actions */}
+      <div className="p-4 bg-white shadow-t-sm flex justify-between gap-2 border-t z-10">
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <div className="flex gap-2">
+          <Button
+            variant="slate"
+            onClick={handleTryOnMidjourney}
+            className="flex items-center gap-1.5"
+          >
+            <Send className="w-4 h-4" />
+            Inject
+          </Button>
+          <Button
+            onClick={handleSaveChanges}
+            className="bg-blue-600 hover:bg-blue-700 text-white flex items-center gap-1.5"
+          >
+            <Save className="w-4 h-4" />
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/organisms/HandBar.tsx
+++ b/src/components/organisms/HandBar.tsx
@@ -39,6 +39,7 @@ export function HandBar() {
               >
                 <CardThumbnail
                   imageUrl={card.thumbnailData}
+                  thumbnailImages={card.selectedThumbnails}
                   alt={card.name}
                   tier={card.tier}
                   size="sm"

--- a/src/components/organisms/LibraryTab.tsx
+++ b/src/components/organisms/LibraryTab.tsx
@@ -3,15 +3,17 @@ import { useLibrary } from "../../hooks/useLibrary"
 import { RARITY_CONFIG } from "../../lib/rarity-config"
 import { SearchField } from "../molecules/SearchField"
 import { CardThumbnail } from "../molecules/CardThumbnail"
+import type { StyleCard } from "../../lib/db-schema"
 
 import { ConnectionAlert, type AlertType } from "../molecules/ConnectionAlert"
 
 interface LibraryTabProps {
   addLog: (msg: string) => void
   setAlertType: (type: AlertType) => void
+  onOpenDetailCard: (card: StyleCard) => void
 }
 
-export function LibraryTab({ addLog, setAlertType }: LibraryTabProps) {
+export function LibraryTab({ addLog, setAlertType, onOpenDetailCard }: LibraryTabProps) {
   const {
     styleCards,
     handleCardClick,
@@ -67,16 +69,21 @@ export function LibraryTab({ addLog, setAlertType }: LibraryTabProps) {
           return (
             <div
               key={card.id}
-              onClick={() => handleCardClick(card)}
+              onClick={() => onOpenDetailCard(card)}
               className={`group bg-white border-2 rounded-lg shadow-sm cursor-pointer overflow-hidden transition-all hover:scale-[1.02] active:scale-[0.98] ${config?.borderClass || "border-slate-200"
                 } ${config?.glowClass || ""}`}
             >
               <CardThumbnail
                 imageUrl={card.thumbnailData}
+                thumbnailImages={card.selectedThumbnails}
                 alt={card.name}
                 tier={card.tier}
                 isPinned={card.isPinned}
                 onPinClick={(e) => togglePin(card, e)}
+                onInjectClick={(e) => {
+                  e.stopPropagation()
+                  handleCardClick(card)
+                }}
               />
               <div className={`p-2 border-t ${config.borderClass} bg-opacity-5 ${config.bgClass}`}>
                 <p className="text-xs font-bold text-slate-800 truncate">{card.name}</p>

--- a/src/components/organisms/Workbench.tsx
+++ b/src/components/organisms/Workbench.tsx
@@ -258,7 +258,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
       <div className="grid grid-cols-2 gap-4 bg-slate-50 p-4 rounded-xl border-2 border-dashed border-slate-200 min-h-[160px]">
         {workbenchCards.map((card) => (
           <div key={card.id} className="relative group animate-in zoom-in-95 duration-200">
-            <CardThumbnail imageUrl={card.thumbnailData} alt={card.name} tier={card.tier} className="w-full aspect-square" />
+            <CardThumbnail imageUrl={card.thumbnailData} thumbnailImages={card.selectedThumbnails} alt={card.name} tier={card.tier} className="w-full aspect-square" />
             <button
               onClick={() => toggleCardSelection(card.id)}
               className="absolute -top-2 -right-2 bg-red-500 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity z-10"

--- a/src/components/templates/SidePanelLayout.tsx
+++ b/src/components/templates/SidePanelLayout.tsx
@@ -73,8 +73,12 @@ export function SidePanelLayout({
       </div>
       <div className="flex-1 overflow-y-auto p-4 space-y-4 pb-24">
         {droppedItem && (
-          <div className="p-3 border rounded bg-white shadow-lg ring-2 ring-blue-500">
-            <p className="text-xs font-bold uppercase">New History Item Added!</p>
+          <div className="p-3 border rounded bg-white shadow-lg ring-2 ring-blue-500 animate-in fade-in slide-in-from-top-4">
+            <p className="text-xs font-bold uppercase text-slate-800">
+              {droppedItem.isMerged
+                ? `Associated with Card "${droppedItem.name || 'Existing Card'}"!`
+                : "New History Item Added!"}
+            </p>
           </div>
         )}
         {children}

--- a/src/hooks/useDragAndDrop.test.ts
+++ b/src/hooks/useDragAndDrop.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { useDragAndDrop } from "./useDragAndDrop"
+import { db } from "../lib/db"
+import { renderHook, act } from "@testing-library/react"
+
+vi.mock("../lib/db", () => {
+  const mockWhere = {
+    equals: vi.fn().mockReturnThis(),
+    first: vi.fn(),
+  }
+  return {
+    db: {
+      historyItems: {
+        put: vi.fn(),
+      },
+      styleCards: {
+        where: vi.fn(() => mockWhere),
+        update: vi.fn(),
+      },
+    },
+  }
+})
+
+describe("useDragAndDrop", () => {
+  const mockAddLog = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should handle drag over and drag leave correctly", () => {
+    const { result } = renderHook(() => useDragAndDrop(mockAddLog))
+
+    expect(result.current.isDragging).toBe(false)
+
+    const dummyEvent = { preventDefault: vi.fn() } as any
+    act(() => {
+      result.current.handleDragOver(dummyEvent)
+    })
+    expect(result.current.isDragging).toBe(true)
+    expect(dummyEvent.preventDefault).toHaveBeenCalled()
+
+    act(() => {
+      result.current.handleDragLeave()
+    })
+    expect(result.current.isDragging).toBe(false)
+  })
+
+  it("should save history item when dropping a new image (no matching jobId)", async () => {
+    const { result } = renderHook(() => useDragAndDrop(mockAddLog))
+
+    // Mock DB: style card not found
+    const styleCardsWhere = db.styleCards.where("jobId")
+    vi.mocked((styleCardsWhere as any).first).mockResolvedValue(null)
+    vi.mocked(db.historyItems.put).mockResolvedValue("test-job-id")
+
+    const mockItem = {
+      id: "test-job-id",
+      fullCommand: "test prompt",
+      imageUrl: "https://example.com/img.png",
+      timestamp: 1234567,
+    }
+
+    const dummyEvent = {
+      preventDefault: vi.fn(),
+      dataTransfer: {
+        getData: vi.fn().mockReturnValue(JSON.stringify(mockItem)),
+      },
+    } as any
+
+    let returnedItem: any
+    await act(async () => {
+      returnedItem = await result.current.handleDrop(dummyEvent)
+    })
+
+    expect(db.styleCards.where).toHaveBeenCalledWith("jobId")
+    expect(db.historyItems.put).toHaveBeenCalledWith(mockItem)
+    expect(result.current.droppedItem).toEqual({ id: "test-job-id", isMerged: false })
+    expect(returnedItem).toEqual(mockItem)
+  })
+
+  it("should append image to existing StyleCard when matching jobId exists", async () => {
+    const { result } = renderHook(() => useDragAndDrop(mockAddLog))
+
+    const mockExistingCard = {
+      id: "card-uuid-123",
+      name: "Cool Card",
+      jobId: "test-job-id",
+      images: ["https://example.com/first.png"],
+      thumbnailData: "https://example.com/first.png",
+    }
+
+    // Mock DB: style card found
+    const styleCardsWhere = db.styleCards.where("jobId")
+    vi.mocked((styleCardsWhere as any).first).mockResolvedValue(mockExistingCard)
+    vi.mocked(db.styleCards.update).mockResolvedValue(1)
+
+    const mockItem = {
+      id: "test-job-id",
+      fullCommand: "test prompt",
+      imageUrl: "https://example.com/second.png",
+      timestamp: 1234567,
+    }
+
+    const dummyEvent = {
+      preventDefault: vi.fn(),
+      dataTransfer: {
+        getData: vi.fn().mockReturnValue(JSON.stringify(mockItem)),
+      },
+    } as any
+
+    let returnedItem: any
+    await act(async () => {
+      returnedItem = await result.current.handleDrop(dummyEvent)
+    })
+
+    expect(db.styleCards.where).toHaveBeenCalledWith("jobId")
+    expect(db.styleCards.update).toHaveBeenCalledWith("card-uuid-123", {
+      images: ["https://example.com/first.png", "https://example.com/second.png"],
+      updatedAt: expect.any(Number),
+    })
+    expect(db.historyItems.put).not.toHaveBeenCalled()
+    expect(result.current.droppedItem).toEqual({
+      id: "card-uuid-123",
+      name: "Cool Card",
+      isMerged: true,
+    })
+    expect(returnedItem).toEqual(mockItem)
+  })
+})

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -4,7 +4,7 @@ import type { HistoryItem } from "../lib/db-schema"
 
 export function useDragAndDrop(addLog: (msg: string) => void) {
   const [isDragging, setIsDragging] = useState(false)
-  const [droppedItem, setDroppedItem] = useState<HistoryItem | null>(null)
+  const [droppedItem, setDroppedItem] = useState<{ id: string; name?: string; isMerged?: boolean } | null>(null)
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
@@ -22,16 +22,37 @@ export function useDragAndDrop(addLog: (msg: string) => void) {
     const jsonData = e.dataTransfer.getData("application/json")
     if (!jsonData) {
       addLog("No JSON data in drop event.")
-      return
+      return null
     }
     try {
       const item = JSON.parse(jsonData) as HistoryItem
       if (item && item.id && item.imageUrl) {
-        await db.historyItems.put(item)
-        addLog(`History item ${item.id} saved.`)
-        setDroppedItem(item)
-        setTimeout(() => setDroppedItem(null), 3000)
-        return item
+        // Query to check if a style card with this jobId already exists
+        const existingCard = await db.styleCards.where("jobId").equals(item.id).first()
+        
+        if (existingCard) {
+          const currentImages = existingCard.images || []
+          if (!currentImages.includes(item.imageUrl)) {
+            const updatedImages = [...currentImages, item.imageUrl]
+            await db.styleCards.update(existingCard.id, {
+              images: updatedImages,
+              updatedAt: Date.now()
+            })
+            addLog(`Image added to existing Style Card "${existingCard.name}".`)
+          } else {
+            addLog(`Image already associated with Style Card "${existingCard.name}".`)
+          }
+          
+          setDroppedItem({ id: existingCard.id, name: existingCard.name, isMerged: true })
+          setTimeout(() => setDroppedItem(null), 3000)
+          return item
+        } else {
+          await db.historyItems.put(item)
+          addLog(`History item ${item.id} saved.`)
+          setDroppedItem({ id: item.id, isMerged: false })
+          setTimeout(() => setDroppedItem(null), 3000)
+          return item
+        }
       } else {
         addLog("Invalid history item data.")
       }

--- a/src/hooks/useMinting.ts
+++ b/src/hooks/useMinting.ts
@@ -109,6 +109,9 @@ export function useMinting(addLog: (msg: string) => void, setActiveTab: (tab: "h
       thumbnailData,
       frameId: "default",
       genealogy,
+      jobId: mintingItem ? mintingItem.id : undefined,
+      images: mintingItem ? [mintingItem.imageUrl] : [],
+      selectedThumbnails: mintingItem ? [mintingItem.imageUrl] : [],
     }
 
     try {

--- a/src/lib/db-schema.ts
+++ b/src/lib/db-schema.ts
@@ -49,6 +49,9 @@ export interface StyleCard {
     mutationNote?: string;    // "Mixed with Watercolor" などの自動メモ
   };
   isVariable?: boolean;     // 変数カード（手札一時保持用）フラグ
+  jobId?: string;           // Midjourney Job ID (for drag-and-drop merging)
+  images?: string[];        // Associated image URLs
+  selectedThumbnails?: string[]; // Selected image URLs for thumbnail display (up to 2)
 }
 
 // プロンプトの構成要素（バブル）

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -8,8 +8,8 @@ export class StyleAtelierDatabase extends Dexie {
 
   constructor() {
     super('StyleAtelierDatabase');
-    this.version(4).stores({
-      styleCards: 'id, name, createdAt, tier, isFavorite, isPinned',
+    this.version(5).stores({
+      styleCards: 'id, name, createdAt, tier, isFavorite, isPinned, jobId',
       historyItems: 'id, timestamp',
       userSettings: 'userId',
     });

--- a/src/pages/SidePanel.tsx
+++ b/src/pages/SidePanel.tsx
@@ -5,20 +5,62 @@ import { HistoryTab } from "../components/organisms/HistoryTab"
 import { LibraryTab } from "../components/organisms/LibraryTab"
 import { Workbench } from "../components/organisms/Workbench"
 import { MintingView } from "../components/organisms/MintingView"
+import { CardDetailView } from "../components/organisms/CardDetailView"
 import { HandBar } from "../components/organisms/HandBar"
 import { useTabs } from "../hooks/useTabs"
 import { useDragAndDrop } from "../hooks/useDragAndDrop"
 import { useMinting } from "../hooks/useMinting"
 import { WorkbenchProvider } from "../contexts/WorkbenchContext"
 import type { AlertType } from "../components/molecules/ConnectionAlert"
+import type { StyleCard } from "../lib/db-schema"
 
 function SidePanelPage() {
   const [logs, setLogs] = useState<string[]>([])
   // New global state for connection alerts
   const [alertType, setAlertType] = useState<AlertType>(null)
+  const [activeDetailCard, setActiveDetailCard] = useState<StyleCard | null>(null)
 
   const addLog = (log: string) => {
     setLogs((prev) => [log, ...prev].slice(0, 20))
+  }
+
+  const handleSaveCardDetails = async (updatedCard: StyleCard) => {
+    try {
+      await db.styleCards.put(updatedCard)
+      addLog(`StyleCard "${updatedCard.name}" updated successfully!`)
+      setActiveDetailCard(null)
+    } catch (err) {
+      console.error("Failed to save style card updates:", err)
+      addLog("Error: Failed to save style card updates.")
+    }
+  }
+
+  const handleInjectPrompt = async (prompt: string) => {
+    setAlertType(null);
+    try {
+      const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+      const activeTab = tabs[0];
+      if (!activeTab?.id) {
+        throw new Error("No active tab found");
+      }
+      const response = await chrome.tabs.sendMessage(activeTab.id, {
+        type: "INJECT_PROMPT",
+        prompt: prompt,
+      });
+      if (response && response.status === "error") {
+        if (response.message && response.message.includes("Could not find chat input")) {
+          setAlertType("no_input");
+        } else {
+          setAlertType("disconnected");
+        }
+      } else {
+        addLog(`Sent prompt: ${prompt.substring(0, 30)}...`)
+      }
+    } catch (err: any) {
+      console.error("Injection failed:", err);
+      setAlertType("disconnected");
+      addLog(`Note: ${err.message || "Could not send to tab"}`)
+    }
   }
 
   const { activeTab, setActiveTab } = useTabs()
@@ -76,6 +118,7 @@ function SidePanelPage() {
             setActiveTab(tab)
             setMintingItem(null)
             setVariationBase(null)
+            setActiveDetailCard(null)
           }}
           isDragging={isDragging}
           logs={logs}
@@ -109,8 +152,17 @@ function SidePanelPage() {
               setCustomName={setCustomName}
             />
           )}
+          {activeDetailCard && (
+            <CardDetailView
+              card={activeDetailCard}
+              onClose={() => setActiveDetailCard(null)}
+              onInject={handleInjectPrompt}
+              onSave={handleSaveCardDetails}
+              setAlertType={setAlertType}
+            />
+          )}
           {activeTab === "history" && <HistoryTab onStartMinting={handleStartMinting} />}
-          {activeTab === "library" && <LibraryTab addLog={addLog} setAlertType={setAlertType} />}
+          {activeTab === "library" && <LibraryTab addLog={addLog} setAlertType={setAlertType} onOpenDetailCard={setActiveDetailCard} />}
           {activeTab === "workbench" && <Workbench onStartVariationMinting={handleStartVariationMinting} addLog={addLog} setAlertType={setAlertType} />}
 
           {/* HandBar is now inside SidePanelLayout children to ensure it stays in same context */}


### PR DESCRIPTION
Closes #25. Adds support for associating multiple images to a single style card, split-rendering up to two selected thumbnails in Library/HandBar/Workbench, and selecting thumbnails in CardDetailView.