### PR TITLE
Fix: Remove non-existent variant options in sandbox (#132)

### DIFF
--- a/tests/sandbox/index.html
+++ b/tests/sandbox/index.html
@@ -79,8 +79,6 @@
     <select id="variant-select">
       <option value="index.html">Default Mock (index.html)</option>
       <option value="pattern2.html">Pattern 2 (pattern2.html)</option>
-      <option value="variant_a.html">Variant A (variant_a.html)</option>
-      <option value="variant_b.html">Variant B (variant_b.html)</option>
     </select>
   </div>
   <iframe id="midjourney-frame" src="about:blank"></iframe>


### PR DESCRIPTION
Closes #132. Removes 'variant_a.html' and 'variant_b.html' from sandbox options dropdown since these mock files do not exist, preventing 404 errors when selected.