### PR TITLE
Modify library card behavior and layout (#79)

### DIFF
--- a/src/components/molecules/CardThumbnail.test.tsx
+++ b/src/components/molecules/CardThumbnail.test.tsx
@@ -156,4 +156,34 @@ describe("CardThumbnail", () => {
     const categoryImg = screen.getAllByRole("img").find(img => img.getAttribute("src") === "data:image/png;base64,icon_data")
     expect(categoryImg).toBeDefined()
   })
+
+  it("renders usage count badge when usageCount is provided", () => {
+    render(
+      <CardThumbnail
+        imageUrl="https://example.com/one.png"
+        alt="Test Card"
+        tier="Common"
+        usageCount={5}
+      />
+    )
+    const usageBadge = screen.getByTestId("usage-count-badge")
+    expect(usageBadge).toBeDefined()
+    expect(usageBadge.textContent).toBe("5 uses")
+  })
+
+  it("calls onEditClick when edit button is clicked", () => {
+    const mockOnEditClick = vi.fn()
+    render(
+      <CardThumbnail
+        imageUrl="https://example.com/one.png"
+        alt="Test Card"
+        tier="Common"
+        onEditClick={mockOnEditClick}
+      />
+    )
+    const editBtn = screen.getByTestId("edit-card-button")
+    expect(editBtn).toBeDefined()
+    fireEvent.click(editBtn)
+    expect(mockOnEditClick).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/components/molecules/CardThumbnail.tsx
+++ b/src/components/molecules/CardThumbnail.tsx
@@ -25,9 +25,11 @@ interface CardThumbnailProps {
   onPinClick?: (e: React.MouseEvent) => void
   onDeleteClick?: (e: React.MouseEvent) => void
   onInjectClick?: (e: React.MouseEvent) => void
+  onEditClick?: (e: React.MouseEvent) => void
   size?: "sm" | "md" | "lg"
   className?: string
   category?: { id: string; name: string; iconEmoji?: string; iconUrl?: string }
+  usageCount?: number
 }
 
 export function CardThumbnail({
@@ -39,9 +41,11 @@ export function CardThumbnail({
   onPinClick,
   onDeleteClick,
   onInjectClick,
+  onEditClick,
   size = "md",
   className = "",
   category,
+  usageCount,
 }: CardThumbnailProps) {
   const sizeClasses = {
     sm: "w-12 h-12",
@@ -138,6 +142,16 @@ export function CardThumbnail({
       {/* Rarity Badge */}
       <RarityBadge tier={tier} className="absolute top-1 right-1" />
       
+      {/* Usage Count Badge */}
+      {usageCount !== undefined && (
+        <div
+          data-testid="usage-count-badge"
+          className="absolute bottom-1.5 left-1.5 bg-slate-900/60 border border-white/20 text-white rounded px-1.5 py-0.5 text-[9px] font-bold backdrop-blur-[2px] shadow-md z-10 select-none pointer-events-none"
+        >
+          {usageCount} uses
+        </div>
+      )}
+
       {/* Actions */}
       <div className="absolute bottom-1 right-1 flex gap-1">
         {onInjectClick && (
@@ -151,6 +165,22 @@ export function CardThumbnail({
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="22" y1="2" x2="11" y2="13"></line>
               <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+            </svg>
+          </IconButton>
+        )}
+
+        {onEditClick && (
+          <IconButton
+            variant="white"
+            size="sm"
+            onClick={onEditClick}
+            className="shadow-md"
+            title="Edit Card"
+            data-testid="edit-card-button"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+              <path d="M18.5 2.5a2.121 2.121 0 1 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
             </svg>
           </IconButton>
         )}

--- a/src/components/organisms/LibraryTab.test.tsx
+++ b/src/components/organisms/LibraryTab.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { LibraryTab } from "./LibraryTab"
+import { useLibrary } from "../../hooks/useLibrary"
+import type { StyleCard } from "../../lib/db-schema"
+
+vi.mock("../../hooks/useLibrary", () => ({
+  useLibrary: vi.fn(),
+}))
+
+const mockCards: StyleCard[] = [
+  {
+    id: "card-1",
+    name: "Golden Dragon",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    promptSegments: [{ type: "text", value: "a golden dragon" }],
+    parameters: {},
+    masking: { isSrefHidden: false, isPHidden: false },
+    tier: "Legendary",
+    isFavorite: false,
+    isPinned: false,
+    usageCount: 12,
+    tags: ["fantasy", "gold"],
+    dominantColor: "#d4af37",
+    thumbnailData: "data:image/png;base64,123",
+    frameId: "default",
+    genealogy: { generation: 1, parentIds: [] },
+  },
+]
+
+describe("LibraryTab", () => {
+  const mockOpenDetailCard = vi.fn()
+  const mockAddLog = vi.fn()
+  const mockSetAlertType = vi.fn()
+
+  const defaultProps = {
+    addLog: mockAddLog,
+    setAlertType: mockSetAlertType,
+    onOpenDetailCard: mockOpenDetailCard,
+  }
+
+  const mockTogglePin = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useLibrary).mockReturnValue({
+      styleCards: mockCards,
+      handleCardClick: vi.fn(),
+      togglePin: mockTogglePin,
+      searchTag: "",
+      setSearchTag: vi.fn(),
+      rarityFilter: "All",
+      setRarityFilter: vi.fn(),
+      categoryFilter: "All",
+      setCategoryFilter: vi.fn(),
+      sortBy: "newest",
+      setSortBy: vi.fn(),
+      allSrefs: [],
+      categories: [],
+    })
+  })
+
+  it("renders search field, filters, and cards", () => {
+    render(<LibraryTab {...defaultProps} />)
+    expect(screen.getByPlaceholderText("Search by tag, name or sref...")).toBeDefined()
+    expect(screen.getByText("Golden Dragon")).toBeDefined()
+  })
+
+  it("triggers togglePin when clicking the card itself", () => {
+    render(<LibraryTab {...defaultProps} />)
+    const cardElement = screen.getByText("Golden Dragon").closest(".group")
+    expect(cardElement).toBeDefined()
+    
+    fireEvent.click(cardElement!)
+    expect(mockTogglePin).toHaveBeenCalledWith(mockCards[0], expect.any(Object))
+  })
+
+  it("triggers onOpenDetailCard when clicking the edit button on the card", () => {
+    render(<LibraryTab {...defaultProps} />)
+    const editBtn = screen.getByTestId("edit-card-button")
+    expect(editBtn).toBeDefined()
+    
+    fireEvent.click(editBtn)
+    expect(mockOpenDetailCard).toHaveBeenCalledWith(mockCards[0])
+    expect(mockTogglePin).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/organisms/LibraryTab.tsx
+++ b/src/components/organisms/LibraryTab.tsx
@@ -121,7 +121,7 @@ export function LibraryTab({ addLog, setAlertType, onOpenDetailCard }: LibraryTa
           return (
             <div
               key={card.id}
-              onClick={() => onOpenDetailCard(card)}
+              onClick={(e) => togglePin(card, e)}
               className={`group bg-white border-2 rounded-lg shadow-sm cursor-pointer overflow-hidden transition-all hover:scale-[1.02] active:scale-[0.98] ${config?.borderClass || "border-slate-200"
                 } ${config?.glowClass || ""}`}
             >
@@ -131,7 +131,12 @@ export function LibraryTab({ addLog, setAlertType, onOpenDetailCard }: LibraryTa
                 alt={card.name}
                 tier={card.tier}
                 isPinned={card.isPinned}
+                usageCount={card.usageCount}
                 onPinClick={(e) => togglePin(card, e)}
+                onEditClick={(e) => {
+                  e.stopPropagation()
+                  onOpenDetailCard(card)
+                }}
                 onInjectClick={(e) => {
                   e.stopPropagation()
                   handleCardClick(card)

--- a/src/components/organisms/Workbench.test.tsx
+++ b/src/components/organisms/Workbench.test.tsx
@@ -18,6 +18,8 @@ vi.mock("../../lib/db", () => ({
   db: {
     styleCards: {
       add: vi.fn(),
+      update: vi.fn().mockResolvedValue(1),
+      get: vi.fn().mockResolvedValue(null),
       toArray: vi.fn().mockResolvedValue([]),
     },
     categories: {
@@ -174,6 +176,10 @@ describe("Workbench", () => {
           prompt: "a photo of, neon tiger, in, neon rain --ar 16:9",
         })
       );
+      // Check that usageCount was incremented
+      expect(db.styleCards.update).toHaveBeenCalledWith("card-1", {
+        usageCount: 6,
+      });
     });
 
     // Check value is saved to localStorage history

--- a/src/components/organisms/Workbench.tsx
+++ b/src/components/organisms/Workbench.tsx
@@ -214,6 +214,12 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
       } else {
         addLog?.(`Prompt injected successfully!`);
 
+        // Increment usage count for all cards in the Workbench
+        workbenchCards.forEach((card) => {
+          db.styleCards.update(card.id, { usageCount: (card.usageCount || 0) + 1 })
+            .catch(err => console.error("Failed to update usage count on workbench inject:", err));
+        });
+
         // Save slot values to history on success
         const existing = localStorage.getItem("style_atelier_slot_history");
         const history: Record<string, string[]> = existing ? JSON.parse(existing) : {};

--- a/src/contexts/WorkbenchContext.tsx
+++ b/src/contexts/WorkbenchContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useCallback } from "react";
+import { db } from "../lib/db";
 
 interface WorkbenchContextType {
   selectedCardIds: string[];
@@ -12,9 +13,19 @@ export const WorkbenchProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
 
   const toggleCardSelection = useCallback((cardId: string) => {
-    setSelectedCardIds((prev) =>
-      prev.includes(cardId) ? prev.filter((id) => id !== cardId) : [...prev, cardId]
-    );
+    setSelectedCardIds((prev) => {
+      const isSelecting = !prev.includes(cardId);
+      if (isSelecting) {
+        db.styleCards.get(cardId).then((card) => {
+          if (card) {
+            db.styleCards.update(cardId, {
+              usageCount: (card.usageCount || 0) + 1
+            }).catch(err => console.error("Failed to update usage count on select:", err));
+          }
+        }).catch(err => console.error("Failed to fetch card on select:", err));
+      }
+      return isSelecting ? [...prev, cardId] : prev.filter((id) => id !== cardId);
+    });
   }, []);
 
   const clearWorkbench = useCallback(() => {

--- a/src/hooks/useLibrary.test.ts
+++ b/src/hooks/useLibrary.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { useLibrary } from "./useLibrary"
+import { db } from "../lib/db"
+import { renderHook, act } from "@testing-library/react"
+
+// Mock dexie-react-hooks
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: (fn: any) => {
+    return []
+  }
+}))
+
+vi.mock("../lib/db", () => ({
+  db: {
+    styleCards: {
+      update: vi.fn().mockResolvedValue(1),
+      toArray: vi.fn().mockResolvedValue([]),
+    },
+    categories: {
+      toArray: vi.fn().mockResolvedValue([]),
+    },
+  },
+}))
+
+// Mock chrome API
+global.chrome = {
+  tabs: {
+    query: vi.fn(),
+    sendMessage: vi.fn(),
+  },
+} as any
+
+describe("useLibrary hook", () => {
+  const mockAddLog = vi.fn()
+  const mockSetAlertType = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(chrome.tabs.query).mockImplementation((query, callback) => {
+      callback([{ id: 1 }])
+    })
+    vi.mocked(chrome.tabs.sendMessage).mockResolvedValue({ status: "success" })
+  })
+
+  it("should increment usageCount when toggling pin (adding to hand)", async () => {
+    const { result } = renderHook(() => useLibrary(mockAddLog, mockSetAlertType))
+    
+    const mockCard = {
+      id: "card-123",
+      name: "Test Card",
+      isPinned: false,
+      usageCount: 4,
+      parameters: {},
+      masking: {},
+      promptSegments: [],
+    } as any
+
+    await act(async () => {
+      await result.current.togglePin(mockCard, { stopPropagation: vi.fn() } as any)
+    })
+
+    expect(db.styleCards.update).toHaveBeenCalledWith("card-123", {
+      isPinned: true,
+      usageCount: 5,
+    })
+  })
+
+  it("should NOT increment usageCount when toggling pin to remove from hand", async () => {
+    const { result } = renderHook(() => useLibrary(mockAddLog, mockSetAlertType))
+    
+    const mockCard = {
+      id: "card-123",
+      name: "Test Card",
+      isPinned: true,
+      usageCount: 4,
+      parameters: {},
+      masking: {},
+      promptSegments: [],
+    } as any
+
+    await act(async () => {
+      await result.current.togglePin(mockCard, { stopPropagation: vi.fn() } as any)
+    })
+
+    expect(db.styleCards.update).toHaveBeenCalledWith("card-123", {
+      isPinned: false,
+    })
+  })
+
+  it("should increment usageCount when prompt is successfully injected", async () => {
+    const { result } = renderHook(() => useLibrary(mockAddLog, mockSetAlertType))
+    
+    const mockCard = {
+      id: "card-123",
+      name: "Test Card",
+      isPinned: false,
+      usageCount: 2,
+      parameters: {},
+      masking: {},
+      promptSegments: [{ type: "text", value: "hello" }],
+    } as any
+
+    await act(async () => {
+      result.current.handleCardClick(mockCard)
+    })
+
+    expect(chrome.tabs.query).toHaveBeenCalled()
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, {
+      type: "INJECT_PROMPT",
+      prompt: "hello",
+    })
+
+    // Wait for the async message response chain to finish and call db update
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10))
+    })
+
+    expect(db.styleCards.update).toHaveBeenCalledWith("card-123", {
+      usageCount: 3,
+    })
+  })
+})

--- a/src/hooks/useLibrary.ts
+++ b/src/hooks/useLibrary.ts
@@ -81,7 +81,11 @@ export function useLibrary(addLog: (msg: string) => void, setAlertType: (type: A
     e.stopPropagation()
     const newPinnedStatus = !card.isPinned
     try {
-      await db.styleCards.update(card.id, { isPinned: newPinnedStatus })
+      const updateData: Partial<StyleCard> = { isPinned: newPinnedStatus }
+      if (newPinnedStatus) {
+        updateData.usageCount = (card.usageCount || 0) + 1
+      }
+      await db.styleCards.update(card.id, updateData)
       addLog(newPinnedStatus ? `Added ${card.name} to hand.` : `Removed ${card.name} from hand.`)
     } catch (err) {
       console.error("Failed to toggle pin:", err)
@@ -114,6 +118,8 @@ export function useLibrary(addLog: (msg: string) => void, setAlertType: (type: A
               }
             } else {
               addLog(`Sent prompt: ${prompt.substring(0, 30)}...`)
+              db.styleCards.update(card.id, { usageCount: (card.usageCount || 0) + 1 })
+                .catch((err) => console.error("Failed to update usage count on inject:", err))
             }
           })
           .catch((err) => {

--- a/src/pages/SidePanel.tsx
+++ b/src/pages/SidePanel.tsx
@@ -55,6 +55,11 @@ function SidePanelPage() {
         }
       } else {
         addLog(`Sent prompt: ${prompt.substring(0, 30)}...`)
+        if (activeDetailCard) {
+          db.styleCards.update(activeDetailCard.id, {
+            usageCount: (activeDetailCard.usageCount || 0) + 1
+          }).catch(err => console.error("Failed to update usage count on details inject:", err));
+        }
       }
     } catch (err: any) {
       console.error("Injection failed:", err);


### PR DESCRIPTION
Closes #79. Modifies the library card interaction behavior so that clicking a card adds it to the hand, clicking the edit button opens the detail view, and the usage count is rendered in the bottom-left corner. Added unit tests for CardThumbnail and LibraryTab.