### PR TITLE
feat(settings): always confirm restore and show Google Drive backup metadata preview (fixes #146)

### DIFF
--- a/src/components/organisms/SettingsTab.test.tsx
+++ b/src/components/organisms/SettingsTab.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { SettingsTab } from "./SettingsTab";
+import * as googleDrive from "../../lib/google-drive";
+
+vi.mock("../../lib/google-drive", () => ({
+  authorize: vi.fn(),
+  clearCachedToken: vi.fn(),
+  uploadBackup: vi.fn(),
+  downloadBackup: vi.fn(),
+  exportDatabase: vi.fn(),
+  importDatabase: vi.fn(),
+  getBackupMetadata: vi.fn(),
+}));
+
+describe("SettingsTab", () => {
+  const mockAddLog = vi.fn();
+  const mockOnResetDb = vi.fn();
+  const originalConfirm = window.confirm;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    window.confirm = vi.fn().mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    window.confirm = originalConfirm;
+  });
+
+  it("renders with default state (sync disabled)", () => {
+    render(<SettingsTab addLog={mockAddLog} onResetDb={mockOnResetDb} />);
+
+    expect(screen.getByText("Google Drive Cloud Sync")).toBeDefined();
+    
+    // Backup and Restore buttons should be disabled
+    const backupBtn = screen.getByRole("button", { name: /Backup Data/i });
+    const restoreBtn = screen.getByRole("button", { name: /Restore Data/i });
+    expect(backupBtn).toBeDisabled();
+    expect(restoreBtn).toBeDisabled();
+  });
+
+  it("enabling sync performs authorization and fetches backup metadata", async () => {
+    vi.mocked(googleDrive.authorize).mockResolvedValue("mock-token-123");
+    vi.mocked(googleDrive.getBackupMetadata).mockResolvedValue({
+      id: "file-123",
+      modifiedTime: "2026-06-03T12:00:00.000Z",
+      size: "153600", // 150 KB
+    });
+
+    render(<SettingsTab addLog={mockAddLog} onResetDb={mockOnResetDb} />);
+
+    const toggleBtn = screen.getByRole("button", { name: "" }); // Switch button has no name text inside but is a button
+    fireEvent.click(toggleBtn);
+
+    await waitFor(() => {
+      expect(googleDrive.authorize).toHaveBeenCalledWith(true);
+      expect(googleDrive.getBackupMetadata).toHaveBeenCalledWith("mock-token-123");
+    });
+
+    // Verify metadata preview is displayed
+    await waitFor(() => {
+      expect(screen.getByText("Cloud Backup Preview")).toBeDefined();
+      expect(screen.getByText(/更新日時: 2026\/6\/3/)).toBeDefined();
+      expect(screen.getByText(/サイズ: 150\.0 KB/)).toBeDefined();
+    });
+  });
+
+  it("always shows confirmation dialog on Restore, even if checked multiple times", async () => {
+    vi.mocked(googleDrive.authorize).mockResolvedValue("mock-token-123");
+    vi.mocked(googleDrive.getBackupMetadata).mockResolvedValue({
+      id: "file-123",
+      modifiedTime: "2026-06-03T12:00:00.000Z",
+      size: "153600",
+    });
+    vi.mocked(googleDrive.downloadBackup).mockResolvedValue("mock-backup-data");
+    vi.mocked(googleDrive.importDatabase).mockResolvedValue(undefined);
+
+    render(<SettingsTab addLog={mockAddLog} onResetDb={mockOnResetDb} />);
+
+    // Enable sync
+    const toggleBtn = screen.getByRole("button", { name: "" });
+    fireEvent.click(toggleBtn);
+
+    // Wait for sync to be enabled
+    await waitFor(() => {
+      expect(screen.getByText("Cloud Backup Preview")).toBeDefined();
+    });
+
+    const restoreBtn = screen.getByRole("button", { name: /Restore Data/i });
+    expect(restoreBtn).not.toBeDisabled();
+
+    // First restore attempt
+    fireEvent.click(restoreBtn);
+    expect(window.confirm).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(window.confirm).mock.calls[0][0]).toContain("クラウド上のバックアップ情報");
+    expect(vi.mocked(window.confirm).mock.calls[0][0]).toContain("150.0 KB");
+
+    await waitFor(() => {
+      expect(googleDrive.downloadBackup).toHaveBeenCalledWith("mock-token-123");
+      expect(googleDrive.importDatabase).toHaveBeenCalledWith("mock-backup-data");
+    });
+
+    // Reset confirm mock calls
+    vi.mocked(window.confirm).mockClear();
+
+    // Second restore attempt - should still prompt confirmation (Skipping should be disabled, issue #146)
+    fireEvent.click(restoreBtn);
+    expect(window.confirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts restore if user cancels confirmation dialog", async () => {
+    window.confirm = vi.fn().mockReturnValue(false); // User clicks Cancel
+    vi.mocked(googleDrive.authorize).mockResolvedValue("mock-token-123");
+    vi.mocked(googleDrive.getBackupMetadata).mockResolvedValue(null);
+
+    render(<SettingsTab addLog={mockAddLog} onResetDb={mockOnResetDb} />);
+
+    // Enable sync
+    const toggleBtn = screen.getByRole("button", { name: "" });
+    fireEvent.click(toggleBtn);
+
+    await waitFor(() => {
+      const restoreBtn = screen.getByRole("button", { name: /Restore Data/i });
+      expect(restoreBtn).not.toBeDisabled();
+    });
+
+    const restoreBtn = screen.getByRole("button", { name: /Restore Data/i });
+    fireEvent.click(restoreBtn);
+
+    expect(window.confirm).toHaveBeenCalledTimes(1);
+    expect(googleDrive.downloadBackup).not.toHaveBeenCalled();
+    expect(googleDrive.importDatabase).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/organisms/SettingsTab.tsx
+++ b/src/components/organisms/SettingsTab.tsx
@@ -19,7 +19,8 @@ import {
   uploadBackup, 
   downloadBackup, 
   exportDatabase, 
-  importDatabase 
+  importDatabase,
+  getBackupMetadata
 } from "../../lib/google-drive";
 
 interface SettingsTabProps {
@@ -36,6 +37,8 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
   const [isBackingUp, setIsBackingUp] = useState(false);
   const [isRestoring, setIsRestoring] = useState(false);
   const [lastBackup, setLastBackup] = useState<string | null>(null);
+  const [cloudBackup, setCloudBackup] = useState<{ modifiedTime: string; size: string } | null>(null);
+  const [isLoadingCloudBackup, setIsLoadingCloudBackup] = useState(false);
 
   // Status logs local view
   const [statusMessage, setStatusMessage] = useState<{ text: string; type: "success" | "error" | "info" | null }>({
@@ -53,6 +56,33 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
     // Load sync enabled state
     const savedSyncEnabled = localStorage.getItem("style-atelier-sync-enabled") === "true";
     setIsSyncEnabled(savedSyncEnabled);
+
+    if (savedSyncEnabled) {
+      // Silently authorize and get backup metadata
+      authorize(false)
+        .then((token) => {
+          setAccessToken(token);
+          setIsLoadingCloudBackup(true);
+          getBackupMetadata(token)
+            .then((meta) => {
+              if (meta) {
+                const dateStr = new Date(meta.modifiedTime).toLocaleString();
+                const sizeKB = (parseInt(meta.size) / 1024).toFixed(1);
+                setCloudBackup({
+                  modifiedTime: dateStr,
+                  size: `${sizeKB} KB`
+                });
+              } else {
+                setCloudBackup(null);
+              }
+            })
+            .catch((err) => console.error(err))
+            .finally(() => setIsLoadingCloudBackup(false));
+        })
+        .catch((err) => {
+          console.log("Silent authorization failed:", err.message);
+        });
+    }
   }, []);
 
   const showStatus = (text: string, type: "success" | "error" | "info") => {
@@ -62,7 +92,7 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
     }, 6000);
   };
 
-  const handleToggleSync = (checked: boolean) => {
+  const handleToggleSync = async (checked: boolean) => {
     setIsSyncEnabled(checked);
     localStorage.setItem("style-atelier-sync-enabled", checked ? "true" : "false");
     addLog(`Google Drive synchronization: ${checked ? "ENABLED" : "DISABLED"}`);
@@ -73,6 +103,33 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
         clearCachedToken(accessToken).catch(console.error);
       }
       setAccessToken(null);
+      setCloudBackup(null);
+    } else {
+      // When turning sync on, fetch metadata using interactive authorization
+      try {
+        const token = await authorize(true);
+        setAccessToken(token);
+        setIsLoadingCloudBackup(true);
+        const meta = await getBackupMetadata(token);
+        if (meta) {
+          const dateStr = new Date(meta.modifiedTime).toLocaleString();
+          const sizeKB = (parseInt(meta.size) / 1024).toFixed(1);
+          setCloudBackup({
+            modifiedTime: dateStr,
+            size: `${sizeKB} KB`
+          });
+        } else {
+          setCloudBackup(null);
+        }
+      } catch (err: any) {
+        console.error(err);
+        addLog(`Sync authorization failed: ${err.message || err}`);
+        showStatus(`Authorization failed: ${err.message || "Unknown error"}`, "error");
+        setIsSyncEnabled(false);
+        localStorage.setItem("style-atelier-sync-enabled", "false");
+      } finally {
+        setIsLoadingCloudBackup(false);
+      }
     }
   };
 
@@ -111,6 +168,17 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
       localStorage.setItem("style-atelier-last-backup", now.toString());
       setLastBackup(new Date(now).toLocaleString());
 
+      // Fetch updated metadata
+      const meta = await getBackupMetadata(token);
+      if (meta) {
+        const dateStr = new Date(meta.modifiedTime).toLocaleString();
+        const sizeKB = (parseInt(meta.size) / 1024).toFixed(1);
+        setCloudBackup({
+          modifiedTime: dateStr,
+          size: `${sizeKB} KB`
+        });
+      }
+
       addLog("Backup uploaded to Google Drive successfully.");
       showStatus("バックアップ完了しました", "success");
     } catch (err: any) {
@@ -131,15 +199,14 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
   const handleRestore = async () => {
     if (!isSyncEnabled) return;
     
-    // Check if restore has been confirmed before
-    const isRestoreConfirmed = localStorage.getItem("style-atelier-restore-confirmed") === "true";
-    if (!isRestoreConfirmed) {
-      const ok = window.confirm(
-        "Google Driveからデータを復元（ロード）し、マージします。\n同じIDのデータはバックアップの内容で上書きされますがよろしいですか？\n(※次回以降、この確認画面は表示されずダイレクトにロードされます。)"
-      );
-      if (!ok) return;
-      localStorage.setItem("style-atelier-restore-confirmed", "true");
+    // Always display confirmation dialog
+    let confirmMsg = "Google Driveからデータを復元（ロード）し、マージします。\n同じIDのデータはバックアップの内容で上書きされますがよろしいですか？";
+    if (cloudBackup) {
+      confirmMsg += `\n\n【クラウド上のバックアップ情報】\n更新日時: ${cloudBackup.modifiedTime}\nサイズ: ${cloudBackup.size}`;
     }
+    
+    const ok = window.confirm(confirmMsg);
+    if (!ok) return;
 
     setIsRestoring(true);
     setStatusMessage({ text: "Downloading backup from Google Drive...", type: "info" });
@@ -277,13 +344,31 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
             </button>
           </div>
 
-          {/* Last Backup Time */}
-          {lastBackup && (
-            <div className="flex flex-col items-center justify-center gap-1 border-t border-slate-100 pt-3">
-              <div className="flex items-center gap-1 text-[10px] text-slate-400 font-medium">
-                <Clock className="w-3.5 h-3.5" />
-                <span>最終バックアップ: {lastBackup}</span>
-              </div>
+          {/* Last Backup Time & Cloud Backup Preview */}
+          {(lastBackup || cloudBackup || isLoadingCloudBackup) && (
+            <div className="flex flex-col items-center justify-center gap-1.5 border-t border-slate-100 pt-3">
+              {lastBackup && (
+                <div className="flex items-center gap-1 text-[10px] text-slate-400 font-medium">
+                  <Clock className="w-3.5 h-3.5" />
+                  <span>ローカル最終バックアップ: {lastBackup}</span>
+                </div>
+              )}
+              {isLoadingCloudBackup ? (
+                <div className="flex items-center gap-1 text-[10px] text-blue-400 font-medium animate-pulse">
+                  <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+                  <span>クラウド情報を取得中...</span>
+                </div>
+              ) : cloudBackup ? (
+                <div className="flex flex-col items-center gap-0.5 text-[10px] text-slate-500 font-medium bg-slate-50 rounded-lg py-1.5 px-3 border border-slate-100 w-full text-center">
+                  <span className="text-[9px] text-slate-400 uppercase tracking-wider font-bold">Cloud Backup Preview</span>
+                  <span>更新日時: {cloudBackup.modifiedTime}</span>
+                  <span>サイズ: {cloudBackup.size}</span>
+                </div>
+              ) : isSyncEnabled && (
+                <div className="text-[10px] text-slate-400 font-medium">
+                  クラウド上のバックアップファイルが見つかりません
+                </div>
+              )}
             </div>
           )}
 

--- a/src/lib/google-drive.test.ts
+++ b/src/lib/google-drive.test.ts
@@ -5,6 +5,7 @@ import {
   authorize, 
   clearCachedToken,
   searchBackupFile, 
+  getBackupMetadata,
   uploadBackup, 
   downloadBackup
 } from "./google-drive";
@@ -177,6 +178,34 @@ describe("Google Drive Utilities (getAuthToken Flow)", () => {
 
       const id = await searchBackupFile("token-123");
       expect(id).toBeNull();
+    });
+  });
+
+  describe("getBackupMetadata", () => {
+    it("should return backup metadata if backup file exists", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          files: [{ id: "drive-file-id-789", name: "style-atelier-backup.json", modifiedTime: "2026-06-03T12:00:00.000Z", size: "102400" }]
+        })
+      });
+
+      const meta = await getBackupMetadata("token-123");
+      expect(meta).toEqual({
+        id: "drive-file-id-789",
+        modifiedTime: "2026-06-03T12:00:00.000Z",
+        size: "102400"
+      });
+    });
+
+    it("should return null if backup file does not exist", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ files: [] })
+      });
+
+      const meta = await getBackupMetadata("token-123");
+      expect(meta).toBeNull();
     });
   });
 

--- a/src/lib/google-drive.ts
+++ b/src/lib/google-drive.ts
@@ -130,6 +130,39 @@ export async function searchBackupFile(accessToken: string): Promise<string | nu
   return null;
 }
 
+export interface BackupMetadata {
+  id: string;
+  modifiedTime: string;
+  size: string;
+}
+
+/**
+ * Search Google Drive for 'style-atelier-backup.json' and return its metadata
+ */
+export async function getBackupMetadata(accessToken: string): Promise<BackupMetadata | null> {
+  const query = encodeURIComponent("name = 'style-atelier-backup.json' and trashed = false");
+  const res = await fetch(`https://www.googleapis.com/drive/v3/files?q=${query}&fields=files(id,name,modifiedTime,size)&spaces=drive`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to get backup metadata: ${res.status} ${res.statusText}`);
+  }
+
+  const data = await res.json();
+  if (data.files && data.files.length > 0) {
+    const file = data.files[0];
+    return {
+      id: file.id,
+      modifiedTime: file.modifiedTime || "",
+      size: file.size || "0"
+    };
+  }
+  return null;
+}
+
 /**
  * Upload backup payload JSON to Google Drive (create or overwrite)
  */


### PR DESCRIPTION
This PR resolves #146 by making the Restore Data operation always prompt for confirmation, removing the skip logic. It also integrates with #122 by fetching the backup file metadata (modifiedTime and size) from Google Drive API and showing a preview of the cloud backup in the UI, as well as including these details in the restore confirmation prompt.