### PR TITLE
feat(history): local image caching for history items (fixes #145)

### DIFF
--- a/src/components/molecules/HistoryCard.test.tsx
+++ b/src/components/molecules/HistoryCard.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import React from "react"
+import { HistoryCard } from "./HistoryCard"
+import { db } from "../../lib/db"
+
+vi.mock("../../lib/db", () => {
+  return {
+    db: {
+      historyItems: {
+        update: vi.fn().mockResolvedValue(1),
+      },
+    },
+  }
+})
+
+describe("HistoryCard", () => {
+  const mockOnMintClick = vi.fn()
+  const mockItem = {
+    id: "job-123",
+    fullCommand: "sunset over Tokyo cyberpunk style",
+    imageUrl: "https://example.com/cdn/job-123.png",
+    timestamp: 1234567,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    
+    // URL methods mocking
+    global.URL.createObjectURL = vi.fn().mockReturnValue("blob:http://localhost/mock-uuid")
+    global.URL.revokeObjectURL = vi.fn()
+    
+    // fetch mocking
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: vi.fn().mockResolvedValue(new Blob(["bytes"], { type: "image/png" })),
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders with CDN image and triggers fetch when localImageBlob is absent", async () => {
+    render(<HistoryCard item={mockItem} onMintClick={mockOnMintClick} />)
+
+    // Verify initial render with CDN imageUrl
+    const img = screen.getByRole("img")
+    expect(img.getAttribute("src")).toBe("https://example.com/cdn/job-123.png")
+    expect(screen.getByText("sunset over Tokyo cyberpunk style")).toBeDefined()
+
+    // Verify fetch and update have been called
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("https://example.com/cdn/job-123.png")
+      expect(db.historyItems.update).toHaveBeenCalledWith("job-123", {
+        localImageBlob: expect.any(Blob),
+      })
+    })
+  })
+
+  it("renders with local object URL when localImageBlob is present", () => {
+    const mockBlob = new Blob(["test"], { type: "image/png" })
+    const itemWithBlob = {
+      ...mockItem,
+      localImageBlob: mockBlob,
+    }
+
+    render(<HistoryCard item={itemWithBlob} onMintClick={mockOnMintClick} />)
+
+    const img = screen.getByRole("img")
+    expect(img.getAttribute("src")).toBe("blob:http://localhost/mock-uuid")
+    expect(global.URL.createObjectURL).toHaveBeenCalledWith(mockBlob)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it("revokes object URL on unmount", () => {
+    const mockBlob = new Blob(["test"], { type: "image/png" })
+    const itemWithBlob = {
+      ...mockItem,
+      localImageBlob: mockBlob,
+    }
+
+    const { unmount } = render(<HistoryCard item={itemWithBlob} onMintClick={mockOnMintClick} />)
+
+    unmount()
+
+    expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:http://localhost/mock-uuid")
+  })
+
+  it("calls onMintClick when Mint Card button is clicked", () => {
+    render(<HistoryCard item={mockItem} onMintClick={mockOnMintClick} />)
+
+    const button = screen.getByRole("button", { name: "Mint Card" })
+    fireEvent.click(button)
+
+    expect(mockOnMintClick).toHaveBeenCalledWith(mockItem)
+  })
+})

--- a/src/components/molecules/HistoryCard.tsx
+++ b/src/components/molecules/HistoryCard.tsx
@@ -1,6 +1,7 @@
-import React from "react"
+import React, { useState, useEffect } from "react"
 import type { HistoryItem } from "../../lib/db-schema"
 import { Button } from "../atoms/Button"
+import { db } from "../../lib/db"
 
 /**
  * プロンプトの実行履歴を表示するカードコンポーネント。
@@ -21,12 +22,45 @@ export function HistoryCard({
   onMintClick,
   className = "",
 }: HistoryCardProps) {
+  const [imgSrc, setImgSrc] = useState<string>(item.imageUrl)
+
+  useEffect(() => {
+    let objectUrl: string | null = null
+
+    if (item.localImageBlob) {
+      objectUrl = URL.createObjectURL(item.localImageBlob)
+      setImgSrc(objectUrl)
+    } else {
+      setImgSrc(item.imageUrl)
+
+      const fetchAndCacheImage = async () => {
+        try {
+          const response = await fetch(item.imageUrl)
+          if (response.ok) {
+            const blob = await response.blob()
+            await db.historyItems.update(item.id, { localImageBlob: blob })
+          }
+        } catch (err) {
+          console.error("Failed to dynamically cache history image:", err)
+        }
+      }
+
+      fetchAndCacheImage()
+    }
+
+    return () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl)
+      }
+    }
+  }, [item.localImageBlob, item.imageUrl, item.id])
+
   return (
     <div
       className={`bg-white border border-slate-200 rounded-lg shadow-sm flex gap-3 p-2 ${className}`}
     >
       <img
-        src={item.imageUrl}
+        src={imgSrc}
         alt={item.id}
         className="w-24 h-24 rounded object-cover"
       />

--- a/src/hooks/useDragAndDrop.test.ts
+++ b/src/hooks/useDragAndDrop.test.ts
@@ -101,9 +101,19 @@ describe("useDragAndDrop", () => {
     })
 
     expect(db.styleCards.where).toHaveBeenCalledWith("jobId")
-    expect(db.historyItems.put).toHaveBeenCalledWith(mockItem)
+    expect(db.historyItems.put).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...mockItem,
+        localImageBlob: expect.any(Blob),
+      })
+    )
     expect(result.current.droppedItem).toEqual({ id: "test-job-id", isMerged: false })
-    expect(returnedItem).toEqual(mockItem)
+    expect(returnedItem).toEqual(
+      expect.objectContaining({
+        ...mockItem,
+        localImageBlob: expect.any(Blob),
+      })
+    )
   })
 
   it("should append image to existing StyleCard when matching jobId exists", async () => {

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -157,6 +157,21 @@ export function useDragAndDrop(addLog: (msg: string) => void) {
           setTimeout(() => setDroppedItem(null), 3000)
           return item
         } else {
+          addLog("Fetching artwork for history item cache...")
+          try {
+            const response = await fetch(item.imageUrl)
+            if (response.ok) {
+              const blob = await response.blob()
+              item.localImageBlob = blob
+              addLog("History artwork cached locally.")
+            } else {
+              addLog("Failed to fetch history artwork from CDN.")
+            }
+          } catch (fetchErr) {
+            console.error("CORS or network error fetching history artwork:", fetchErr)
+            addLog("Failed to cache history artwork.")
+          }
+
           await db.historyItems.put(item)
           addLog(`History item ${item.id} saved.`)
           setDroppedItem({ id: item.id, isMerged: false })

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -123,7 +123,13 @@ test.describe("Style Atelier Sandbox E2E Tests", () => {
       // ドラッグのイベント発生が正しく仲介されていれば、サイドパネルに通知が表示される。
       // もしドラッグが成功しなかった場合は、プログラム的にdropイベントを発火させて処理フローを補完・検証する。
       const notification = spFrame.locator("text=New History Item Added!");
-      const isVisible = await notification.isVisible({ timeout: 4000 }).catch(() => false);
+      let isVisible = false;
+      try {
+        await expect(notification).toBeVisible({ timeout: 6000 });
+        isVisible = true;
+      } catch (e) {
+        isVisible = false;
+      }
       
       if (!isVisible) {
         console.log("Fallback: Dispatching programmatic drop event to guarantee coverage...");
@@ -167,7 +173,7 @@ test.describe("Style Atelier Sandbox E2E Tests", () => {
 
       // 8. 注入したヒストリーアイテムが一覧に表示されることを検証
       console.log("Verifying history list contains the dropped item...");
-      const historyItem = spFrame.locator("text=超高層ビルを見上げた景色");
+      const historyItem = spFrame.locator("text=超高層ビルを見上げた景色").first();
       await expect(historyItem).toBeVisible({ timeout: 10000 });
 
       console.log("Drag-and-drop E2E test passed successfully!");


### PR DESCRIPTION
This PR implements local image caching in IndexedDB (localImageBlob) for history items, solving the problem of Midjourney CDN image expiration. It handles caching during drag-and-drop as well as dynamic caching when viewing history cards. Unit and E2E tests have been added and verified.