### PR TITLE
feat(qr): #99 implement card import via QR image drag and drop

### DIFF
--- a/src/components/organisms/LibraryTab.test.tsx
+++ b/src/components/organisms/LibraryTab.test.tsx
@@ -9,6 +9,44 @@ vi.mock("../../hooks/useLibrary", () => ({
   useLibrary: vi.fn(),
 }))
 
+vi.mock("../../lib/db", () => ({
+  db: {
+    styleCards: {
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue("card-123"),
+      toArray: vi.fn().mockResolvedValue([]),
+    },
+    categories: {
+      toArray: vi.fn().mockResolvedValue([]),
+    },
+  },
+}))
+
+vi.mock("../../lib/qr-utils", () => ({
+  readQRCodeFromImage: vi.fn().mockResolvedValue("mock-payload"),
+  decompressCardData: vi.fn().mockReturnValue({
+    id: "card-123",
+    name: "Imported Card",
+    promptSegments: [{ type: "text", value: "imported cat" }],
+    parameters: {},
+    images: ["https://example.com/cdn.png"],
+  }),
+}))
+
+global.fetch = vi.fn().mockResolvedValue({
+  ok: true,
+  blob: vi.fn().mockResolvedValue(new Blob(["bytes"], { type: "image/png" })),
+})
+
+class MockFileReader {
+  onloadend: () => void = () => {}
+  result: string = "data:image/png;base64,mockbase64"
+  readAsDataURL() {
+    setTimeout(() => this.onloadend(), 0)
+  }
+}
+global.FileReader = MockFileReader as any
+
 const mockCards: StyleCard[] = [
   {
     id: "card-1",
@@ -85,5 +123,46 @@ describe("LibraryTab", () => {
     fireEvent.click(editBtn)
     expect(mockOpenDetailCard).toHaveBeenCalledWith(mockCards[0])
     expect(mockTogglePin).not.toHaveBeenCalled()
+  })
+
+  it("handles dropping a card image and imports it", async () => {
+    const { act } = await import("@testing-library/react")
+    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
+    
+    const container = screen.getByTestId("library-tab-container")
+    
+    // Simulate DragOver with files
+    const dragOverEvent = {
+      preventDefault: vi.fn(),
+      dataTransfer: {
+        types: ["Files"],
+      },
+    }
+    fireEvent.dragOver(container, dragOverEvent)
+    expect(screen.getByText("Drop QR Card Image to Import")).toBeDefined()
+
+    // Simulate Drop of an image file
+    const mockFile = new File(["test"], "card.png", { type: "image/png" })
+    const dropEvent = {
+      preventDefault: vi.fn(),
+      dataTransfer: {
+        files: [mockFile],
+      },
+    }
+    
+    await act(async () => {
+      fireEvent.drop(container, dropEvent)
+      await new Promise(resolve => setTimeout(resolve, 50))
+    })
+
+    const { db } = await import("../../lib/db")
+    expect(db.styleCards.put).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "card-123",
+        name: "Imported Card",
+        thumbnailData: "data:image/png;base64,mockbase64",
+      })
+    )
+    expect(mockAddLog).toHaveBeenCalledWith('Imported card "Imported Card" successfully!')
   })
 })

--- a/src/components/organisms/LibraryTab.test.tsx
+++ b/src/components/organisms/LibraryTab.test.tsx
@@ -9,44 +9,6 @@ vi.mock("../../hooks/useLibrary", () => ({
   useLibrary: vi.fn(),
 }))
 
-vi.mock("../../lib/db", () => ({
-  db: {
-    styleCards: {
-      get: vi.fn().mockResolvedValue(null),
-      put: vi.fn().mockResolvedValue("card-123"),
-      toArray: vi.fn().mockResolvedValue([]),
-    },
-    categories: {
-      toArray: vi.fn().mockResolvedValue([]),
-    },
-  },
-}))
-
-vi.mock("../../lib/qr-utils", () => ({
-  readQRCodeFromImage: vi.fn().mockResolvedValue("mock-payload"),
-  decompressCardData: vi.fn().mockReturnValue({
-    id: "card-123",
-    name: "Imported Card",
-    promptSegments: [{ type: "text", value: "imported cat" }],
-    parameters: {},
-    images: ["https://example.com/cdn.png"],
-  }),
-}))
-
-global.fetch = vi.fn().mockResolvedValue({
-  ok: true,
-  blob: vi.fn().mockResolvedValue(new Blob(["bytes"], { type: "image/png" })),
-})
-
-class MockFileReader {
-  onloadend: () => void = () => {}
-  result: string = "data:image/png;base64,mockbase64"
-  readAsDataURL() {
-    setTimeout(() => this.onloadend(), 0)
-  }
-}
-global.FileReader = MockFileReader as any
-
 const mockCards: StyleCard[] = [
   {
     id: "card-1",
@@ -123,46 +85,5 @@ describe("LibraryTab", () => {
     fireEvent.click(editBtn)
     expect(mockOpenDetailCard).toHaveBeenCalledWith(mockCards[0])
     expect(mockTogglePin).not.toHaveBeenCalled()
-  })
-
-  it("handles dropping a card image and imports it", async () => {
-    const { act } = await import("@testing-library/react")
-    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
-    
-    const container = screen.getByTestId("library-tab-container")
-    
-    // Simulate DragOver with files
-    const dragOverEvent = {
-      preventDefault: vi.fn(),
-      dataTransfer: {
-        types: ["Files"],
-      },
-    }
-    fireEvent.dragOver(container, dragOverEvent)
-    expect(screen.getByText("Drop QR Card Image to Import")).toBeDefined()
-
-    // Simulate Drop of an image file
-    const mockFile = new File(["test"], "card.png", { type: "image/png" })
-    const dropEvent = {
-      preventDefault: vi.fn(),
-      dataTransfer: {
-        files: [mockFile],
-      },
-    }
-    
-    await act(async () => {
-      fireEvent.drop(container, dropEvent)
-      await new Promise(resolve => setTimeout(resolve, 50))
-    })
-
-    const { db } = await import("../../lib/db")
-    expect(db.styleCards.put).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: "card-123",
-        name: "Imported Card",
-        thumbnailData: "data:image/png;base64,mockbase64",
-      })
-    )
-    expect(mockAddLog).toHaveBeenCalledWith('Imported card "Imported Card" successfully!')
   })
 })

--- a/src/components/organisms/LibraryTab.tsx
+++ b/src/components/organisms/LibraryTab.tsx
@@ -8,6 +8,7 @@ import { Plus } from "lucide-react"
 import { CategoryManagerModal } from "./CategoryManagerModal"
 import { ConnectionAlert, type AlertType } from "../molecules/ConnectionAlert"
 import { useTutorial } from "../../contexts/TutorialContext"
+import { db } from "../../lib/db"
 
 interface LibraryTabProps {
   addLog: (msg: string) => void
@@ -18,6 +19,112 @@ interface LibraryTabProps {
 export function LibraryTab({ addLog, setAlertType, onOpenDetailCard }: LibraryTabProps) {
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false)
   const { advanceIfStep } = useTutorial()
+  const [isFileDragging, setIsFileDragging] = useState(false)
+  const [isImporting, setIsImporting] = useState(false)
+
+  const handleFileDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    if (e.dataTransfer.types.includes("Files")) {
+      setIsFileDragging(true)
+    }
+  }
+
+  const handleFileDragLeave = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsFileDragging(false)
+  }
+
+  const handleFileDrop = async (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsFileDragging(false)
+
+    const files = Array.from(e.dataTransfer.files)
+    const imageFile = files.find((f) => f.type.startsWith("image/"))
+    if (!imageFile) {
+      addLog("No valid image file dropped.")
+      return
+    }
+
+    setIsImporting(true)
+    addLog("Processing dropped card image...")
+
+    try {
+      const { readQRCodeFromImage, decompressCardData } = await import("../../lib/qr-utils")
+      const payload = await readQRCodeFromImage(imageFile)
+      
+      if (!payload) {
+        addLog("No QR code found in the image.")
+        setIsImporting(false)
+        return
+      }
+
+      const partialCard = decompressCardData(payload)
+      if (!partialCard.name || !partialCard.promptSegments) {
+        addLog("Invalid card data in QR code.")
+        setIsImporting(false)
+        return
+      }
+
+      const cdnUrl = partialCard.images?.[0]
+      let finalThumbnailData = "assets/icon.png"
+      
+      if (cdnUrl) {
+        addLog("Fetching clean artwork from Midjourney...")
+        try {
+          const response = await fetch(cdnUrl)
+          if (response.ok) {
+            const blob = await response.blob()
+            finalThumbnailData = await new Promise<string>((resolve, reject) => {
+              const reader = new FileReader()
+              reader.onloadend = () => resolve(reader.result as string)
+              reader.onerror = reject
+              reader.readAsDataURL(blob)
+            })
+            addLog("Artwork downloaded successfully.")
+          } else {
+            addLog("Could not fetch artwork from Midjourney CDN. Using placeholder.")
+          }
+        } catch (fetchErr) {
+          console.error("CORS or network error fetching artwork:", fetchErr)
+          addLog("Failed to download artwork. Using placeholder.")
+        }
+      } else {
+        addLog("No artwork URL found in card. Using placeholder.")
+      }
+
+      const existingCard = partialCard.id ? await db.styleCards.get(partialCard.id) : null
+      
+      const importedCard: StyleCard = {
+        id: partialCard.id || crypto.randomUUID(),
+        name: partialCard.name,
+        createdAt: existingCard?.createdAt || Date.now(),
+        updatedAt: Date.now(),
+        promptSegments: partialCard.promptSegments,
+        parameters: partialCard.parameters || {},
+        masking: partialCard.masking || { isSrefHidden: false, isPHidden: false },
+        tier: partialCard.tier || "Common",
+        isFavorite: existingCard?.isFavorite || false,
+        usageCount: existingCard?.usageCount || 0,
+        tags: partialCard.tags || [],
+        category: partialCard.category,
+        dominantColor: partialCard.dominantColor || "#1e293b",
+        accentColor: partialCard.accentColor || "#3b82f6",
+        thumbnailData: finalThumbnailData,
+        frameId: partialCard.frameId || "default",
+        genealogy: partialCard.genealogy || { generation: 1, parentIds: [] },
+        images: cdnUrl ? [cdnUrl] : [],
+        selectedThumbnails: cdnUrl ? [cdnUrl] : [],
+      }
+
+      await db.styleCards.put(importedCard)
+      addLog(`Imported card "${importedCard.name}" successfully!`)
+    } catch (err) {
+      console.error("Failed to import card:", err)
+      addLog("Error occurred while importing card.")
+    } finally {
+      setIsImporting(false)
+    }
+  }
 
   const {
     styleCards,
@@ -36,7 +143,40 @@ export function LibraryTab({ addLog, setAlertType, onOpenDetailCard }: LibraryTa
   } = useLibrary(addLog, setAlertType)
 
   return (
-    <div className="flex flex-col gap-4">
+    <div 
+      className="flex flex-col gap-4 relative"
+      onDragOver={handleFileDragOver}
+      onDragLeave={handleFileDragLeave}
+      onDrop={handleFileDrop}
+      data-testid="library-tab-container"
+    >
+      {isFileDragging && (
+        <div className="absolute inset-0 bg-blue-500/10 border-2 border-dashed border-blue-500 rounded-lg flex flex-col items-center justify-center z-50 backdrop-blur-[2px] pointer-events-none animate-pulse">
+          <div className="bg-white p-4 rounded-full shadow-lg flex items-center justify-center border border-blue-100">
+            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-blue-500">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+              <polyline points="17 8 12 3 7 8"></polyline>
+              <line x1="12" y1="3" x2="12" y2="15"></line>
+            </svg>
+          </div>
+          <span className="text-xs font-bold text-blue-600 mt-2 bg-white px-2 py-0.5 rounded shadow-sm">
+            Drop QR Card Image to Import
+          </span>
+        </div>
+      )}
+      
+      {isImporting && (
+        <div className="absolute inset-0 bg-slate-900/40 rounded-lg flex flex-col items-center justify-center z-50 backdrop-blur-[1px] pointer-events-none">
+          <div className="bg-white p-4 rounded-lg shadow-xl flex items-center gap-3 border border-slate-100">
+            <svg className="animate-spin h-5 w-5 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            <span className="text-xs font-bold text-slate-700">Importing Card...</span>
+          </div>
+        </div>
+      )}
+
       {/* Search and Filters */}
       <div className="flex flex-col gap-2 bg-slate-50 p-2 rounded-lg border border-slate-200">
         <SearchField

--- a/src/components/organisms/LibraryTab.tsx
+++ b/src/components/organisms/LibraryTab.tsx
@@ -8,7 +8,6 @@ import { Plus } from "lucide-react"
 import { CategoryManagerModal } from "./CategoryManagerModal"
 import { ConnectionAlert, type AlertType } from "../molecules/ConnectionAlert"
 import { useTutorial } from "../../contexts/TutorialContext"
-import { db } from "../../lib/db"
 
 interface LibraryTabProps {
   addLog: (msg: string) => void
@@ -19,112 +18,6 @@ interface LibraryTabProps {
 export function LibraryTab({ addLog, setAlertType, onOpenDetailCard }: LibraryTabProps) {
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false)
   const { advanceIfStep } = useTutorial()
-  const [isFileDragging, setIsFileDragging] = useState(false)
-  const [isImporting, setIsImporting] = useState(false)
-
-  const handleFileDragOver = (e: React.DragEvent) => {
-    e.preventDefault()
-    if (e.dataTransfer.types.includes("Files")) {
-      setIsFileDragging(true)
-    }
-  }
-
-  const handleFileDragLeave = (e: React.DragEvent) => {
-    e.preventDefault()
-    setIsFileDragging(false)
-  }
-
-  const handleFileDrop = async (e: React.DragEvent) => {
-    e.preventDefault()
-    setIsFileDragging(false)
-
-    const files = Array.from(e.dataTransfer.files)
-    const imageFile = files.find((f) => f.type.startsWith("image/"))
-    if (!imageFile) {
-      addLog("No valid image file dropped.")
-      return
-    }
-
-    setIsImporting(true)
-    addLog("Processing dropped card image...")
-
-    try {
-      const { readQRCodeFromImage, decompressCardData } = await import("../../lib/qr-utils")
-      const payload = await readQRCodeFromImage(imageFile)
-      
-      if (!payload) {
-        addLog("No QR code found in the image.")
-        setIsImporting(false)
-        return
-      }
-
-      const partialCard = decompressCardData(payload)
-      if (!partialCard.name || !partialCard.promptSegments) {
-        addLog("Invalid card data in QR code.")
-        setIsImporting(false)
-        return
-      }
-
-      const cdnUrl = partialCard.images?.[0]
-      let finalThumbnailData = "assets/icon.png"
-      
-      if (cdnUrl) {
-        addLog("Fetching clean artwork from Midjourney...")
-        try {
-          const response = await fetch(cdnUrl)
-          if (response.ok) {
-            const blob = await response.blob()
-            finalThumbnailData = await new Promise<string>((resolve, reject) => {
-              const reader = new FileReader()
-              reader.onloadend = () => resolve(reader.result as string)
-              reader.onerror = reject
-              reader.readAsDataURL(blob)
-            })
-            addLog("Artwork downloaded successfully.")
-          } else {
-            addLog("Could not fetch artwork from Midjourney CDN. Using placeholder.")
-          }
-        } catch (fetchErr) {
-          console.error("CORS or network error fetching artwork:", fetchErr)
-          addLog("Failed to download artwork. Using placeholder.")
-        }
-      } else {
-        addLog("No artwork URL found in card. Using placeholder.")
-      }
-
-      const existingCard = partialCard.id ? await db.styleCards.get(partialCard.id) : null
-      
-      const importedCard: StyleCard = {
-        id: partialCard.id || crypto.randomUUID(),
-        name: partialCard.name,
-        createdAt: existingCard?.createdAt || Date.now(),
-        updatedAt: Date.now(),
-        promptSegments: partialCard.promptSegments,
-        parameters: partialCard.parameters || {},
-        masking: partialCard.masking || { isSrefHidden: false, isPHidden: false },
-        tier: partialCard.tier || "Common",
-        isFavorite: existingCard?.isFavorite || false,
-        usageCount: existingCard?.usageCount || 0,
-        tags: partialCard.tags || [],
-        category: partialCard.category,
-        dominantColor: partialCard.dominantColor || "#1e293b",
-        accentColor: partialCard.accentColor || "#3b82f6",
-        thumbnailData: finalThumbnailData,
-        frameId: partialCard.frameId || "default",
-        genealogy: partialCard.genealogy || { generation: 1, parentIds: [] },
-        images: cdnUrl ? [cdnUrl] : [],
-        selectedThumbnails: cdnUrl ? [cdnUrl] : [],
-      }
-
-      await db.styleCards.put(importedCard)
-      addLog(`Imported card "${importedCard.name}" successfully!`)
-    } catch (err) {
-      console.error("Failed to import card:", err)
-      addLog("Error occurred while importing card.")
-    } finally {
-      setIsImporting(false)
-    }
-  }
 
   const {
     styleCards,
@@ -143,41 +36,7 @@ export function LibraryTab({ addLog, setAlertType, onOpenDetailCard }: LibraryTa
   } = useLibrary(addLog, setAlertType)
 
   return (
-    <div 
-      className="flex flex-col gap-4 relative"
-      onDragOver={handleFileDragOver}
-      onDragLeave={handleFileDragLeave}
-      onDrop={handleFileDrop}
-      data-testid="library-tab-container"
-    >
-      {isFileDragging && (
-        <div className="absolute inset-0 bg-blue-500/10 border-2 border-dashed border-blue-500 rounded-lg flex flex-col items-center justify-center z-50 backdrop-blur-[2px] pointer-events-none animate-pulse">
-          <div className="bg-white p-4 rounded-full shadow-lg flex items-center justify-center border border-blue-100">
-            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-blue-500">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-              <polyline points="17 8 12 3 7 8"></polyline>
-              <line x1="12" y1="3" x2="12" y2="15"></line>
-            </svg>
-          </div>
-          <span className="text-xs font-bold text-blue-600 mt-2 bg-white px-2 py-0.5 rounded shadow-sm">
-            Drop QR Card Image to Import
-          </span>
-        </div>
-      )}
-      
-      {isImporting && (
-        <div className="absolute inset-0 bg-slate-900/40 rounded-lg flex flex-col items-center justify-center z-50 backdrop-blur-[1px] pointer-events-none">
-          <div className="bg-white p-4 rounded-lg shadow-xl flex items-center gap-3 border border-slate-100">
-            <svg className="animate-spin h-5 w-5 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-            </svg>
-            <span className="text-xs font-bold text-slate-700">Importing Card...</span>
-          </div>
-        </div>
-      )}
-
-      {/* Search and Filters */}
+    <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2 bg-slate-50 p-2 rounded-lg border border-slate-200">
         <SearchField
           placeholder="Search by tag, name or sref..."

--- a/src/components/templates/SidePanelLayout.tsx
+++ b/src/components/templates/SidePanelLayout.tsx
@@ -17,6 +17,8 @@ interface SidePanelLayoutProps {
   onRetryConnection?: () => void
   onDismissAlert?: () => void
   onOpenGuide: () => void
+  isDraggingFile?: boolean
+  isImporting?: boolean
 }
 
 export function SidePanelLayout({
@@ -31,7 +33,9 @@ export function SidePanelLayout({
   alertType,
   onRetryConnection,
   onDismissAlert,
-  onOpenGuide
+  onOpenGuide,
+  isDraggingFile,
+  isImporting
 }: SidePanelLayoutProps) {
   return (
     <div
@@ -84,7 +88,34 @@ export function SidePanelLayout({
           </div>
         </div>
       </div>
-      <div className="flex-1 overflow-y-auto p-4 space-y-4 pb-24">
+      <div className="flex-1 overflow-y-auto p-4 space-y-4 pb-24 relative">
+        {isDraggingFile && (
+          <div className="absolute inset-0 bg-blue-500/10 border-2 border-dashed border-blue-500 rounded-lg flex flex-col items-center justify-center z-50 backdrop-blur-[2px] pointer-events-none animate-pulse">
+            <div className="bg-white p-4 rounded-full shadow-lg flex items-center justify-center border border-blue-100">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-blue-500">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <polyline points="17 8 12 3 7 8"></polyline>
+                <line x1="12" y1="3" x2="12" y2="15"></line>
+              </svg>
+            </div>
+            <span className="text-xs font-bold text-blue-600 mt-2 bg-white px-2 py-0.5 rounded shadow-sm">
+              Drop QR Card Image to Import
+            </span>
+          </div>
+        )}
+        
+        {isImporting && (
+          <div className="absolute inset-0 bg-slate-900/40 rounded-lg flex flex-col items-center justify-center z-50 backdrop-blur-[1px] pointer-events-none">
+            <div className="bg-white p-4 rounded-lg shadow-xl flex items-center gap-3 border border-slate-100">
+              <svg className="animate-spin h-5 w-5 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              <span className="text-xs font-bold text-slate-700">Importing Card...</span>
+            </div>
+          </div>
+        )}
+
         {droppedItem && (
           <div className="p-3 border rounded bg-white shadow-lg ring-2 ring-blue-500 animate-in fade-in slide-in-from-top-4">
             <p className="text-xs font-bold uppercase text-slate-800">

--- a/src/hooks/useDragAndDrop.test.ts
+++ b/src/hooks/useDragAndDrop.test.ts
@@ -254,5 +254,46 @@ describe("useDragAndDrop", () => {
       expect(mockAddLog).toHaveBeenCalledWith('Imported card "Imported Card" successfully!')
       expect(returnVal).toEqual({ id: "imported-card-id", isImport: true })
     })
+
+    it("should prioritize JSON data over file import when both are present", async () => {
+      const { result } = renderHook(() => useDragAndDrop(mockAddLog))
+
+      const mockExistingCard = {
+        id: "card-uuid-123",
+        name: "Cool Card",
+        jobId: "test-job-id",
+        images: ["https://example.com/first.png"],
+        thumbnailData: "https://example.com/first.png",
+      }
+
+      const styleCardsWhere = db.styleCards.where("jobId")
+      vi.mocked((styleCardsWhere as any).first).mockResolvedValue(mockExistingCard)
+      vi.mocked(db.styleCards.update).mockResolvedValue(1)
+
+      const mockItem = {
+        id: "test-job-id",
+        fullCommand: "test prompt",
+        imageUrl: "https://example.com/second.png",
+        timestamp: 1234567,
+      }
+
+      const dummyFile = new File(["test"], "card.png", { type: "image/png" })
+      const dummyEvent = {
+        preventDefault: vi.fn(),
+        dataTransfer: {
+          types: ["Files", "application/json"],
+          files: [dummyFile],
+          getData: vi.fn().mockReturnValue(JSON.stringify(mockItem)),
+        },
+      } as any
+
+      let returnVal: any
+      await act(async () => {
+        returnVal = await result.current.handleDrop(dummyEvent)
+      })
+
+      expect(db.styleCards.update).toHaveBeenCalled()
+      expect(returnVal).toEqual(mockItem)
+    })
   })
 })

--- a/src/hooks/useDragAndDrop.test.ts
+++ b/src/hooks/useDragAndDrop.test.ts
@@ -16,10 +16,37 @@ vi.mock("../lib/db", () => {
       styleCards: {
         where: vi.fn(() => mockWhere),
         update: vi.fn(),
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue("imported-card-id"),
       },
     },
   }
 })
+
+vi.mock("../lib/qr-utils", () => ({
+  readQRCodeFromImage: vi.fn().mockResolvedValue("mock-payload"),
+  decompressCardData: vi.fn().mockReturnValue({
+    id: "imported-card-id",
+    name: "Imported Card",
+    promptSegments: [{ type: "text", value: "imported cat" }],
+    parameters: {},
+    images: ["https://example.com/cdn.png"],
+  }),
+}))
+
+global.fetch = vi.fn().mockResolvedValue({
+  ok: true,
+  blob: vi.fn().mockResolvedValue(new Blob(["bytes"], { type: "image/png" })),
+})
+
+class MockFileReader {
+  onloadend: () => void = () => {}
+  result: string = "data:image/png;base64,mockbase64"
+  readAsDataURL() {
+    setTimeout(() => this.onloadend(), 0)
+  }
+}
+global.FileReader = MockFileReader as any
 
 describe("useDragAndDrop", () => {
   const mockAddLog = vi.fn()
@@ -179,5 +206,53 @@ describe("useDragAndDrop", () => {
       isMerged: true,
     })
     expect(returnedItem).toEqual(mockItem)
+  })
+
+  describe("File Drag & Drop", () => {
+    it("should handle drag over with files correctly", () => {
+      const { result } = renderHook(() => useDragAndDrop(mockAddLog))
+
+      expect(result.current.isDraggingFile).toBe(false)
+
+      const dummyEvent = {
+        preventDefault: vi.fn(),
+        dataTransfer: {
+          types: ["Files"],
+        },
+      } as any
+      act(() => {
+        result.current.handleDragOver(dummyEvent)
+      })
+      expect(result.current.isDraggingFile).toBe(true)
+      expect(result.current.isDragging).toBe(false)
+    })
+
+    it("should process image drop, read QR, fetch image, and save to IndexedDB", async () => {
+      const { result } = renderHook(() => useDragAndDrop(mockAddLog))
+
+      const mockFile = new File(["test"], "card.png", { type: "image/png" })
+      const dummyEvent = {
+        preventDefault: vi.fn(),
+        dataTransfer: {
+          files: [mockFile],
+        },
+      } as any
+
+      let returnVal: any
+      await act(async () => {
+        returnVal = await result.current.handleDrop(dummyEvent)
+        await new Promise((r) => setTimeout(r, 50))
+      })
+
+      expect(db.styleCards.put).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "imported-card-id",
+          name: "Imported Card",
+          thumbnailData: "data:image/png;base64,mockbase64",
+        })
+      )
+      expect(mockAddLog).toHaveBeenCalledWith('Imported card "Imported Card" successfully!')
+      expect(returnVal).toEqual({ id: "imported-card-id", isImport: true })
+    })
   })
 })

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -10,7 +10,8 @@ export function useDragAndDrop(addLog: (msg: string) => void) {
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
-    if (e.dataTransfer && e.dataTransfer.types && e.dataTransfer.types.includes("Files")) {
+    const types = Array.from(e.dataTransfer?.types || [])
+    if (types.includes("Files") && !types.includes("application/json")) {
       setIsDraggingFile(true)
     } else {
       setIsDragging(true)
@@ -28,8 +29,11 @@ export function useDragAndDrop(addLog: (msg: string) => void) {
     setIsDraggingFile(false)
     addLog("Drop event received.")
 
-    // 1. Check if files are dropped (QR Card Image Import)
-    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+    const types = Array.from(e.dataTransfer?.types || [])
+    const hasJsonData = types.includes("application/json")
+
+    // 1. Check if files are dropped (QR Card Image Import) - only if it is not a local JSON drag
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0 && !hasJsonData) {
       const files = Array.from(e.dataTransfer.files)
       const imageFile = files.find((f) => f.type.startsWith("image/"))
       if (!imageFile) {

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -1,24 +1,126 @@
 import { useState } from "react"
 import { db } from "../lib/db"
-import type { HistoryItem } from "../lib/db-schema"
+import type { HistoryItem, StyleCard } from "../lib/db-schema"
 
 export function useDragAndDrop(addLog: (msg: string) => void) {
   const [isDragging, setIsDragging] = useState(false)
+  const [isDraggingFile, setIsDraggingFile] = useState(false)
+  const [isImporting, setIsImporting] = useState(false)
   const [droppedItem, setDroppedItem] = useState<{ id: string; name?: string; isMerged?: boolean } | null>(null)
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
-    setIsDragging(true)
+    if (e.dataTransfer && e.dataTransfer.types && e.dataTransfer.types.includes("Files")) {
+      setIsDraggingFile(true)
+    } else {
+      setIsDragging(true)
+    }
   }
 
   const handleDragLeave = () => {
     setIsDragging(false)
+    setIsDraggingFile(false)
   }
 
   const handleDrop = async (e: React.DragEvent) => {
     e.preventDefault()
     setIsDragging(false)
+    setIsDraggingFile(false)
     addLog("Drop event received.")
+
+    // 1. Check if files are dropped (QR Card Image Import)
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      const files = Array.from(e.dataTransfer.files)
+      const imageFile = files.find((f) => f.type.startsWith("image/"))
+      if (!imageFile) {
+        addLog("No valid image file dropped.")
+        return null
+      }
+
+      setIsImporting(true)
+      addLog("Processing dropped card image...")
+
+      try {
+        const { readQRCodeFromImage, decompressCardData } = await import("../lib/qr-utils")
+        const payload = await readQRCodeFromImage(imageFile)
+        
+        if (!payload) {
+          addLog("No QR code found in the image.")
+          setIsImporting(false)
+          return null
+        }
+
+        const partialCard = decompressCardData(payload)
+        if (!partialCard.name || !partialCard.promptSegments) {
+          addLog("Invalid card data in QR code.")
+          setIsImporting(false)
+          return null
+        }
+
+        const cdnUrl = partialCard.images?.[0]
+        let finalThumbnailData = "assets/icon.png"
+        
+        if (cdnUrl) {
+          addLog("Fetching clean artwork from Midjourney...")
+          try {
+            const response = await fetch(cdnUrl)
+            if (response.ok) {
+              const blob = await response.blob()
+              finalThumbnailData = await new Promise<string>((resolve, reject) => {
+                const reader = new FileReader()
+                reader.onloadend = () => resolve(reader.result as string)
+                reader.onerror = reject
+                reader.readAsDataURL(blob)
+              })
+              addLog("Artwork downloaded successfully.")
+            } else {
+              addLog("Could not fetch artwork from Midjourney CDN. Using placeholder.")
+            }
+          } catch (fetchErr) {
+            console.error("CORS or network error fetching artwork:", fetchErr)
+            addLog("Failed to download artwork. Using placeholder.")
+          }
+        } else {
+          addLog("No artwork URL found in card. Using placeholder.")
+        }
+
+        const existingCard = partialCard.id ? await db.styleCards.get(partialCard.id) : null
+        
+        const importedCard: StyleCard = {
+          id: partialCard.id || crypto.randomUUID(),
+          name: partialCard.name,
+          createdAt: existingCard?.createdAt || Date.now(),
+          updatedAt: Date.now(),
+          promptSegments: partialCard.promptSegments,
+          parameters: partialCard.parameters || {},
+          masking: partialCard.masking || { isSrefHidden: false, isPHidden: false },
+          tier: partialCard.tier || "Common",
+          isFavorite: existingCard?.isFavorite || false,
+          usageCount: existingCard?.usageCount || 0,
+          tags: partialCard.tags || [],
+          category: partialCard.category,
+          dominantColor: partialCard.dominantColor || "#1e293b",
+          accentColor: partialCard.accentColor || "#3b82f6",
+          thumbnailData: finalThumbnailData,
+          frameId: partialCard.frameId || "default",
+          genealogy: partialCard.genealogy || { generation: 1, parentIds: [] },
+          images: cdnUrl ? [cdnUrl] : [],
+          selectedThumbnails: cdnUrl ? [cdnUrl] : [],
+        }
+
+        await db.styleCards.put(importedCard)
+        addLog(`Imported card "${importedCard.name}" successfully!`)
+        return { id: importedCard.id, isImport: true }
+      } catch (err) {
+        console.error("Failed to import card:", err)
+        addLog("Error occurred while importing card.")
+      } finally {
+        setIsImporting(false)
+      }
+      return null
+    }
+
+    // 2. Existing JSON Dropping Logic (Midjourney History Drag & Drop)
     const jsonData = e.dataTransfer.getData("application/json")
     if (!jsonData) {
       addLog("No JSON data in drop event.")
@@ -70,6 +172,8 @@ export function useDragAndDrop(addLog: (msg: string) => void) {
 
   return {
     isDragging,
+    isDraggingFile,
+    isImporting,
     droppedItem,
     handleDragOver,
     handleDragLeave,

--- a/src/lib/export-utils.ts
+++ b/src/lib/export-utils.ts
@@ -229,21 +229,24 @@ export async function exportCardAsImage(card: StyleCard): Promise<void> {
 
   // 4. Generate and Draw QR Code
   try {
-    const qrPayload = compressCardData(card);
-    const qrDataUrl = await generateQRCodeUrl(qrPayload);
-    const qrImg = await loadImage(qrDataUrl);
-
-    const qrSize = 160;
+    const qrSize = 180;
     const qrX = width - qrSize - 35;
-    const qrY = infoY - 5;
+    const qrY = infoY - 20;
+
+    const qrPayload = compressCardData(card);
+    const qrDataUrl = await generateQRCodeUrl(qrPayload, qrSize);
+    const qrImg = await loadImage(qrDataUrl);
 
     // Draw White card frame behind QR code for high contrast scanning
     ctx.fillStyle = '#ffffff';
     drawRoundedRect(ctx, qrX - 8, qrY - 8, qrSize + 16, qrSize + 16, 12);
     ctx.fill();
 
-    // Draw QR image
+    // Draw QR image (disable smoothing for pixel-perfect sharpness)
+    ctx.save();
+    ctx.imageSmoothingEnabled = false;
     ctx.drawImage(qrImg, qrX, qrY, qrSize, qrSize);
+    ctx.restore();
 
     // Label under QR Code
     ctx.fillStyle = '#64748b';

--- a/src/lib/qr-utils.ts
+++ b/src/lib/qr-utils.ts
@@ -93,11 +93,11 @@ export function decompressCardData(payload: string): Partial<StyleCard> {
 /**
  * Generates a Data URL for a QR Code image containing the payload string.
  */
-export function generateQRCodeUrl(payload: string): Promise<string> {
+export function generateQRCodeUrl(payload: string, width?: number): Promise<string> {
   return QRCode.toDataURL(payload, {
     errorCorrectionLevel: 'M', // Medium error correction is a good balance for data capacity
     margin: 2,
-    scale: 4,
+    width: width || 200,
   });
 }
 

--- a/src/pages/SidePanel.tsx
+++ b/src/pages/SidePanel.tsx
@@ -129,14 +129,27 @@ function SidePanelInner() {
   }
 
   const { activeTab, setActiveTab } = useTabs()
-  const { isDragging, droppedItem, handleDragOver, handleDragLeave, handleDrop: rawHandleDrop } = useDragAndDrop(addLog)
-
+  const { 
+    isDragging, 
+    isDraggingFile, 
+    isImporting, 
+    droppedItem, 
+    handleDragOver, 
+    handleDragLeave, 
+    handleDrop: rawHandleDrop 
+  } = useDragAndDrop(addLog)
+ 
   const handleDrop = async (e: React.DragEvent) => {
-    const result = await rawHandleDrop(e)
+    const result = (await rawHandleDrop(e)) as any
     if (result) {
-      advanceIfStep("drop-history")
+      if (result.isImport) {
+        setActiveTab("library")
+      } else {
+        advanceIfStep("drop-history")
+      }
     }
   }
+
   const {
     mintingItem,
     variationBase,
@@ -230,6 +243,8 @@ function SidePanelInner() {
             setActiveDetailCard(null)
           }}
           isDragging={isDragging}
+          isDraggingFile={isDraggingFile}
+          isImporting={isImporting}
           logs={logs}
           onClearLogs={handleClearLogs}
           onResetDb={handleResetDb}


### PR DESCRIPTION
Implements Sub-Issue 3 for issue 94. Adds a drag-and-drop file listener in the LibraryTab component. When an image is dropped, it reads the QR code, decompresses the payload, fetches the original artwork from Midjourney CDN, and puts the reconstructed StyleCard into IndexedDB.