### PR TITLE
Fix: Resolve assets/icon.png bundling in production build (#131)

### DIFF
--- a/src/components/molecules/AssociatedImageGallery.tsx
+++ b/src/components/molecules/AssociatedImageGallery.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { CheckCircle2 } from "lucide-react";
+import iconUrl from "url:../../../assets/icon.png";
 
 /**
  * Props for the AssociatedImageGallery component.
@@ -55,7 +56,7 @@ export const AssociatedImageGallery: React.FC<AssociatedImageGalleryProps> = ({
               }`}
             >
               <img
-                src={imgUrl}
+                src={imgUrl === "assets/icon.png" ? iconUrl : imgUrl}
                 className="w-full h-full object-cover"
                 alt={`Card Image ${index + 1}`}
               />

--- a/src/components/molecules/CardThumbnail.tsx
+++ b/src/components/molecules/CardThumbnail.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { RarityBadge } from "../atoms/RarityBadge"
 import { IconButton } from "../atoms/IconButton"
 import type { RarityTier } from "../../lib/rarity-config"
+import iconUrl from "url:../../../assets/icon.png"
 
 /**
  * カードのサムネイル画像、レアリティバッジ、ピン留めアクションを組み合わせたコンポーネント。
@@ -55,9 +56,10 @@ export function CardThumbnail({
     lg: "w-full h-48",
   }
 
-  const imagesToRender = thumbnailImages && thumbnailImages.length > 0
+  const imagesToRender = (thumbnailImages && thumbnailImages.length > 0
     ? thumbnailImages.slice(0, 4)
     : [imageUrl].filter(Boolean) as string[]
+  ).map((img) => img === "assets/icon.png" ? iconUrl : img)
 
   return (
     <div className={`relative overflow-hidden rounded-lg group ${sizeClasses[size]} ${className}`}>
@@ -135,7 +137,7 @@ export function CardThumbnail({
         </div>
       ) : (
         <img
-          src={imagesToRender[0] || "assets/icon.png"}
+          src={imagesToRender[0] || iconUrl}
           alt={alt}
           className="w-full h-full object-cover transition-transform group-hover:scale-110"
         />

--- a/src/components/organisms/CardDetailView.tsx
+++ b/src/components/organisms/CardDetailView.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import type { StyleCard, PromptSegment } from "../../lib/db-schema";
 import { PromptBubbleEditor } from "./PromptBubbleEditor";
+import iconUrl from "url:../../../assets/icon.png";
 import { ParameterEditor } from "./ParameterEditor";
 import { RaritySelector } from "../molecules/RaritySelector";
 import { Button } from "../atoms/Button";

--- a/src/components/organisms/HandBar.tsx
+++ b/src/components/organisms/HandBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react"
 import { createPortal } from "react-dom"
 import { useHand } from "../../hooks/useHand"
+import iconUrl from "url:../../../assets/icon.png"
 import { RARITY_CONFIG } from "../../lib/rarity-config"
 import { Button } from "../atoms/Button"
 import { CardThumbnail } from "../molecules/CardThumbnail"
@@ -234,7 +235,7 @@ export function HandBar({ onNavigateToWorkbench, onOpenDetailCard }: HandBarProp
                         }`}
                       >
                         <div className="w-10 h-10 rounded overflow-hidden flex-shrink-0 border bg-white">
-                          <img src={c.thumbnailData || "assets/icon.png"} className="w-full h-full object-cover" />
+                          <img src={(!c.thumbnailData || c.thumbnailData === "assets/icon.png") ? iconUrl : c.thumbnailData} className="w-full h-full object-cover" />
                         </div>
                         <div className="flex-1 min-w-0">
                           <p className="text-xs font-bold text-slate-700 truncate">{c.name}</p>
@@ -262,7 +263,7 @@ export function HandBar({ onNavigateToWorkbench, onOpenDetailCard }: HandBarProp
                         >
                           <div className="flex items-center gap-2.5 min-w-0">
                             <div className="w-8 h-8 rounded overflow-hidden flex-shrink-0 border bg-white">
-                              <img src={c.thumbnailData || "assets/icon.png"} className="w-full h-full object-cover" />
+                              <img src={(!c.thumbnailData || c.thumbnailData === "assets/icon.png") ? iconUrl : c.thumbnailData} className="w-full h-full object-cover" />
                             </div>
                             <div className="min-w-0">
                               <p className="text-xs font-semibold text-slate-600 truncate">{c.name}</p>

--- a/src/components/organisms/MergeStackModal.tsx
+++ b/src/components/organisms/MergeStackModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { X, Layers } from "lucide-react";
 import { Button } from "../atoms/Button";
 import type { StyleCard } from "../../lib/db-schema";
+import iconUrl from "url:../../../assets/icon.png";
 
 /**
  * Props for the MergeStackModal component.
@@ -125,7 +126,7 @@ export const MergeStackModal: React.FC<MergeStackModalProps> = ({
                   >
                     <div className="w-10 h-10 rounded overflow-hidden flex-shrink-0 border bg-white">
                       <img
-                        src={c.thumbnailData || "assets/icon.png"}
+                        src={(!c.thumbnailData || c.thumbnailData === "assets/icon.png") ? iconUrl : c.thumbnailData}
                         className="w-full h-full object-cover"
                         alt={c.name}
                       />
@@ -165,7 +166,7 @@ export const MergeStackModal: React.FC<MergeStackModalProps> = ({
                         <div className="flex items-center gap-2.5 min-w-0">
                           <div className="w-8 h-8 rounded overflow-hidden flex-shrink-0 border bg-white">
                             <img
-                              src={c.thumbnailData || "assets/icon.png"}
+                              src={(!c.thumbnailData || c.thumbnailData === "assets/icon.png") ? iconUrl : c.thumbnailData}
                               className="w-full h-full object-cover"
                               alt={c.name}
                             />

--- a/src/components/organisms/ShareCardModal.tsx
+++ b/src/components/organisms/ShareCardModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import type { StyleCard } from "../../lib/db-schema"
 import { Button } from "../atoms/Button"
+import iconUrl from "url:../../../assets/icon.png"
 import { X, Share2, ExternalLink, Download, AlertCircle, Clipboard } from "lucide-react"
 import { exportCardAsImage, renderCardToCanvas } from "../../lib/export-utils"
 
@@ -107,7 +108,7 @@ export function ShareCardModal({ card, onClose, addLog }: ShareCardModalProps) {
           <div className="flex items-center gap-3 p-3 bg-slate-50 border rounded-lg">
             <div className="w-16 h-16 rounded overflow-hidden border border-slate-200 shadow-sm flex-shrink-0">
               <img
-                src={card.thumbnailData || "assets/icon.png"}
+                src={(!card.thumbnailData || card.thumbnailData === "assets/icon.png") ? iconUrl : card.thumbnailData}
                 className="w-full h-full object-cover"
                 alt={card.name}
               />

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { db } from "../lib/db"
 import type { HistoryItem, StyleCard } from "../lib/db-schema"
+import iconUrl from "url:../../assets/icon.png"
 
 export function useDragAndDrop(addLog: (msg: string) => void) {
   const [isDragging, setIsDragging] = useState(false)

--- a/src/lib/color-utils.test.ts
+++ b/src/lib/color-utils.test.ts
@@ -77,5 +77,13 @@ describe("Color Utilities", () => {
       expect(colors.dominantHex).toBe("#4f46e5");
       expect(colors.accentHex).toBe("#f59e0b");
     });
+
+    it("returns default/fallback values when image is placeholder asset", async () => {
+      const colors1 = await analyzeImageColors("assets/icon.png");
+      expect(colors1.dominantName).toBe("Blue");
+      
+      const colors2 = await analyzeImageColors("url:../../assets/icon.png");
+      expect(colors2.dominantName).toBe("Blue");
+    });
   });
 });

--- a/src/lib/color-utils.ts
+++ b/src/lib/color-utils.ts
@@ -1,3 +1,5 @@
+import iconUrl from "url:../../assets/icon.png";
+
 export interface ExtractedColors {
   dominantHex: string;
   dominantName: string;
@@ -71,6 +73,7 @@ export async function analyzeImageColors(imageUrl: string): Promise<ExtractedCol
     typeof document === "undefined" ||
     isTest ||
     imageUrl.includes("assets/icon.png") ||
+    imageUrl.includes(iconUrl) ||
     imageUrl === ""
   ) {
     return {

--- a/src/lib/export-utils.ts
+++ b/src/lib/export-utils.ts
@@ -1,5 +1,6 @@
 import type { StyleCard } from './db-schema';
 import { compressCardData, generateQRCodeUrl } from './qr-utils';
+import iconUrl from 'url:../../assets/icon.png';
 
 /**
  * Loads an image from a URL or Base64 string, handling CORS.
@@ -77,11 +78,13 @@ export async function renderCardToCanvas(card: StyleCard): Promise<HTMLCanvasEle
 
   // 2. Load and Draw Art Image(s)
   // Gather available image sources, fallback to thumbnailData
-  const imageSources = card.selectedThumbnails && card.selectedThumbnails.length > 0
+  const rawImageSources = card.selectedThumbnails && card.selectedThumbnails.length > 0
     ? card.selectedThumbnails.slice(0, 4)
     : card.images && card.images.length > 0
       ? card.images.slice(0, 4)
       : [card.thumbnailData].filter(Boolean);
+
+  const imageSources = rawImageSources.map((src) => src === "assets/icon.png" ? iconUrl : src);
 
   const artX = 30;
   const artY = 30;
@@ -108,7 +111,8 @@ export async function renderCardToCanvas(card: StyleCard): Promise<HTMLCanvasEle
         // Fallback to card's base64 thumbnailData if CDN fetch fails
         if (src !== card.thumbnailData && card.thumbnailData) {
           try {
-            const fallbackImg = await loadImage(card.thumbnailData);
+            const fallbackSrc = card.thumbnailData === "assets/icon.png" ? iconUrl : card.thumbnailData;
+            const fallbackImg = await loadImage(fallbackSrc);
             loadedImages.push(fallbackImg);
           } catch (fallbackErr) {
             console.error('Fallback image failed to load as well.', fallbackErr);

--- a/tests/sandbox/vite.config.ts
+++ b/tests/sandbox/vite.config.ts
@@ -29,6 +29,14 @@ export default defineConfig({
       }
     }
   ],
+  resolve: {
+    alias: [
+      {
+        find: /^url:(.*)$/,
+        replacement: "$1",
+      },
+    ],
+  },
   server: {
     port: 5173,
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,14 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  resolve: {
+    alias: [
+      {
+        find: /^url:(.*)$/,
+        replacement: "$1",
+      },
+    ],
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
Closes #131. Resolves issue with assets/icon.png not being bundled by using Plasmo's url: import scheme and mapping it dynamically at runtime.