### PR TITLE
feat(ux): add premium empty states and guides (fixes #154)

### DIFF
--- a/src/components/organisms/HistoryTab.test.tsx
+++ b/src/components/organisms/HistoryTab.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import React from "react"
+import { HistoryTab } from "./HistoryTab"
+import { useHistory } from "../../hooks/useHistory"
+import type { HistoryItem } from "../../lib/db-schema"
+
+vi.mock("../../hooks/useHistory", () => ({
+  useHistory: vi.fn(),
+}))
+
+const mockHistoryItems: HistoryItem[] = [
+  {
+    id: "item-1",
+    fullCommand: "a majestic golden castle",
+    imageUrl: "data:image/png;base64,123",
+    timestamp: Date.now(),
+    srefs: ["https://midjourney.com/sref1"],
+    crefs: [],
+    imagePrompts: [],
+    promptSegments: [],
+    parameters: {},
+    dominantColor: "#000000",
+  },
+]
+
+describe("HistoryTab", () => {
+  const mockStartMinting = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders empty container while loading", () => {
+    vi.mocked(useHistory).mockReturnValue({
+      historyItems: undefined,
+      loadMore: vi.fn(),
+      hasMore: false,
+    })
+
+    const { container } = render(<HistoryTab onStartMinting={mockStartMinting} />)
+    expect(container.firstChild).not.toBeNull()
+    const dropZone = container.querySelector('[data-tutorial="history-drop-zone"]')
+    expect(dropZone).toBeDefined()
+    expect(dropZone?.childNodes.length).toBe(0)
+  })
+
+  it("renders empty state when there are no history items", () => {
+    vi.mocked(useHistory).mockReturnValue({
+      historyItems: [],
+      loadMore: vi.fn(),
+      hasMore: false,
+    })
+
+    render(<HistoryTab onStartMinting={mockStartMinting} />)
+    expect(screen.getByText("履歴がありません")).toBeDefined()
+    expect(screen.getByText(/Midjourneyのプロンプト入力エリアから画像/)).toBeDefined()
+    expect(screen.getByRole("link", { name: "Midjourneyを開く" })).toBeDefined()
+  })
+
+  it("renders history items when they exist", () => {
+    vi.mocked(useHistory).mockReturnValue({
+      historyItems: mockHistoryItems,
+      loadMore: vi.fn(),
+      hasMore: false,
+    })
+
+    render(<HistoryTab onStartMinting={mockStartMinting} />)
+    expect(screen.getByText("a majestic golden castle")).toBeDefined()
+  })
+})

--- a/src/components/organisms/HistoryTab.tsx
+++ b/src/components/organisms/HistoryTab.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from "react"
 import { useHistory } from "../../hooks/useHistory"
 import type { HistoryItem } from "../../lib/db-schema"
 import { HistoryCard } from "../molecules/HistoryCard"
+import { History, ExternalLink } from "lucide-react"
 
 interface HistoryTabProps {
   onStartMinting: (item: HistoryItem) => void
@@ -37,6 +38,32 @@ export function HistoryTab({ onStartMinting }: HistoryTabProps) {
       observer.disconnect()
     }
   }, [hasMore, loadMore, historyItems])
+
+  if (historyItems !== undefined && historyItems.length === 0) {
+    return (
+      <div 
+        className="flex flex-col items-center justify-center text-center p-8 bg-slate-50/50 rounded-xl border border-slate-200 border-dashed backdrop-blur-sm animate-in fade-in duration-300"
+        data-tutorial="history-drop-zone"
+      >
+        <div className="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mb-4 text-slate-400">
+          <History className="w-6 h-6 text-slate-500" />
+        </div>
+        <h3 className="text-sm font-bold text-slate-800 mb-1">履歴がありません</h3>
+        <p className="text-xs text-slate-500 max-w-[240px] leading-relaxed mb-4">
+          Midjourneyのプロンプト入力エリアから画像をドラッグ＆ドロップするか、MidjourneyのWebサイトからスタイルを連携してください。
+        </p>
+        <a
+          href="https://www.midjourney.com/explore"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors shadow-sm"
+        >
+          <span>Midjourneyを開く</span>
+          <ExternalLink className="w-3.5 h-3.5" />
+        </a>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-3 pb-4" data-tutorial="history-drop-zone">

--- a/src/components/organisms/LibraryTab.test.tsx
+++ b/src/components/organisms/LibraryTab.test.tsx
@@ -59,6 +59,7 @@ describe("LibraryTab", () => {
       setSortBy: vi.fn(),
       allSrefs: [],
       categories: [],
+      allCards: mockCards,
     })
   })
 
@@ -101,5 +102,63 @@ describe("LibraryTab", () => {
     // Modal should now be in the document
     expect(screen.getByText("Share Style Card")).toBeDefined()
     expect(screen.getByText("Open Dedicated Image Page")).toBeDefined()
+  })
+
+  it("renders empty state when there are no cards in the library", () => {
+    vi.mocked(useLibrary).mockReturnValue({
+      styleCards: [],
+      handleCardClick: vi.fn(),
+      togglePin: mockTogglePin,
+      searchTag: "",
+      setSearchTag: vi.fn(),
+      rarityFilter: "All",
+      setRarityFilter: vi.fn(),
+      categoryFilter: "All",
+      setCategoryFilter: vi.fn(),
+      sortBy: "newest",
+      setSortBy: vi.fn(),
+      allSrefs: [],
+      categories: [],
+      allCards: [],
+    })
+
+    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
+    expect(screen.getByText("スタイルカードがありません")).toBeDefined()
+    expect(screen.getByText(/Historyタブから画像をドラッグ＆ドロップ/)).toBeDefined()
+  })
+
+  it("renders empty state when search filters return no cards and allows clearing filters", () => {
+    const mockSetSearchTag = vi.fn()
+    const mockSetRarityFilter = vi.fn()
+    const mockSetCategoryFilter = vi.fn()
+
+    vi.mocked(useLibrary).mockReturnValue({
+      styleCards: [],
+      handleCardClick: vi.fn(),
+      togglePin: mockTogglePin,
+      searchTag: "NonExistentTag",
+      setSearchTag: mockSetSearchTag,
+      rarityFilter: "All",
+      setRarityFilter: mockSetRarityFilter,
+      categoryFilter: "All",
+      setCategoryFilter: mockSetCategoryFilter,
+      sortBy: "newest",
+      setSortBy: vi.fn(),
+      allSrefs: [],
+      categories: [],
+      allCards: mockCards,
+    })
+
+    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
+    expect(screen.getByText("カードが見つかりません")).toBeDefined()
+    expect(screen.getByText(/検索キーワードやフィルターの条件を変更するか/)).toBeDefined()
+
+    const clearButton = screen.getByRole("button", { name: "フィルターをクリア" })
+    expect(clearButton).toBeDefined()
+    fireEvent.click(clearButton)
+
+    expect(mockSetSearchTag).toHaveBeenCalledWith("")
+    expect(mockSetRarityFilter).toHaveBeenCalledWith("All")
+    expect(mockSetCategoryFilter).toHaveBeenCalledWith("All")
   })
 })

--- a/src/components/organisms/LibraryTab.tsx
+++ b/src/components/organisms/LibraryTab.tsx
@@ -4,7 +4,7 @@ import { RARITY_CONFIG } from "../../lib/rarity-config"
 import { SearchField } from "../molecules/SearchField"
 import { CardThumbnail } from "../molecules/CardThumbnail"
 import type { StyleCard } from "../../lib/db-schema"
-import { Tag } from "lucide-react"
+import { Tag, BookUp2, Search } from "lucide-react"
 import { CategoryManagerModal } from "./CategoryManagerModal"
 import { ShareCardModal } from "./ShareCardModal"
 import { ConnectionAlert, type AlertType } from "../molecules/ConnectionAlert"
@@ -36,6 +36,7 @@ export function LibraryTab({ addLog, setAlertType, onOpenDetailCard, onNavigateT
     setSortBy,
     allSrefs,
     categories,
+    allCards,
   } = useLibrary(addLog, setAlertType, onNavigateToWorkbench)
 
   return (
@@ -117,50 +118,86 @@ export function LibraryTab({ addLog, setAlertType, onOpenDetailCard, onNavigateT
         </button>
       </div>
 
-      <div className="grid grid-cols-2 gap-3" data-tutorial="library-card-grid">
-        {styleCards?.map((card, idx) => {
-          const config = RARITY_CONFIG[card.tier]
-          const cardCategory = categories.find((c) => c.id === card.category)
-          return (
-            <div
-              key={card.id}
-              data-tutorial={idx === 0 ? "library-card" : undefined}
-              onClick={(e) => {
-                togglePin(card, e)
-                advanceIfStep("card-to-hand")
-              }}
-              className={`group bg-white border-2 rounded-lg shadow-sm cursor-pointer overflow-hidden transition-all hover:scale-[1.02] active:scale-[0.98] ${config?.borderClass || "border-slate-200"
-                } ${config?.glowClass || ""}`}
-            >
-              <CardThumbnail
-                imageUrl={card.thumbnailData}
-                thumbnailImages={card.selectedThumbnails}
-                alt={card.name}
-                tier={card.tier}
-                isPinned={card.isPinned}
-                usageCount={card.usageCount}
-                onPinClick={(e) => togglePin(card, e)}
-                onEditClick={(e) => {
-                  e.stopPropagation()
-                  onOpenDetailCard(card)
+      {styleCards !== undefined && styleCards.length > 0 ? (
+        <div className="grid grid-cols-2 gap-3" data-tutorial="library-card-grid">
+          {styleCards.map((card, idx) => {
+            const config = RARITY_CONFIG[card.tier]
+            const cardCategory = categories.find((c) => c.id === card.category)
+            return (
+              <div
+                key={card.id}
+                data-tutorial={idx === 0 ? "library-card" : undefined}
+                onClick={(e) => {
+                  togglePin(card, e)
+                  advanceIfStep("card-to-hand")
                 }}
-                onInjectClick={(e) => {
-                  e.stopPropagation()
-                  handleCardClick(card)
-                }}
-                onShareClick={(e) => {
-                  e.stopPropagation()
-                  setSharingCard(card)
-                }}
-                category={cardCategory}
-              />
-              <div className={`p-2 border-t ${config.borderClass} bg-opacity-5 ${config.bgClass}`}>
-                <p className="text-xs font-bold text-slate-800 truncate">{card.name}</p>
+                className={`group bg-white border-2 rounded-lg shadow-sm cursor-pointer overflow-hidden transition-all hover:scale-[1.02] active:scale-[0.98] ${config?.borderClass || "border-slate-200"
+                  } ${config?.glowClass || ""}`}
+              >
+                <CardThumbnail
+                  imageUrl={card.thumbnailData}
+                  thumbnailImages={card.selectedThumbnails}
+                  alt={card.name}
+                  tier={card.tier}
+                  isPinned={card.isPinned}
+                  usageCount={card.usageCount}
+                  onPinClick={(e) => togglePin(card, e)}
+                  onEditClick={(e) => {
+                    e.stopPropagation()
+                    onOpenDetailCard(card)
+                  }}
+                  onInjectClick={(e) => {
+                    e.stopPropagation()
+                    handleCardClick(card)
+                  }}
+                  onShareClick={(e) => {
+                    e.stopPropagation()
+                    setSharingCard(card)
+                  }}
+                  category={cardCategory}
+                />
+                <div className={`p-2 border-t ${config.borderClass} bg-opacity-5 ${config.bgClass}`}>
+                  <p className="text-xs font-bold text-slate-800 truncate">{card.name}</p>
+                </div>
               </div>
-            </div>
-          )
-        })}
-      </div>
+            )
+          })}
+        </div>
+      ) : styleCards !== undefined ? (
+        <div className="flex flex-col items-center justify-center text-center p-8 bg-slate-50/50 rounded-xl border border-slate-200 border-dashed backdrop-blur-sm animate-in fade-in duration-300">
+          {allCards !== undefined && allCards.filter(c => !c.isVariable).length === 0 ? (
+            <>
+              <div className="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mb-4 text-slate-400">
+                <BookUp2 className="w-6 h-6 text-slate-500" />
+              </div>
+              <h3 className="text-sm font-bold text-slate-800 mb-1">スタイルカードがありません</h3>
+              <p className="text-xs text-slate-500 max-w-[240px] leading-relaxed">
+                Historyタブから画像をドラッグ＆ドロップして、あなただけの特別なスタイルカードを作成しましょう！
+              </p>
+            </>
+          ) : (
+            <>
+              <div className="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mb-4 text-slate-400">
+                <Search className="w-6 h-6 text-slate-500" />
+              </div>
+              <h3 className="text-sm font-bold text-slate-800 mb-1">カードが見つかりません</h3>
+              <p className="text-xs text-slate-500 max-w-[240px] leading-relaxed mb-4">
+                検索キーワードやフィルターの条件を変更するか、クリアしてください。
+              </p>
+              <button
+                onClick={() => {
+                  setSearchTag("")
+                  setRarityFilter("All")
+                  setCategoryFilter("All")
+                }}
+                className="px-3 py-1.5 text-xs font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-md transition-colors shadow-sm"
+              >
+                フィルターをクリア
+              </button>
+            </>
+          )}
+        </div>
+      ) : null}
 
       {isCategoryModalOpen && (
         <CategoryManagerModal

--- a/src/components/organisms/Workbench.test.tsx
+++ b/src/components/organisms/Workbench.test.tsx
@@ -114,7 +114,7 @@ describe("Workbench", () => {
     });
 
     render(<Workbench setAlertType={mockSetAlertType} addLog={mockAddLog} />);
-    expect(screen.getByText("Workbench is Empty")).toBeDefined();
+    expect(screen.getByText("Workbench は空です")).toBeDefined();
   });
 
   it("renders card segments and slot variable inputs when card has slots", async () => {

--- a/src/components/organisms/Workbench.tsx
+++ b/src/components/organisms/Workbench.tsx
@@ -393,10 +393,48 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
         )}
 
         {!isEvolutionMode && !isMixingMode && (
-          <div className="text-center py-12 px-6 bg-slate-50/50 rounded-xl border border-slate-100 border-dashed">
-            <BookUp2 className="w-8 h-8 text-slate-200 mx-auto mb-3" />
-            <p className="text-sm font-medium text-slate-400 mb-1">Workbench is Empty</p>
-            <p className="text-xs text-slate-300">Send style cards to Workbench from Library.</p>
+          <div className="flex flex-col items-center justify-center py-10 px-6 bg-slate-50/50 rounded-xl border border-slate-200 border-dashed backdrop-blur-sm animate-in fade-in duration-300">
+            <div className="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mb-4 text-slate-400 animate-pulse">
+              <Layers className="w-6 h-6 text-blue-500" />
+            </div>
+            <h3 className="text-sm font-bold text-slate-800 mb-1">Workbench は空です</h3>
+            <p className="text-xs text-slate-500 max-w-[280px] leading-relaxed mb-6 text-center">
+              Libraryタブからスタイルカードをピン留めして、スタイルの調合やカードの進化を開始しましょう。
+            </p>
+
+            <div className="w-full max-w-xs space-y-4 text-left border-t border-slate-200/60 pt-6">
+              <h4 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">使い方ガイド</h4>
+              
+              <div className="flex gap-3">
+                <div className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-50 border border-blue-200 text-blue-600 flex items-center justify-center text-[10px] font-bold">
+                  1
+                </div>
+                <div>
+                  <h5 className="text-xs font-bold text-slate-700">スタイルをピン留め</h5>
+                  <p className="text-[10px] text-slate-500">Libraryからお気に入りのスタイルをWorkbenchへ送ります。</p>
+                </div>
+              </div>
+
+              <div className="flex gap-3">
+                <div className="flex-shrink-0 w-5 h-5 rounded-full bg-purple-50 border border-purple-200 text-purple-600 flex items-center justify-center text-[10px] font-bold">
+                  2
+                </div>
+                <div>
+                  <h5 className="text-xs font-bold text-slate-700">プロンプトを調合 / カードを進化</h5>
+                  <p className="text-[10px] text-slate-500">2枚以上でブレンド、1枚ならプロンプトの調整や、使用回数に応じた進化が可能です。</p>
+                </div>
+              </div>
+
+              <div className="flex gap-3">
+                <div className="flex-shrink-0 w-5 h-5 rounded-full bg-indigo-50 border border-indigo-200 text-indigo-600 flex items-center justify-center text-[10px] font-bold">
+                  3
+                </div>
+                <div>
+                  <h5 className="text-xs font-bold text-slate-700">Midjourneyで生成</h5>
+                  <p className="text-[10px] text-slate-500">「Try on Midjourney」ボタンでプロンプトをチャットへ直接送信します。</p>
+                </div>
+              </div>
+            </div>
           </div>
         )}
       </div>

--- a/src/hooks/useLibrary.ts
+++ b/src/hooks/useLibrary.ts
@@ -167,5 +167,6 @@ export function useLibrary(
     setSortBy,
     allSrefs,
     categories,
+    allCards,
   }
 }


### PR DESCRIPTION
This PR adds premium glassmorphism empty states, guided instructions, and links for when data is empty in the HistoryTab, LibraryTab, and Workbench. Unit tests have been added and updated accordingly.