### PR TITLE
feat(sync): integrate slot history into backup and restore (fixes #153)

### DIFF
--- a/src/lib/google-drive.test.ts
+++ b/src/lib/google-drive.test.ts
@@ -80,6 +80,19 @@ describe("Google Drive Utilities (getAuthToken Flow)", () => {
       expect(parsed.data.historyItems[0].id).toBe("hist1");
       expect(parsed.data.historyItems[1].id).toBe("hist2");
     });
+
+    it("should include slotHistory from localStorage in the exported payload", async () => {
+      const mockSlotHistory = {
+        subject: ["cat", "dog"],
+        style: ["anime"]
+      };
+      localStorage.setItem("style_atelier_slot_history", JSON.stringify(mockSlotHistory));
+
+      const json = await exportDatabase();
+      const parsed = JSON.parse(json);
+
+      expect(parsed.data.slotHistory).toEqual(mockSlotHistory);
+    });
   });
 
   describe("importDatabase", () => {
@@ -106,6 +119,70 @@ describe("Google Drive Utilities (getAuthToken Flow)", () => {
       expect(db.userSettings.bulkPut).toHaveBeenCalledWith(mockPayload.data.userSettings);
       expect(db.historyItems.clear).not.toHaveBeenCalled();
       expect(db.historyItems.bulkPut).toHaveBeenCalledWith(mockPayload.data.historyItems);
+    });
+
+    it("should restore and merge slotHistory into localStorage, keeping incoming values first, removing duplicates, and limiting to 10 items", async () => {
+      const existingHistory = {
+        subject: ["existing1", "existing2", "common"],
+        style: ["minimalist"]
+      };
+      localStorage.setItem("style_atelier_slot_history", JSON.stringify(existingHistory));
+
+      const incomingHistory = {
+        subject: ["common", "incoming1", "incoming2"],
+        style: ["gothic"],
+        artist: ["picasso"]
+      };
+
+      const mockPayload = {
+        version: 1,
+        exportedAt: 123456,
+        data: {
+          styleCards: [],
+          categories: [],
+          userSettings: [],
+          historyItems: [],
+          slotHistory: incomingHistory
+        }
+      };
+
+      await importDatabase(JSON.stringify(mockPayload));
+
+      const restored = JSON.parse(localStorage.getItem("style_atelier_slot_history") || "{}");
+
+      expect(restored.subject).toEqual(["common", "incoming1", "incoming2", "existing1", "existing2"]);
+      expect(restored.style).toEqual(["gothic", "minimalist"]);
+      expect(restored.artist).toEqual(["picasso"]);
+    });
+
+    it("should cap merged slotHistory items at 10 per variable", async () => {
+      const existingHistory = {
+        subject: ["1", "2", "3", "4", "5", "6", "7", "8"]
+      };
+      localStorage.setItem("style_atelier_slot_history", JSON.stringify(existingHistory));
+
+      const incomingHistory = {
+        subject: ["9", "10", "11", "12", "13"]
+      };
+
+      const mockPayload = {
+        version: 1,
+        exportedAt: 123456,
+        data: {
+          styleCards: [],
+          categories: [],
+          userSettings: [],
+          historyItems: [],
+          slotHistory: incomingHistory
+        }
+      };
+
+      await importDatabase(JSON.stringify(mockPayload));
+
+      const restored = JSON.parse(localStorage.getItem("style_atelier_slot_history") || "{}");
+
+      expect(restored.subject).toEqual(["9", "10", "11", "12", "13", "1", "2", "3", "4", "5"]);
+      expect(restored.subject).toHaveLength(10);
     });
 
     it("should throw error if payload structure is invalid", async () => {

--- a/src/lib/google-drive.ts
+++ b/src/lib/google-drive.ts
@@ -8,6 +8,7 @@ export interface BackupPayload {
     categories: any[];
     userSettings: any[];
     historyItems: any[];
+    slotHistory?: Record<string, string[]>;
   };
 }
 
@@ -68,6 +69,16 @@ export async function exportDatabase(): Promise<string> {
     return rest;
   });
 
+  let slotHistory: Record<string, string[]> | undefined = undefined;
+  try {
+    const stored = localStorage.getItem("style_atelier_slot_history");
+    if (stored) {
+      slotHistory = JSON.parse(stored);
+    }
+  } catch (e) {
+    console.error("Failed to read slot history for backup:", e);
+  }
+
   const payload: BackupPayload = {
     version: 1,
     exportedAt: Date.now(),
@@ -75,7 +86,8 @@ export async function exportDatabase(): Promise<string> {
       styleCards: cards,
       categories,
       userSettings: settings,
-      historyItems: historyWithoutBlobs
+      historyItems: historyWithoutBlobs,
+      slotHistory
     }
   };
 
@@ -106,6 +118,27 @@ export async function importDatabase(jsonData: string): Promise<void> {
       await db.historyItems.bulkPut(payload.data.historyItems);
     }
   });
+
+  if (payload.data.slotHistory) {
+    try {
+      const stored = localStorage.getItem("style_atelier_slot_history");
+      const existingHistory: Record<string, string[]> = stored ? JSON.parse(stored) : {};
+      
+      const mergedHistory: Record<string, string[]> = { ...existingHistory };
+      
+      for (const [key, incomingValues] of Object.entries(payload.data.slotHistory)) {
+        if (Array.isArray(incomingValues)) {
+          const localValues = mergedHistory[key] || [];
+          const merged = Array.from(new Set([...incomingValues, ...localValues])).slice(0, 10);
+          mergedHistory[key] = merged;
+        }
+      }
+      
+      localStorage.setItem("style_atelier_slot_history", JSON.stringify(mergedHistory));
+    } catch (e) {
+      console.error("Failed to restore/merge slot history:", e);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
This PR integrates the slot history stored in localStorage (style_atelier_slot_history) into the database backup and restore payloads. The history from multiple devices is safely merged with duplicates removed and capped at 10 items. Unit tests are added to verify the functionality.