### PR TITLE
feat: Midjourney以外のサイトで開いた際に案内画面と誘導ボタンを表示する (#83)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,15 @@
     "vitest": "^4.0.16"
   },
   "manifest": {
-    "host_permissions": [
-      "https://*/*"
-    ],
     "permissions": [
-      "scripting"
+      "activeTab"
+    ],
+    "host_permissions": [
+      "https://midjourney.com/*",
+      "https://*.midjourney.com/*",
+      "https://*.discord.com/*",
+      "https://*.discordapp.com/*",
+      "https://*.discordapp.net/*"
     ]
   }
 }

--- a/src/components/organisms/NonTargetSiteView.test.tsx
+++ b/src/components/organisms/NonTargetSiteView.test.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { NonTargetSiteView } from "./NonTargetSiteView"
+
+describe("NonTargetSiteView", () => {
+  it("should render welcome text and buttons", () => {
+    const mockOpenMidjourney = vi.fn()
+    const mockOpenDiscord = vi.fn()
+
+    render(
+      <NonTargetSiteView
+        onOpenMidjourney={mockOpenMidjourney}
+        onOpenDiscord={mockOpenDiscord}
+      />
+    )
+
+    expect(screen.getByText("Style Atelier")).toBeInTheDocument()
+    expect(screen.getByText("Waiting for Connection")).toBeInTheDocument()
+    expect(
+      screen.getByText(/本拡張機能は Midjourney または Discord のページでのみご利用いただけます。/)
+    ).toBeInTheDocument()
+
+    const mjButton = screen.getByRole("button", { name: /Midjourneyを開く/ })
+    const dcButton = screen.getByRole("button", { name: /Discordを開く/ })
+
+    expect(mjButton).toBeInTheDocument()
+    expect(dcButton).toBeInTheDocument()
+
+    fireEvent.click(mjButton)
+    expect(mockOpenMidjourney).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(dcButton)
+    expect(mockOpenDiscord).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/organisms/NonTargetSiteView.tsx
+++ b/src/components/organisms/NonTargetSiteView.tsx
@@ -1,0 +1,67 @@
+import React from "react"
+import { Compass, ExternalLink } from "lucide-react"
+
+interface NonTargetSiteViewProps {
+  onOpenMidjourney: () => void
+  onOpenDiscord: () => void
+}
+
+export function NonTargetSiteView({ onOpenMidjourney, onOpenDiscord }: NonTargetSiteViewProps) {
+  return (
+    <div className="w-full h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-900 via-slate-950 to-indigo-950 p-6 text-slate-200 font-sans select-none overflow-hidden">
+      <div className="relative w-full max-w-sm flex flex-col items-center text-center space-y-6">
+        
+        {/* Glow effect in background */}
+        <div className="absolute -top-12 w-48 h-48 bg-blue-500/10 rounded-full blur-3xl" />
+        <div className="absolute -bottom-12 w-48 h-48 bg-indigo-500/10 rounded-full blur-3xl" />
+
+        {/* Animated icon container */}
+        <div className="relative z-10 w-20 h-20 rounded-3xl bg-gradient-to-tr from-blue-600 to-indigo-600 flex items-center justify-center shadow-xl shadow-blue-900/30 animate-pulse duration-[3000ms]">
+          <Compass className="w-10 h-10 text-white" style={{ animation: "spin 8s linear infinite" }} />
+          
+          {/* Decorative mini card floating around */}
+          <div className="absolute -top-1 -right-1 w-5 h-5 bg-yellow-500 rounded-lg shadow transform rotate-12 flex items-center justify-center text-[10px]">
+            🎴
+          </div>
+        </div>
+
+        {/* Text descriptions */}
+        <div className="space-y-2 z-10">
+          <h2 className="text-xl font-black tracking-tight text-white bg-gradient-to-r from-blue-200 via-indigo-100 to-white bg-clip-text text-transparent">
+            Style Atelier
+          </h2>
+          <div className="inline-block px-2.5 py-0.5 rounded-full text-[10px] font-bold tracking-wider uppercase bg-indigo-500/10 border border-indigo-500/20 text-indigo-300">
+            Waiting for Connection
+          </div>
+          <p className="text-sm text-slate-400 max-w-[260px] mx-auto leading-relaxed pt-2">
+            本拡張機能は Midjourney または Discord のページでのみご利用いただけます。
+          </p>
+        </div>
+
+        {/* CTA Buttons */}
+        <div className="w-full flex flex-col gap-3 pt-4 z-10">
+          <button
+            onClick={onOpenMidjourney}
+            className="group w-full py-3 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white text-sm font-bold rounded-xl shadow-lg shadow-indigo-900/40 hover:shadow-indigo-800/60 active:scale-98 transition-all duration-200 flex items-center justify-center gap-2"
+          >
+            Midjourneyを開く
+            <ExternalLink className="w-4 h-4 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform" />
+          </button>
+          
+          <button
+            onClick={onOpenDiscord}
+            className="w-full py-2.5 bg-slate-800/50 hover:bg-slate-800 border border-slate-700/80 text-slate-300 hover:text-white text-xs font-semibold rounded-xl transition-all duration-200 flex items-center justify-center gap-2"
+          >
+            Discordを開く
+            <ExternalLink className="w-3.5 h-3.5 opacity-60" />
+          </button>
+        </div>
+
+        {/* Bottom branding footer */}
+        <div className="text-[10px] text-slate-600 pt-8 z-10">
+          Style Atelier &copy; {new Date().getFullYear()}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useActiveTabUrl.test.ts
+++ b/src/hooks/useActiveTabUrl.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useActiveTabUrl } from "./useActiveTabUrl"
+
+describe("useActiveTabUrl hook", () => {
+  let mockActivatedListener: any = null
+  let mockUpdatedListener: any = null
+  let mockFocusListener: any = null
+
+  beforeEach(() => {
+    vi.stubGlobal("chrome", {
+      tabs: {
+        query: vi.fn(),
+        onActivated: {
+          addListener: vi.fn((fn) => {
+            mockActivatedListener = fn
+          }),
+          removeListener: vi.fn()
+        },
+        onUpdated: {
+          addListener: vi.fn((fn) => {
+            mockUpdatedListener = fn
+          }),
+          removeListener: vi.fn()
+        }
+      },
+      windows: {
+        onFocusChanged: {
+          addListener: vi.fn((fn) => {
+            mockFocusListener = fn
+          }),
+          removeListener: vi.fn()
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    mockActivatedListener = null
+    mockUpdatedListener = null
+    mockFocusListener = null
+  })
+
+  it("should return isTargetSite = true when active tab is a Midjourney domain", async () => {
+    vi.mocked(chrome.tabs.query).mockResolvedValue([
+      { url: "https://www.midjourney.com/imagine" }
+    ] as any)
+
+    const { result } = renderHook(() => useActiveTabUrl())
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isTargetSite).toBe(true)
+  })
+
+  it("should return isTargetSite = false when active tab is not a target domain", async () => {
+    vi.mocked(chrome.tabs.query).mockResolvedValue([
+      { url: "https://www.google.com" }
+    ] as any)
+
+    const { result } = renderHook(() => useActiveTabUrl())
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(result.current.isTargetSite).toBe(false)
+  })
+
+  it("should update isTargetSite when tab is activated", async () => {
+    vi.mocked(chrome.tabs.query).mockResolvedValue([
+      { url: "https://www.midjourney.com" }
+    ] as any)
+
+    const { result } = renderHook(() => useActiveTabUrl())
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(result.current.isTargetSite).toBe(true)
+
+    vi.mocked(chrome.tabs.query).mockResolvedValue([
+      { url: "https://google.com" }
+    ] as any)
+
+    await act(async () => {
+      mockActivatedListener()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(result.current.isTargetSite).toBe(false)
+  })
+
+  it("should update isTargetSite when tab URL updates", async () => {
+    vi.mocked(chrome.tabs.query).mockResolvedValue([
+      { url: "https://google.com" }
+    ] as any)
+
+    const { result } = renderHook(() => useActiveTabUrl())
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(result.current.isTargetSite).toBe(false)
+
+    vi.mocked(chrome.tabs.query).mockResolvedValue([
+      { url: "https://discord.com/channels/123" }
+    ] as any)
+
+    await act(async () => {
+      mockUpdatedListener(1, { url: "https://discord.com/channels/123" }, {})
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(result.current.isTargetSite).toBe(true)
+  })
+})

--- a/src/hooks/useActiveTabUrl.ts
+++ b/src/hooks/useActiveTabUrl.ts
@@ -72,9 +72,11 @@ export function useActiveTabUrl() {
     chrome.windows?.onFocusChanged?.addListener(handleWindowFocus)
 
     return () => {
-      chrome.tabs.onActivated?.removeListener(handleActivated)
-      chrome.tabs.onUpdated?.removeListener(handleUpdated)
-      chrome.windows?.onFocusChanged?.removeListener(handleWindowFocus)
+      if (typeof chrome !== "undefined") {
+        chrome.tabs?.onActivated?.removeListener(handleActivated)
+        chrome.tabs?.onUpdated?.removeListener(handleUpdated)
+        chrome.windows?.onFocusChanged?.removeListener(handleWindowFocus)
+      }
     }
   }, [])
 

--- a/src/hooks/useActiveTabUrl.ts
+++ b/src/hooks/useActiveTabUrl.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react"
+
+const TARGET_DOMAINS = [
+  "midjourney.com",
+  "discord.com",
+  "discordapp.com",
+  "discordapp.net"
+]
+
+export function useActiveTabUrl() {
+  const [isTargetSite, setIsTargetSite] = useState<boolean>(true)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+
+  const checkActiveTab = async () => {
+    if (typeof chrome === "undefined" || !chrome.tabs || !chrome.tabs.query) {
+      setIsTargetSite(true)
+      setIsLoading(false)
+      return
+    }
+
+    try {
+      const tabs = await chrome.tabs.query({ active: true, currentWindow: true })
+      const activeTab = tabs[0]
+      if (!activeTab) {
+        setIsTargetSite(false)
+        return
+      }
+
+      const url = activeTab.url || activeTab.pendingUrl
+      if (!url) {
+        setIsTargetSite(false)
+        return
+      }
+
+      const hasMatch = TARGET_DOMAINS.some((domain) => url.includes(domain))
+      setIsTargetSite(hasMatch)
+    } catch (error) {
+      console.error("Error checking active tab URL:", error)
+      setIsTargetSite(false)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    checkActiveTab()
+
+    if (typeof chrome === "undefined" || !chrome.tabs) {
+      return
+    }
+
+    const handleActivated = () => {
+      checkActiveTab()
+    }
+
+    const handleUpdated = (
+      tabId: number,
+      changeInfo: chrome.tabs.TabChangeInfo,
+      tab: chrome.tabs.Tab
+    ) => {
+      if (changeInfo.status === "complete" || changeInfo.url) {
+        checkActiveTab()
+      }
+    }
+
+    const handleWindowFocus = () => {
+      checkActiveTab()
+    }
+
+    chrome.tabs.onActivated?.addListener(handleActivated)
+    chrome.tabs.onUpdated?.addListener(handleUpdated)
+    chrome.windows?.onFocusChanged?.addListener(handleWindowFocus)
+
+    return () => {
+      chrome.tabs.onActivated?.removeListener(handleActivated)
+      chrome.tabs.onUpdated?.removeListener(handleUpdated)
+      chrome.windows?.onFocusChanged?.removeListener(handleWindowFocus)
+    }
+  }, [])
+
+  return { isTargetSite, isLoading }
+}

--- a/src/pages/SidePanel.tsx
+++ b/src/pages/SidePanel.tsx
@@ -11,6 +11,8 @@ import { InteractiveTutorial } from "../components/organisms/InteractiveTutorial
 import { useTabs } from "../hooks/useTabs"
 import { useDragAndDrop } from "../hooks/useDragAndDrop"
 import { useMinting } from "../hooks/useMinting"
+import { useActiveTabUrl } from "../hooks/useActiveTabUrl"
+import { NonTargetSiteView } from "../components/organisms/NonTargetSiteView"
 import { WorkbenchProvider } from "../contexts/WorkbenchContext"
 import { TutorialProvider, useTutorial } from "../contexts/TutorialContext"
 import type { AlertType } from "../components/molecules/ConnectionAlert"
@@ -52,6 +54,7 @@ function WelcomeDialog({ onStart, onSkip }: { onStart: () => void; onSkip: () =>
 }
 
 function SidePanelInner() {
+  const { isTargetSite, isLoading } = useActiveTabUrl()
   const { startTutorial, advanceIfStep } = useTutorial()
   const [logs, setLogs] = useState<string[]>([])
   // New global state for connection alerts
@@ -189,6 +192,43 @@ function SidePanelInner() {
 
   const handleDismissAlert = () => {
     setAlertType(null);
+  }
+
+  const handleOpenMidjourney = () => {
+    if (typeof chrome !== "undefined" && chrome.tabs && chrome.tabs.update) {
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        if (tabs[0]?.id) {
+          chrome.tabs.update(tabs[0].id, { url: "https://www.midjourney.com/imagine" })
+        }
+      })
+    } else {
+      window.open("https://www.midjourney.com/imagine", "_blank")
+    }
+  }
+
+  const handleOpenDiscord = () => {
+    if (typeof chrome !== "undefined" && chrome.tabs && chrome.tabs.update) {
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        if (tabs[0]?.id) {
+          chrome.tabs.update(tabs[0].id, { url: "https://discord.com" })
+        }
+      })
+    } else {
+      window.open("https://discord.com", "_blank")
+    }
+  }
+
+  if (isLoading) {
+    return <div className="w-full h-screen bg-slate-950" />
+  }
+
+  if (!isTargetSite) {
+    return (
+      <NonTargetSiteView
+        onOpenMidjourney={handleOpenMidjourney}
+        onOpenDiscord={handleOpenDiscord}
+      />
+    )
   }
 
   return (


### PR DESCRIPTION
## 概要
Midjourney以外のサイトでサイドパネルを開いた際に、ユーザーが迷わずにツールを利用できるようにするための案内画面（Placeholder）と、「Midjourneyを開く」ための誘導ボタンを表示するようにしました。

## 変更内容
1. `package.json` に `"activeTab"` 権限を追加しました（ストア審査時の影響がほぼない安全な権限です）。
2. アクティブなタブのURLが Midjourney または Discord 関連の対象ドメインであるかを判定・監視する `useActiveTabUrl` フックを追加しました。
3. 対象外のサイトを開いているときに表示する、デザイン性の高い `NonTargetSiteView` コンポーネントを新規追加しました。
4. `SidePanel` コンポーネントにて、対象外サイトがアクティブな場合は案内画面を表示するよう修正しました。
5. 変更内容に対するユニットテストの追加とビルド検証を行いました。

Closes #83
