### PR TITLE
[fix] CORS/Fallback fix for card export

### DIFF
--- a/src/lib/export-utils.test.ts
+++ b/src/lib/export-utils.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderCardToCanvas } from "./export-utils";
+import type { StyleCard } from "./db-schema";
+import { db } from "./db";
+
+const originalImage = global.Image;
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+
+describe("export-utils", () => {
+  let createdObjectURLs: string[] = [];
+
+  beforeEach(() => {
+    createdObjectURLs = [];
+    URL.createObjectURL = vi.fn((blob: Blob) => {
+      const url = `blob:mock-url-${createdObjectURLs.length}`;
+      createdObjectURLs.push(url);
+      return url;
+    });
+    URL.revokeObjectURL = vi.fn();
+
+    const mockContext = {
+      fillRect: vi.fn(),
+      stroke: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      closePath: vi.fn(),
+      save: vi.fn(),
+      clip: vi.fn(),
+      restore: vi.fn(),
+      fillText: vi.fn(),
+      createRadialGradient: vi.fn().mockReturnValue({
+        addColorStop: vi.fn(),
+      }),
+      drawImage: vi.fn(),
+      fill: vi.fn(),
+      measureText: vi.fn().mockReturnValue({ width: 100 }),
+    };
+
+    HTMLCanvasElement.prototype.getContext = vi.fn((contextId) => {
+      if (contextId === '2d') {
+        return mockContext;
+      }
+      return null;
+    }) as any;
+
+    // Mock Image load process
+    global.Image = class {
+      src: string = "";
+      crossOrigin: string = "";
+      onload: (() => void) | null = null;
+      onerror: ((err: any) => void) | null = null;
+
+      constructor() {
+        setTimeout(() => {
+          if (this.onload) this.onload();
+        }, 10);
+      }
+    } as any;
+  });
+
+  afterEach(() => {
+    global.Image = originalImage;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    vi.restoreAllMocks();
+  });
+
+  const baseCard: StyleCard = {
+    id: "card-uuid",
+    name: "Test Card",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    promptSegments: [{ type: "text", value: "A beautiful landscape" }],
+    parameters: { ar: "16:9" },
+    masking: { isSrefHidden: false, isPHidden: false },
+    tier: "Common",
+    isFavorite: false,
+    usageCount: 0,
+    tags: [],
+    dominantColor: "#123456",
+    thumbnailData: "data:image/png;base64,mockbase64",
+    frameId: "default",
+    genealogy: { generation: 1, parentIds: [] },
+  };
+
+  it("should prioritize local thumbnailData and skip external CDN loading when only 1 thumbnail is needed", async () => {
+    const spyGet = vi.spyOn(db.historyItems, "get").mockResolvedValue(undefined);
+    
+    const imageLoadSources: string[] = [];
+    global.Image = class {
+      _src: string = "";
+      crossOrigin: string = "";
+      onload: (() => void) | null = null;
+      onerror: ((err: any) => void) | null = null;
+
+      set src(val: string) {
+        this._src = val;
+        imageLoadSources.push(val);
+        setTimeout(() => {
+          if (this.onload) this.onload();
+        }, 10);
+      }
+      get src() {
+        return this._src;
+      }
+    } as any;
+
+    const card: StyleCard = {
+      ...baseCard,
+      thumbnailData: "data:image/png;base64,mockbase64",
+      selectedThumbnails: ["https://cdn.midjourney.com/image.png"],
+    };
+
+    await renderCardToCanvas(card);
+
+    expect(imageLoadSources).toContain("data:image/png;base64,mockbase64");
+    expect(imageLoadSources).not.toContain("https://cdn.midjourney.com/image.png");
+    expect(spyGet).not.toHaveBeenCalled();
+  });
+
+  it("should resolve cached localImageBlob from db.historyItems when grid layout is required and use Object URL", async () => {
+    const mockBlob = new Blob(["mock"], { type: "image/png" });
+    const spyGet = vi.spyOn(db.historyItems, "get").mockResolvedValue({
+      id: "job-1",
+      fullCommand: "",
+      imageUrl: "https://cdn.midjourney.com/image1.png",
+      localImageBlob: mockBlob,
+      timestamp: Date.now(),
+    });
+
+    const imageLoadSources: string[] = [];
+    global.Image = class {
+      _src: string = "";
+      crossOrigin: string = "";
+      onload: (() => void) | null = null;
+      onerror: ((err: any) => void) | null = null;
+
+      set src(val: string) {
+        this._src = val;
+        imageLoadSources.push(val);
+        setTimeout(() => {
+          if (this.onload) this.onload();
+        }, 10);
+      }
+      get src() {
+        return this._src;
+      }
+    } as any;
+
+    const card: StyleCard = {
+      ...baseCard,
+      thumbnailData: "data:image/png;base64,mockbase64",
+      selectedThumbnails: [
+        "https://cdn.midjourney.com/image1.png",
+        "https://cdn.midjourney.com/image2.png"
+      ],
+      associatedJobIds: ["job-1"],
+    };
+
+    await renderCardToCanvas(card);
+
+    expect(imageLoadSources).toContain("blob:mock-url-0");
+    expect(imageLoadSources).toContain("https://cdn.midjourney.com/image2.png");
+    expect(spyGet).toHaveBeenCalledWith("job-1");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url-0");
+  });
+});

--- a/src/lib/export-utils.ts
+++ b/src/lib/export-utils.ts
@@ -1,6 +1,47 @@
 import type { StyleCard } from './db-schema';
+import { db } from './db';
 import { compressCardData, generateQRCodeUrl } from './qr-utils';
 import iconUrl from 'url:../../assets/icon.png';
+
+/**
+ * Resolves a given image source URL to a local cache URL (Object URL of local blob)
+ * if it exists in db.historyItems. Otherwise, returns the original URL.
+ */
+async function resolveLocalImageSource(src: string, card: StyleCard): Promise<string> {
+  // If it's already a local data/blob URL or placeholder asset, return as is
+  if (
+    !src ||
+    src.startsWith('data:') ||
+    src.startsWith('blob:') ||
+    src.includes('assets/icon.png') ||
+    src.startsWith('url:')
+  ) {
+    return src;
+  }
+
+  try {
+    // Look for a matching history item in associatedJobIds first
+    const jobIds = card.associatedJobIds || (card.jobId ? [card.jobId] : []);
+    for (const jobId of jobIds) {
+      const historyItem = await db.historyItems.get(jobId);
+      if (historyItem && historyItem.imageUrl === src && historyItem.localImageBlob) {
+        return URL.createObjectURL(historyItem.localImageBlob);
+      }
+    }
+
+    // Fallback: search all history items matching this imageUrl (if not too many)
+    const matchedItem = await db.historyItems
+      .filter((item) => item.imageUrl === src && !!item.localImageBlob)
+      .first();
+    if (matchedItem && matchedItem.localImageBlob) {
+      return URL.createObjectURL(matchedItem.localImageBlob);
+    }
+  } catch (err) {
+    console.warn('Failed to resolve local image from database:', err);
+  }
+
+  return src;
+}
 
 /**
  * Loads an image from a URL or Base64 string, handling CORS.
@@ -77,12 +118,26 @@ export async function renderCardToCanvas(card: StyleCard): Promise<HTMLCanvasEle
   ctx.stroke();
 
   // 2. Load and Draw Art Image(s)
-  // Gather available image sources, fallback to thumbnailData
-  const rawImageSources = card.selectedThumbnails && card.selectedThumbnails.length > 0
-    ? card.selectedThumbnails.slice(0, 4)
-    : card.images && card.images.length > 0
-      ? card.images.slice(0, 4)
-      : [card.thumbnailData].filter(Boolean);
+  // Determine if card.thumbnailData is already a local base64/blob URL or placeholder asset
+  const isLocalThumb = card.thumbnailData && (
+    card.thumbnailData.startsWith('data:') ||
+    card.thumbnailData.startsWith('blob:') ||
+    card.thumbnailData.includes('assets/icon.png') ||
+    card.thumbnailData.startsWith('url:')
+  );
+
+  let rawImageSources: string[] = [];
+  if (isLocalThumb && (!card.selectedThumbnails || card.selectedThumbnails.length <= 1)) {
+    // If thumbnailData is already a local cache and we don't need a grid (0 or 1 thumbnails),
+    // prioritize it to avoid CORS issues and redundant CDN network traffic entirely.
+    rawImageSources = [card.thumbnailData];
+  } else if (card.selectedThumbnails && card.selectedThumbnails.length > 0) {
+    rawImageSources = card.selectedThumbnails.slice(0, 4);
+  } else if (card.images && card.images.length > 0) {
+    rawImageSources = card.images.slice(0, 4);
+  } else if (card.thumbnailData) {
+    rawImageSources = [card.thumbnailData];
+  }
 
   const imageSources = rawImageSources.map((src) => src === "assets/icon.png" ? iconUrl : src);
 
@@ -100,20 +155,39 @@ export async function renderCardToCanvas(card: StyleCard): Promise<HTMLCanvasEle
   ctx.fillStyle = '#1e293b';
   ctx.fillRect(artX, artY, artW, artH);
 
+  // Keep track of dynamically generated object URLs so we can revoke them and prevent memory leaks
+  const objectUrlsToRevoke: string[] = [];
+
   try {
-    const loadedImages: HTMLImageElement[] = [];
+    // Resolve all image sources to local cached blobs if available
+    const resolvedSources: string[] = [];
     for (const src of imageSources) {
+      const resolved = await resolveLocalImageSource(src, card);
+      resolvedSources.push(resolved);
+      if (resolved.startsWith('blob:') && resolved !== src) {
+        objectUrlsToRevoke.push(resolved);
+      }
+    }
+
+    const loadedImages: HTMLImageElement[] = [];
+    for (let i = 0; i < resolvedSources.length; i++) {
+      const src = resolvedSources[i];
+      const originalSrc = imageSources[i];
       try {
         const img = await loadImage(src);
         loadedImages.push(img);
       } catch (err) {
         console.warn(`Failed to load image: ${src}, falling back.`, err);
-        // Fallback to card's base64 thumbnailData if CDN fetch fails
-        if (src !== card.thumbnailData && card.thumbnailData) {
+        // Fallback to card's base64 thumbnailData if CDN/blob fetch fails
+        if (originalSrc !== card.thumbnailData && card.thumbnailData) {
           try {
             const fallbackSrc = card.thumbnailData === "assets/icon.png" ? iconUrl : card.thumbnailData;
-            const fallbackImg = await loadImage(fallbackSrc);
+            const resolvedFallback = await resolveLocalImageSource(fallbackSrc, card);
+            const fallbackImg = await loadImage(resolvedFallback);
             loadedImages.push(fallbackImg);
+            if (resolvedFallback.startsWith('blob:') && resolvedFallback !== fallbackSrc) {
+              objectUrlsToRevoke.push(resolvedFallback);
+            }
           } catch (fallbackErr) {
             console.error('Fallback image failed to load as well.', fallbackErr);
           }
@@ -154,6 +228,11 @@ export async function renderCardToCanvas(card: StyleCard): Promise<HTMLCanvasEle
     }
   } catch (err) {
     console.error('Error drawing artwork to canvas:', err);
+  } finally {
+    // Revoke object URLs to prevent memory leaks
+    for (const url of objectUrlsToRevoke) {
+      URL.revokeObjectURL(url);
+    }
   }
   ctx.restore();
 


### PR DESCRIPTION
Closes #139. Resolves unnecessary external CDN access and CORS errors during card export by prioritizing local thumbnail data and resolving cached history blobs.