### PR TITLE
feat: Dynamic Job ID extraction from data-attribute & modal overlay (#129)

### DIFF
--- a/src/contents/_domain/extractors/WebDataExtractor.test.ts
+++ b/src/contents/_domain/extractors/WebDataExtractor.test.ts
@@ -111,4 +111,55 @@ describe("WebDataExtractor", () => {
 
     document.body.removeChild(container)
   })
+
+  it("should extract jobId from data-job-id attribute on the image itself or its parent", () => {
+    const container = document.createElement("div")
+    container.setAttribute("data-job-id", "22222222-3333-4444-5555-666666666666")
+    container.innerHTML = `
+      <div class="overflow-clip">
+        <div class="relative group/promptText">
+          <div class="break-word">A neon cyberpunk alleyway</div>
+        </div>
+      </div>
+      <img id="test-img-data-attr" src="https://cdn.midjourney.com/placeholder.png" />
+    `
+    document.body.appendChild(container)
+    const img = document.getElementById("test-img-data-attr") as HTMLImageElement
+
+    const result = extractor.extract(img)
+
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe("22222222-3333-4444-5555-666666666666")
+    expect(result?.fullCommand).toBe("A neon cyberpunk alleyway")
+
+    document.body.removeChild(container)
+  })
+
+  it("should extract jobId from a wider modal/overlay container even when sibling containers do not wrap the image directly", () => {
+    const modal = document.createElement("div")
+    modal.className = "fixed bg-white"
+    modal.innerHTML = `
+      <div class="image-wrapper">
+        <img id="test-img-modal-fallback" src="https://cdn.midjourney.com/placeholder.png" />
+      </div>
+      <div class="sidebar">
+        <div class="overflow-clip">
+          <div class="relative group/promptText">
+            <div class="break-word">A futuristic space station orbiting Mars</div>
+          </div>
+        </div>
+        <a href="https://www.midjourney.com/jobs/77777777-8888-9999-aaaa-bbbbbbbbbbbb">Job Details Link</a>
+      </div>
+    `
+    document.body.appendChild(modal)
+    const img = document.getElementById("test-img-modal-fallback") as HTMLImageElement
+
+    const result = extractor.extract(img)
+
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe("77777777-8888-9999-aaaa-bbbbbbbbbbbb")
+    expect(result?.fullCommand).toBe("A futuristic space station orbiting Mars")
+
+    document.body.removeChild(modal)
+  })
 })

--- a/src/contents/_domain/extractors/WebDataExtractor.ts
+++ b/src/contents/_domain/extractors/WebDataExtractor.ts
@@ -18,16 +18,26 @@ export class WebDataExtractor implements IExtractor {
         prompt = img.alt || ""
     }
     
-    // Attempt to extract Job ID from parent link
     let jobId = ""
     const parentLink = img.closest("a")
-    if (parentLink && parentLink.href) {
-        const id = extractJobIdFromUrl(parentLink.href)
-        if (id) jobId = id
+
+    // 1. Attempt to extract from data-job-id attribute on the image or its parent hierarchy
+    const dataJobIdEl = img.closest("[data-job-id]")
+    if (dataJobIdEl) {
+      const attrVal = dataJobIdEl.getAttribute("data-job-id")
+      if (attrVal) jobId = attrVal
     }
 
+    // 2. Attempt to extract Job ID from parent link
     if (!jobId) {
-      // Find the unit container of the current image to search for job link
+      if (parentLink && parentLink.href) {
+        const id = extractJobIdFromUrl(parentLink.href)
+        if (id) jobId = id
+      }
+    }
+
+    // 3. Find the unit container of the current image to search for job link
+    if (!jobId) {
       const unitContainer = img.closest("#pageScroll > div") || img.closest(".absolute") || img.closest(".group")
       if (unitContainer) {
         const jobLink = unitContainer.querySelector("a[href*='/jobs/']")
@@ -38,13 +48,22 @@ export class WebDataExtractor implements IExtractor {
       }
     }
 
-    if (!jobId && typeof window !== "undefined") {
-      if (window.location.href.includes("pattern2.html")) {
-        jobId = "100cc076-ef20-46b4-8aeb-f7c294169800"
-      } else {
-        const id = extractJobIdFromUrl(window.location.href)
-        if (id) jobId = id
+    // 4. Attempt to search for job links in a wider modal/overlay context
+    if (!jobId) {
+      const modalContainer = img.closest(".fixed") || img.closest("[draggable='true']") || (typeof document !== "undefined" ? document.body : null)
+      if (modalContainer) {
+        const jobLink = modalContainer.querySelector("a[href*='/jobs/']")
+        if (jobLink && (jobLink as HTMLAnchorElement).href) {
+          const id = extractJobIdFromUrl((jobLink as HTMLAnchorElement).href)
+          if (id) jobId = id
+        }
       }
+    }
+
+    // 5. Fallback to extracting Job ID from the current page URL
+    if (!jobId && typeof window !== "undefined") {
+      const id = extractJobIdFromUrl(window.location.href)
+      if (id) jobId = id
     }
 
     if (!jobId) {

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -226,6 +226,38 @@ test.describe("Style Atelier Sandbox E2E Tests", () => {
     console.log("Extraction test passed successfully!");
   });
 
+  test("should correctly extract Job ID, prompt, and image source from pattern2.html sandbox variant", async ({ page }) => {
+    console.log("Navigating to sandbox page with pattern2 variant...");
+    await page.goto("/tests/sandbox/index.html?variant=pattern2.html");
+
+    const mjFrame = page.frameLocator("#midjourney-frame");
+
+    // Wait for Midjourney mock images to render
+    console.log("Waiting for Midjourney mock images to render...");
+    const mockImage = mjFrame.locator("img[src*='0_1.jpeg']");
+    await expect(mockImage).toBeVisible({ timeout: 15000 });
+
+    // Evaluate extractor inside midjourney-frame context
+    console.log("Evaluating WebDataExtractor on the pattern2 image...");
+    const result = await mjFrame.locator("body").evaluate(() => {
+      const img = document.querySelector("img[src*='0_1.jpeg']") as HTMLImageElement;
+      if (!img) return null;
+      
+      const extractor = (window as any)._extractor;
+      if (!extractor) return { error: "Extractor not found on window" };
+
+      return extractor.extract(img);
+    });
+
+    console.log("Extracted result from pattern2:", result);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe("100cc076-ef20-46b4-8aeb-f7c294169800");
+    expect(result.fullCommand).toContain("俊足の怪人");
+    expect(result.fullCommand).toContain("聖歌隊の行進");
+    expect(result.imageUrl).toContain("0_1.jpeg");
+    console.log("pattern2 variant extraction test passed successfully!");
+  });
+
   test("should render slot variables and handle pin to hand in Workbench", async ({ page }) => {
     console.log("Navigating to sandbox page for Workbench slot variable test...");
     await page.goto("/tests/sandbox/index.html");


### PR DESCRIPTION
Resolves #129

### Changes:
1. **Dynamic Job ID Extraction**:
   - Added support for retrieving Job IDs from \data-job-id\ attributes on the dragged image or close parent nodes.
   - Added fallback logic to query anchor tags referencing \/jobs/<UUID>\ in a wider context (e.g. modals/overlays or document body), removing the hardcoded \pattern2.html\ exception.
2. **Updated Sandbox Mock**:
   - Injected the simulated \data-job-id\ and a dummy job link into the \pattern2.html\ layout to test realistic overlay behaviors.
3. **Tests**:
   - Added unit tests in \WebDataExtractor.test.ts\ for testing data-attribute and wider-overlay extraction strategies.
   - Added an E2E test in \extension.spec.ts\ targeting the \pattern2.html\ variant to verify full-flow dynamic Job ID, prompt, and image source resolution.