### PR TITLE
test: add comprehensive unit tests for backup-validator.ts (#184)

### DIFF
--- a/src/components/organisms/SettingsTab.test.tsx
+++ b/src/components/organisms/SettingsTab.test.tsx
@@ -11,7 +11,19 @@ vi.mock("../../lib/google-drive", () => ({
   uploadBackup: vi.fn(),
   downloadBackup: vi.fn(),
   exportDatabase: vi.fn().mockResolvedValue('{"version": 1, "data": {"styleCards": [], "categories": [], "userSettings": [], "historyItems": []}}'),
-  importDatabase: vi.fn().mockResolvedValue(undefined),
+  importDatabase: vi.fn().mockImplementation(async (jsonData: string) => {
+    const { validateBackupPayload } = await import("../../lib/backup-validator");
+    let payload: any;
+    try {
+      payload = JSON.parse(jsonData);
+    } catch (e) {
+      throw new Error("Invalid JSON format. Failed to parse backup file.");
+    }
+    const validation = validateBackupPayload(payload);
+    if (!validation.isValid) {
+      throw new Error(`Database validation failed: ${validation.error}`);
+    }
+  }),
   getBackupMetadata: vi.fn(),
 }));
 
@@ -94,7 +106,32 @@ describe("SettingsTab", () => {
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
     expect(fileInput).toBeDefined();
 
-    const backupContent = '{"version": 1, "data": {"styleCards": [{"id": "c1", "name": "Card C1"}]}}';
+    const mockStyleCard = {
+      id: "card-123",
+      name: "Mock Card",
+      createdAt: 123456789,
+      updatedAt: 123456789,
+      promptSegments: [{ type: "text", value: "test command" }],
+      parameters: { ar: "16:9" },
+      masking: { isSrefHidden: false, isPHidden: false },
+      tier: "Common",
+      isFavorite: false,
+      isPinned: false,
+      usageCount: 0,
+      tags: ["test"],
+      category: "cat1",
+      dominantColor: "#ffffff",
+      thumbnailData: "data:image/png;base64,abc",
+      frameId: "default",
+      genealogy: { generation: 1, parentIds: [] }
+    };
+    const backupContent = JSON.stringify({
+      version: 1,
+      exportedAt: 123456789,
+      data: {
+        styleCards: [mockStyleCard]
+      }
+    });
     const file = new File([backupContent], "backup.json", { type: "application/json" });
 
     // Trigger file change event
@@ -121,7 +158,7 @@ describe("SettingsTab", () => {
       expect(mockAddLog).toHaveBeenCalledWith(expect.stringContaining("Import failed:"));
     });
 
-    expect(importDatabase).not.toHaveBeenCalled();
+    expect(importDatabase).toHaveBeenCalledWith(invalidContent);
   });
 
   it("cancels import if user rejects confirmation", async () => {

--- a/src/components/organisms/SettingsTab.tsx
+++ b/src/components/organisms/SettingsTab.tsx
@@ -289,11 +289,6 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
           throw new Error("File is empty.");
         }
         
-        const parsed = JSON.parse(text);
-        if (!parsed.data || !parsed.data.styleCards) {
-          throw new Error("Invalid backup file: Missing styleCards data.");
-        }
-        
         await importDatabase(text);
         addLog("Database restored from local JSON file successfully.");
         showStatus("インポートが完了しました！", "success");

--- a/src/lib/backup-validator.test.ts
+++ b/src/lib/backup-validator.test.ts
@@ -1,0 +1,542 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateCustomCategory,
+  validateStyleCard,
+  validateHistoryItem,
+  validateUserSettings,
+  validateSlotHistory,
+  validateBackupPayload
+} from "./backup-validator";
+
+// Mock Data Builders
+const createValidCategory = () => ({
+  id: "cat-1",
+  name: "My Category",
+  iconEmoji: "⭐",
+  iconUrl: "http://example.com/icon.png",
+  iconCardId: "card-1",
+  createdAt: 123456789
+});
+
+const createValidStyleCard = () => ({
+  id: "card-1",
+  name: "My Style",
+  createdAt: 123456789,
+  updatedAt: 123456789,
+  promptSegments: [
+    { type: "text", value: "hello" },
+    { type: "slot", label: "slot1", default: "world" },
+    { type: "chip", kind: "sref", value: "sref1" }
+  ],
+  parameters: {
+    ar: "16:9",
+    sref: ["sref-url"],
+    cref: ["cref-url"],
+    p: ["p-url"],
+    imagePrompts: ["prompt-url"],
+    stylize: 100,
+    chaos: 10,
+    weird: 20,
+    tile: true,
+    raw: false
+  },
+  masking: {
+    isSrefHidden: false,
+    isPHidden: true
+  },
+  tier: "Epic",
+  isFavorite: true,
+  isPinned: false,
+  usageCount: 5,
+  tags: ["tag1", "tag2"],
+  category: "cat-1",
+  dominantColor: "#ff0000",
+  accentColor: "#00ff00",
+  thumbnailData: "data:image/png;base64,abc",
+  frameId: "default-frame",
+  genealogy: {
+    generation: 2,
+    parentIds: ["parent-1"],
+    originCreatorId: "creator-1",
+    mutationNote: "mutated"
+  },
+  isVariable: true,
+  jobId: "job-1",
+  associatedJobIds: ["job-1", "job-2"],
+  images: ["img-1"],
+  selectedThumbnails: ["thumb-1"]
+});
+
+const createValidHistoryItem = () => ({
+  id: "hist-1",
+  fullCommand: "/imagine prompt: test",
+  imageUrl: "http://example.com/img.png",
+  timestamp: 123456789,
+  relatedCardId: "card-1"
+});
+
+const createValidUserSettings = () => ({
+  userId: "user-1",
+  isPro: true,
+  unlockedSkins: ["skin-1", "skin-2"],
+  branding: {
+    enabled: true,
+    customLogo: "logo.png",
+    signatureName: "John Doe"
+  }
+});
+
+const createValidSlotHistory = () => ({
+  subject: ["cat", "dog"],
+  style: ["anime"]
+});
+
+const createValidBackupPayload = () => ({
+  version: 1,
+  exportedAt: 123456789,
+  data: {
+    styleCards: [createValidStyleCard()],
+    categories: [createValidCategory()],
+    userSettings: [createValidUserSettings()],
+    historyItems: [createValidHistoryItem()],
+    slotHistory: createValidSlotHistory()
+  }
+});
+
+describe("backup-validator", () => {
+  describe("validateCustomCategory", () => {
+    it("should validate a correct category", () => {
+      const cat = createValidCategory();
+      expect(validateCustomCategory(cat, 0)).toEqual({ isValid: true });
+    });
+
+    it("should validate category without optional fields", () => {
+      const cat = createValidCategory();
+      delete cat.iconEmoji;
+      delete cat.iconUrl;
+      delete cat.iconCardId;
+      expect(validateCustomCategory(cat, 0)).toEqual({ isValid: true });
+    });
+
+    it("should reject non-object values", () => {
+      expect(validateCustomCategory(null, 0).isValid).toBe(false);
+      expect(validateCustomCategory("string", 0).isValid).toBe(false);
+    });
+
+    it("should reject invalid fields", () => {
+      const cat = createValidCategory();
+      
+      expect(validateCustomCategory({ ...cat, id: 123 }, 0).isValid).toBe(false);
+      expect(validateCustomCategory({ ...cat, name: 123 }, 0).isValid).toBe(false);
+      expect(validateCustomCategory({ ...cat, iconEmoji: 123 }, 0).isValid).toBe(false);
+      expect(validateCustomCategory({ ...cat, iconUrl: 123 }, 0).isValid).toBe(false);
+      expect(validateCustomCategory({ ...cat, iconCardId: 123 }, 0).isValid).toBe(false);
+      expect(validateCustomCategory({ ...cat, createdAt: "not-a-number" }, 0).isValid).toBe(false);
+    });
+  });
+
+  describe("validateStyleCard", () => {
+    it("should validate a correct style card", () => {
+      const card = createValidStyleCard();
+      expect(validateStyleCard(card, 0)).toEqual({ isValid: true });
+    });
+
+    it("should validate a style card without optional fields", () => {
+      const card = createValidStyleCard();
+      delete card.isPinned;
+      delete card.category;
+      delete card.accentColor;
+      delete card.isVariable;
+      delete card.jobId;
+      delete card.associatedJobIds;
+      delete card.images;
+      delete card.selectedThumbnails;
+      delete card.genealogy.originCreatorId;
+      delete card.genealogy.mutationNote;
+      
+      // parameters optionals
+      delete card.parameters.ar;
+      delete card.parameters.sref;
+      delete card.parameters.cref;
+      delete card.parameters.p;
+      delete card.parameters.imagePrompts;
+      delete card.parameters.stylize;
+      delete card.parameters.chaos;
+      delete card.parameters.weird;
+      delete card.parameters.tile;
+      delete card.parameters.raw;
+      
+      expect(validateStyleCard(card, 0)).toEqual({ isValid: true });
+    });
+
+    it("should reject non-object values", () => {
+      expect(validateStyleCard(null, 0).isValid).toBe(false);
+      expect(validateStyleCard("card", 0).isValid).toBe(false);
+    });
+
+    it("should reject invalid basic identity fields", () => {
+      const card = createValidStyleCard();
+      expect(validateStyleCard({ ...card, id: 123 }, 0).isValid).toBe(false);
+      expect(validateStyleCard({ ...card, name: 123 }, 0).isValid).toBe(false);
+      expect(validateStyleCard({ ...card, createdAt: "not-a-number" }, 0).isValid).toBe(false);
+      expect(validateStyleCard({ ...card, updatedAt: "not-a-number" }, 0).isValid).toBe(false);
+    });
+
+    describe("promptSegments validation", () => {
+      it("should reject if promptSegments is not an array", () => {
+        const card = createValidStyleCard();
+        (card as any).promptSegments = "not-an-array";
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+
+      it("should reject if a segment is not an object", () => {
+        const card = createValidStyleCard();
+        card.promptSegments[0] = "not-an-object" as any;
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+
+      it("should reject if a segment has missing or invalid type", () => {
+        const card = createValidStyleCard();
+        card.promptSegments[0] = { value: "hello" } as any; // missing type
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+        
+        card.promptSegments[0] = { type: 123, value: "hello" } as any; // invalid type
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+
+      it("should reject invalid text segments", () => {
+        const card = createValidStyleCard();
+        card.promptSegments[0] = { type: "text", value: 123 } as any; // value must be string
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+
+      it("should reject invalid slot segments", () => {
+        const card = createValidStyleCard();
+        card.promptSegments[1] = { type: "slot", label: 123, default: "world" } as any;
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+
+        card.promptSegments[1] = { type: "slot", label: "slot", default: 123 } as any;
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+
+      it("should reject invalid chip segments", () => {
+        const card = createValidStyleCard();
+        card.promptSegments[2] = { type: "chip", kind: "invalid-kind", value: "val" } as any;
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+
+        card.promptSegments[2] = { type: "chip", kind: "sref", value: 123 } as any;
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+
+      it("should reject unknown segment types", () => {
+        const card = createValidStyleCard();
+        card.promptSegments[0] = { type: "unknown-type" } as any;
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+    });
+
+    describe("parameters validation", () => {
+      it("should reject if parameters is not an object", () => {
+        const card = createValidStyleCard();
+        card.parameters = "not-an-object" as any;
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+
+      it("should reject invalid parameters values", () => {
+        const card = createValidStyleCard();
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, ar: 123 } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, sref: "not-array" } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, sref: [123] } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, cref: [123] } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, p: [123] } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, imagePrompts: [123] } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, stylize: "100" } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, chaos: "10" } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, weird: "20" } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, tile: "true" } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, parameters: { ...card.parameters, raw: "false" } }, 0).isValid).toBe(false);
+      });
+    });
+
+    describe("masking validation", () => {
+      it("should reject if masking is not an object", () => {
+        const card = createValidStyleCard();
+        card.masking = "not-an-object" as any;
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+
+      it("should reject invalid masking values", () => {
+        const card = createValidStyleCard();
+        expect(validateStyleCard({ ...card, masking: { isSrefHidden: "false", isPHidden: false } as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, masking: { isSrefHidden: false, isPHidden: "true" } as any }, 0).isValid).toBe(false);
+      });
+    });
+
+    describe("TCG and other metadata validation", () => {
+      it("should reject invalid tier", () => {
+        const card = createValidStyleCard();
+        card.tier = "SuperRare" as any;
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+
+      it("should reject other invalid metadata", () => {
+        const card = createValidStyleCard();
+        expect(validateStyleCard({ ...card, isFavorite: "true" as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, isPinned: "false" as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, usageCount: "5" as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, tags: "not-array" as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, tags: [123] as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, category: 123 as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, dominantColor: 123 as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, accentColor: 123 as any }, 0).isValid).toBe(false);
+      });
+    });
+
+    describe("Visuals validation", () => {
+      it("should reject invalid visuals", () => {
+        const card = createValidStyleCard();
+        expect(validateStyleCard({ ...card, thumbnailData: 123 as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, frameId: 123 as any }, 0).isValid).toBe(false);
+      });
+    });
+
+    describe("Genealogy validation", () => {
+      it("should reject if genealogy is not an object", () => {
+        const card = createValidStyleCard();
+        card.genealogy = "not-an-object" as any;
+        expect(validateStyleCard(card, 0).isValid).toBe(false);
+      });
+
+      it("should reject invalid genealogy values", () => {
+        const card = createValidStyleCard();
+        expect(validateStyleCard({ ...card, genealogy: { ...card.genealogy, generation: "2" as any } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, genealogy: { ...card.genealogy, parentIds: "not-array" as any } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, genealogy: { ...card.genealogy, parentIds: [123] as any } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, genealogy: { ...card.genealogy, originCreatorId: 123 as any } }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, genealogy: { ...card.genealogy, mutationNote: 123 as any } }, 0).isValid).toBe(false);
+      });
+    });
+
+    describe("Variables, Job ID validation", () => {
+      it("should reject invalid variables and job parameters", () => {
+        const card = createValidStyleCard();
+        expect(validateStyleCard({ ...card, isVariable: "true" as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, jobId: 123 as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, associatedJobIds: "not-array" as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, associatedJobIds: [123] as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, images: [123] as any }, 0).isValid).toBe(false);
+        expect(validateStyleCard({ ...card, selectedThumbnails: [123] as any }, 0).isValid).toBe(false);
+      });
+    });
+  });
+
+  describe("validateHistoryItem", () => {
+    it("should validate a correct history item", () => {
+      const item = createValidHistoryItem();
+      expect(validateHistoryItem(item, 0)).toEqual({ isValid: true });
+    });
+
+    it("should validate a history item without optional fields", () => {
+      const item = createValidHistoryItem();
+      delete item.relatedCardId;
+      expect(validateHistoryItem(item, 0)).toEqual({ isValid: true });
+    });
+
+    it("should reject non-object values", () => {
+      expect(validateHistoryItem(null, 0).isValid).toBe(false);
+      expect(validateHistoryItem("item", 0).isValid).toBe(false);
+    });
+
+    it("should reject invalid fields", () => {
+      const item = createValidHistoryItem();
+      expect(validateHistoryItem({ ...item, id: 123 }, 0).isValid).toBe(false);
+      expect(validateHistoryItem({ ...item, fullCommand: 123 }, 0).isValid).toBe(false);
+      expect(validateHistoryItem({ ...item, imageUrl: 123 }, 0).isValid).toBe(false);
+      expect(validateHistoryItem({ ...item, timestamp: "not-a-number" }, 0).isValid).toBe(false);
+      expect(validateHistoryItem({ ...item, relatedCardId: 123 }, 0).isValid).toBe(false);
+    });
+  });
+
+  describe("validateUserSettings", () => {
+    it("should validate a correct user setting", () => {
+      const setting = createValidUserSettings();
+      expect(validateUserSettings(setting, 0)).toEqual({ isValid: true });
+    });
+
+    it("should validate user settings without optional branding fields", () => {
+      const setting = createValidUserSettings();
+      delete setting.branding.customLogo;
+      delete setting.branding.signatureName;
+      expect(validateUserSettings(setting, 0)).toEqual({ isValid: true });
+    });
+
+    it("should reject non-object values", () => {
+      expect(validateUserSettings(null, 0).isValid).toBe(false);
+      expect(validateUserSettings("setting", 0).isValid).toBe(false);
+    });
+
+    it("should reject invalid root fields", () => {
+      const setting = createValidUserSettings();
+      expect(validateUserSettings({ ...setting, userId: 123 }, 0).isValid).toBe(false);
+      expect(validateUserSettings({ ...setting, isPro: "true" }, 0).isValid).toBe(false);
+      expect(validateUserSettings({ ...setting, unlockedSkins: "not-array" }, 0).isValid).toBe(false);
+      expect(validateUserSettings({ ...setting, unlockedSkins: [123] }, 0).isValid).toBe(false);
+    });
+
+    it("should reject invalid branding fields", () => {
+      const setting = createValidUserSettings();
+      expect(validateUserSettings({ ...setting, branding: "not-object" }, 0).isValid).toBe(false);
+      expect(validateUserSettings({ ...setting, branding: { ...setting.branding, enabled: "true" } }, 0).isValid).toBe(false);
+      expect(validateUserSettings({ ...setting, branding: { ...setting.branding, customLogo: 123 } }, 0).isValid).toBe(false);
+      expect(validateUserSettings({ ...setting, branding: { ...setting.branding, signatureName: 123 } }, 0).isValid).toBe(false);
+    });
+  });
+
+  describe("validateSlotHistory", () => {
+    it("should validate correct slot history", () => {
+      const sh = createValidSlotHistory();
+      expect(validateSlotHistory(sh)).toEqual({ isValid: true });
+    });
+
+    it("should reject non-object values", () => {
+      expect(validateSlotHistory(null).isValid).toBe(false);
+      expect(validateSlotHistory("slotHistory").isValid).toBe(false);
+    });
+
+    it("should reject if values are not string arrays", () => {
+      const sh = { subject: "not-array" };
+      expect(validateSlotHistory(sh).isValid).toBe(false);
+
+      const sh2 = { subject: [123] };
+      expect(validateSlotHistory(sh2).isValid).toBe(false);
+    });
+  });
+
+  describe("validateBackupPayload", () => {
+    it("should validate a correct full backup payload", () => {
+      const payload = createValidBackupPayload();
+      expect(validateBackupPayload(payload)).toEqual({ isValid: true });
+    });
+
+    it("should validate payload without optional data arrays", () => {
+      const payload = createValidBackupPayload();
+      delete payload.data.categories;
+      delete payload.data.userSettings;
+      delete payload.data.historyItems;
+      delete payload.data.slotHistory;
+      expect(validateBackupPayload(payload)).toEqual({ isValid: true });
+    });
+
+    it("should reject non-object payload", () => {
+      expect(validateBackupPayload(null).isValid).toBe(false);
+      expect(validateBackupPayload("payload").isValid).toBe(false);
+    });
+
+    describe("version validation", () => {
+      it("should reject if version is missing", () => {
+        const payload = createValidBackupPayload();
+        delete (payload as any).version;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+      });
+
+      it("should reject if version is not a number", () => {
+        const payload = createValidBackupPayload();
+        (payload as any).version = "1";
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+      });
+
+      it("should reject if version is greater than supported version (1)", () => {
+        const payload = createValidBackupPayload();
+        payload.version = 2;
+        const res = validateBackupPayload(payload);
+        expect(res.isValid).toBe(false);
+        expect(res.error).toContain("Backup version (2) is not supported");
+      });
+
+      it("should reject if version is less than 1", () => {
+        const payload = createValidBackupPayload();
+        payload.version = 0;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+        
+        payload.version = -1;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+      });
+    });
+
+    describe("exportedAt and data wrapper validation", () => {
+      it("should reject if exportedAt is missing or invalid", () => {
+        const payload = createValidBackupPayload();
+        delete (payload as any).exportedAt;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+
+        const payload2 = createValidBackupPayload();
+        payload2.exportedAt = "not-a-number" as any;
+        expect(validateBackupPayload(payload2).isValid).toBe(false);
+      });
+
+      it("should reject if data is missing or invalid", () => {
+        const payload = createValidBackupPayload();
+        delete (payload as any).data;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+
+        const payload2 = createValidBackupPayload();
+        payload2.data = "not-an-object" as any;
+        expect(validateBackupPayload(payload2).isValid).toBe(false);
+      });
+    });
+
+    describe("nested elements propagation", () => {
+      it("should reject if styleCards array is missing or invalid", () => {
+        const payload = createValidBackupPayload();
+        delete (payload.data as any).styleCards;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+
+        const payload2 = createValidBackupPayload();
+        payload2.data.styleCards = "not-an-array" as any;
+        expect(validateBackupPayload(payload2).isValid).toBe(false);
+      });
+
+      it("should propagate error if a style card is invalid", () => {
+        const payload = createValidBackupPayload();
+        payload.data.styleCards[0].tier = "InvalidTier" as any;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+      });
+
+      it("should propagate error if categories is not an array, or if a category is invalid", () => {
+        const payload = createValidBackupPayload();
+        payload.data.categories = "not-an-array" as any;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+
+        const payload2 = createValidBackupPayload();
+        payload2.data.categories![0].name = 123 as any;
+        expect(validateBackupPayload(payload2).isValid).toBe(false);
+      });
+
+      it("should propagate error if userSettings is not an array, or if userSettings is invalid", () => {
+        const payload = createValidBackupPayload();
+        payload.data.userSettings = "not-an-array" as any;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+
+        const payload2 = createValidBackupPayload();
+        payload2.data.userSettings![0].isPro = "true" as any;
+        expect(validateBackupPayload(payload2).isValid).toBe(false);
+      });
+
+      it("should propagate error if historyItems is not an array, or if a history item is invalid", () => {
+        const payload = createValidBackupPayload();
+        payload.data.historyItems = "not-an-array" as any;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+
+        const payload2 = createValidBackupPayload();
+        payload2.data.historyItems![0].timestamp = "not-a-number" as any;
+        expect(validateBackupPayload(payload2).isValid).toBe(false);
+      });
+
+      it("should propagate error if slotHistory is invalid", () => {
+        const payload = createValidBackupPayload();
+        payload.data.slotHistory = { subject: "not-an-array" } as any;
+        expect(validateBackupPayload(payload).isValid).toBe(false);
+      });
+    });
+  });
+});

--- a/src/lib/backup-validator.ts
+++ b/src/lib/backup-validator.ts
@@ -1,0 +1,429 @@
+import type { BackupPayload } from "./google-drive";
+import type { StyleCard, CustomCategory, HistoryItem, UserSettings, PromptSegment } from "./db-schema";
+
+export interface ValidationResult {
+  isValid: boolean;
+  error?: string;
+}
+
+/**
+ * Validate that a value is a valid string
+ */
+function isString(val: any): boolean {
+  return typeof val === "string";
+}
+
+/**
+ * Validate that a value is a valid number
+ */
+function isNumber(val: any): boolean {
+  return typeof val === "number" && !isNaN(val);
+}
+
+/**
+ * Validate that a value is a boolean
+ */
+function isBoolean(val: any): boolean {
+  return typeof val === "boolean";
+}
+
+/**
+ * Validate that a value is an array of strings
+ */
+function isStringArray(val: any): boolean {
+  return Array.isArray(val) && val.every(item => typeof item === "string");
+}
+
+/**
+ * Validate CustomCategory schema
+ */
+export function validateCustomCategory(category: any, index: number): ValidationResult {
+  if (!category || typeof category !== "object") {
+    return { isValid: false, error: `Categories[${index}] is not an object.` };
+  }
+  if (!isString(category.id)) {
+    return { isValid: false, error: `Categories[${index}].id must be a string. Got: ${typeof category.id}` };
+  }
+  if (!isString(category.name)) {
+    return { isValid: false, error: `Categories[${index}] (${category.id}) must have a string 'name'.` };
+  }
+  if (category.iconEmoji !== undefined && !isString(category.iconEmoji)) {
+    return { isValid: false, error: `Categories[${index}] (${category.id}) has invalid 'iconEmoji'.` };
+  }
+  if (category.iconUrl !== undefined && !isString(category.iconUrl)) {
+    return { isValid: false, error: `Categories[${index}] (${category.id}) has invalid 'iconUrl'.` };
+  }
+  if (category.iconCardId !== undefined && !isString(category.iconCardId)) {
+    return { isValid: false, error: `Categories[${index}] (${category.id}) has invalid 'iconCardId'.` };
+  }
+  if (!isNumber(category.createdAt)) {
+    return { isValid: false, error: `Categories[${index}] (${category.id}) must have a numeric 'createdAt'.` };
+  }
+  return { isValid: true };
+}
+
+/**
+ * Validate PromptSegment schema
+ */
+function validatePromptSegment(segment: any, cardId: string, index: number): ValidationResult {
+  if (!segment || typeof segment !== "object") {
+    return { isValid: false, error: `Card(${cardId}) has invalid prompt segment at index ${index}: Not an object.` };
+  }
+  if (!isString(segment.type)) {
+    return { isValid: false, error: `Card(${cardId}) prompt segment[${index}] must have a string 'type'.` };
+  }
+
+  if (segment.type === "text") {
+    if (!isString(segment.value)) {
+      return { isValid: false, error: `Card(${cardId}) prompt segment[${index}] (text) must have a string 'value'.` };
+    }
+  } else if (segment.type === "slot") {
+    if (!isString(segment.label)) {
+      return { isValid: false, error: `Card(${cardId}) prompt segment[${index}] (slot) must have a string 'label'.` };
+    }
+    if (!isString(segment.default)) {
+      return { isValid: false, error: `Card(${cardId}) prompt segment[${index}] (slot) must have a string 'default'.` };
+    }
+  } else if (segment.type === "chip") {
+    if (segment.kind !== "sref" && segment.kind !== "cref") {
+      return { isValid: false, error: `Card(${cardId}) prompt segment[${index}] (chip) must have 'kind' as 'sref' or 'cref'.` };
+    }
+    if (!isString(segment.value)) {
+      return { isValid: false, error: `Card(${cardId}) prompt segment[${index}] (chip) must have a string 'value'.` };
+    }
+  } else {
+    return { isValid: false, error: `Card(${cardId}) prompt segment[${index}] has unknown type: '${segment.type}'.` };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validate StyleCard schema
+ */
+export function validateStyleCard(card: any, index: number): ValidationResult {
+  if (!card || typeof card !== "object") {
+    return { isValid: false, error: `StyleCards[${index}] is not an object.` };
+  }
+
+  const cardId = isString(card.id) ? card.id : `Index ${index}`;
+
+  // Basic Identity
+  if (!isString(card.id)) {
+    return { isValid: false, error: `StyleCards[${index}] must have a string 'id'.` };
+  }
+  if (!isString(card.name)) {
+    return { isValid: false, error: `Card(${cardId}) must have a string 'name'.` };
+  }
+  if (!isNumber(card.createdAt)) {
+    return { isValid: false, error: `Card(${cardId}) must have a numeric 'createdAt'.` };
+  }
+  if (!isNumber(card.updatedAt)) {
+    return { isValid: false, error: `Card(${cardId}) must have a numeric 'updatedAt'.` };
+  }
+
+  // Prompt Segments
+  if (!Array.isArray(card.promptSegments)) {
+    return { isValid: false, error: `Card(${cardId}) 'promptSegments' must be an array.` };
+  }
+  for (let i = 0; i < card.promptSegments.length; i++) {
+    const segmentResult = validatePromptSegment(card.promptSegments[i], cardId, i);
+    if (!segmentResult.isValid) return segmentResult;
+  }
+
+  // Parameters
+  if (!card.parameters || typeof card.parameters !== "object") {
+    return { isValid: false, error: `Card(${cardId}) must have a 'parameters' object.` };
+  }
+  const params = card.parameters;
+  if (params.ar !== undefined && !isString(params.ar)) {
+    return { isValid: false, error: `Card(${cardId}) parameter 'ar' must be a string.` };
+  }
+  if (params.sref !== undefined && !isStringArray(params.sref)) {
+    return { isValid: false, error: `Card(${cardId}) parameter 'sref' must be an array of strings.` };
+  }
+  if (params.cref !== undefined && !isStringArray(params.cref)) {
+    return { isValid: false, error: `Card(${cardId}) parameter 'cref' must be an array of strings.` };
+  }
+  if (params.p !== undefined && !isStringArray(params.p)) {
+    return { isValid: false, error: `Card(${cardId}) parameter 'p' must be an array of strings.` };
+  }
+  if (params.imagePrompts !== undefined && !isStringArray(params.imagePrompts)) {
+    return { isValid: false, error: `Card(${cardId}) parameter 'imagePrompts' must be an array of strings.` };
+  }
+  if (params.stylize !== undefined && !isNumber(params.stylize)) {
+    return { isValid: false, error: `Card(${cardId}) parameter 'stylize' must be a number.` };
+  }
+  if (params.chaos !== undefined && !isNumber(params.chaos)) {
+    return { isValid: false, error: `Card(${cardId}) parameter 'chaos' must be a number.` };
+  }
+  if (params.weird !== undefined && !isNumber(params.weird)) {
+    return { isValid: false, error: `Card(${cardId}) parameter 'weird' must be a number.` };
+  }
+  if (params.tile !== undefined && !isBoolean(params.tile)) {
+    return { isValid: false, error: `Card(${cardId}) parameter 'tile' must be a boolean.` };
+  }
+  if (params.raw !== undefined && !isBoolean(params.raw)) {
+    return { isValid: false, error: `Card(${cardId}) parameter 'raw' must be a boolean.` };
+  }
+
+  // Masking
+  if (!card.masking || typeof card.masking !== "object") {
+    return { isValid: false, error: `Card(${cardId}) must have a 'masking' object.` };
+  }
+  if (!isBoolean(card.masking.isSrefHidden)) {
+    return { isValid: false, error: `Card(${cardId}) 'masking.isSrefHidden' must be a boolean.` };
+  }
+  if (!isBoolean(card.masking.isPHidden)) {
+    return { isValid: false, error: `Card(${cardId}) 'masking.isPHidden' must be a boolean.` };
+  }
+
+  // TCG Attributes
+  const allowedTiers = ["Common", "Rare", "Epic", "Legendary"];
+  if (!allowedTiers.includes(card.tier)) {
+    return { isValid: false, error: `Card(${cardId}) has invalid tier: '${card.tier}'. Allowed: ${allowedTiers.join(", ")}` };
+  }
+  if (!isBoolean(card.isFavorite)) {
+    return { isValid: false, error: `Card(${cardId}) 'isFavorite' must be a boolean.` };
+  }
+  if (card.isPinned !== undefined && !isBoolean(card.isPinned)) {
+    return { isValid: false, error: `Card(${cardId}) 'isPinned' must be a boolean.` };
+  }
+  if (!isNumber(card.usageCount)) {
+    return { isValid: false, error: `Card(${cardId}) 'usageCount' must be a number.` };
+  }
+  if (!isStringArray(card.tags)) {
+    return { isValid: false, error: `Card(${cardId}) 'tags' must be an array of strings.` };
+  }
+  if (card.category !== undefined && !isString(card.category)) {
+    return { isValid: false, error: `Card(${cardId}) 'category' must be a string.` };
+  }
+  if (!isString(card.dominantColor)) {
+    return { isValid: false, error: `Card(${cardId}) 'dominantColor' must be a string.` };
+  }
+  if (card.accentColor !== undefined && !isString(card.accentColor)) {
+    return { isValid: false, error: `Card(${cardId}) 'accentColor' must be a string.` };
+  }
+
+  // Visuals
+  if (!isString(card.thumbnailData)) {
+    return { isValid: false, error: `Card(${cardId}) 'thumbnailData' must be a string.` };
+  }
+  if (!isString(card.frameId)) {
+    return { isValid: false, error: `Card(${cardId}) 'frameId' must be a string.` };
+  }
+
+  // Genealogy
+  if (!card.genealogy || typeof card.genealogy !== "object") {
+    return { isValid: false, error: `Card(${cardId}) must have a 'genealogy' object.` };
+  }
+  if (!isNumber(card.genealogy.generation)) {
+    return { isValid: false, error: `Card(${cardId}) 'genealogy.generation' must be a number.` };
+  }
+  if (!isStringArray(card.genealogy.parentIds)) {
+    return { isValid: false, error: `Card(${cardId}) 'genealogy.parentIds' must be an array of strings.` };
+  }
+  if (card.genealogy.originCreatorId !== undefined && !isString(card.genealogy.originCreatorId)) {
+    return { isValid: false, error: `Card(${cardId}) 'genealogy.originCreatorId' must be a string.` };
+  }
+  if (card.genealogy.mutationNote !== undefined && !isString(card.genealogy.mutationNote)) {
+    return { isValid: false, error: `Card(${cardId}) 'genealogy.mutationNote' must be a string.` };
+  }
+
+  // Variables, Job ID, etc.
+  if (card.isVariable !== undefined && !isBoolean(card.isVariable)) {
+    return { isValid: false, error: `Card(${cardId}) 'isVariable' must be a boolean.` };
+  }
+  if (card.jobId !== undefined && !isString(card.jobId)) {
+    return { isValid: false, error: `Card(${cardId}) 'jobId' must be a string.` };
+  }
+  if (card.associatedJobIds !== undefined && !isStringArray(card.associatedJobIds)) {
+    return { isValid: false, error: `Card(${cardId}) 'associatedJobIds' must be an array of strings.` };
+  }
+  if (card.images !== undefined && !isStringArray(card.images)) {
+    return { isValid: false, error: `Card(${cardId}) 'images' must be an array of strings.` };
+  }
+  if (card.selectedThumbnails !== undefined && !isStringArray(card.selectedThumbnails)) {
+    return { isValid: false, error: `Card(${cardId}) 'selectedThumbnails' must be an array of strings.` };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validate HistoryItem schema
+ */
+export function validateHistoryItem(item: any, index: number): ValidationResult {
+  if (!item || typeof item !== "object") {
+    return { isValid: false, error: `HistoryItems[${index}] is not an object.` };
+  }
+
+  const itemId = isString(item.id) ? item.id : `Index ${index}`;
+
+  if (!isString(item.id)) {
+    return { isValid: false, error: `HistoryItems[${index}] must have a string 'id'.` };
+  }
+  if (!isString(item.fullCommand)) {
+    return { isValid: false, error: `HistoryItem(${itemId}) must have a string 'fullCommand'.` };
+  }
+  if (!isString(item.imageUrl)) {
+    return { isValid: false, error: `HistoryItem(${itemId}) must have a string 'imageUrl'.` };
+  }
+  if (!isNumber(item.timestamp)) {
+    return { isValid: false, error: `HistoryItem(${itemId}) must have a numeric 'timestamp'.` };
+  }
+  if (item.relatedCardId !== undefined && !isString(item.relatedCardId)) {
+    return { isValid: false, error: `HistoryItem(${itemId}) 'relatedCardId' must be a string.` };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validate UserSettings schema
+ */
+export function validateUserSettings(setting: any, index: number): ValidationResult {
+  if (!setting || typeof setting !== "object") {
+    return { isValid: false, error: `UserSettings[${index}] is not an object.` };
+  }
+
+  const userId = isString(setting.userId) ? setting.userId : `Index ${index}`;
+
+  if (!isString(setting.userId)) {
+    return { isValid: false, error: `UserSettings[${index}] must have a string 'userId'.` };
+  }
+  if (!isBoolean(setting.isPro)) {
+    return { isValid: false, error: `UserSettings(${userId}) 'isPro' must be a boolean.` };
+  }
+  if (!isStringArray(setting.unlockedSkins)) {
+    return { isValid: false, error: `UserSettings(${userId}) 'unlockedSkins' must be an array of strings.` };
+  }
+
+  if (!setting.branding || typeof setting.branding !== "object") {
+    return { isValid: false, error: `UserSettings(${userId}) must have a 'branding' object.` };
+  }
+  if (!isBoolean(setting.branding.enabled)) {
+    return { isValid: false, error: `UserSettings(${userId}) 'branding.enabled' must be a boolean.` };
+  }
+  if (setting.branding.customLogo !== undefined && !isString(setting.branding.customLogo)) {
+    return { isValid: false, error: `UserSettings(${userId}) 'branding.customLogo' must be a string.` };
+  }
+  if (setting.branding.signatureName !== undefined && !isString(setting.branding.signatureName)) {
+    return { isValid: false, error: `UserSettings(${userId}) 'branding.signatureName' must be a string.` };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validate slotHistory
+ */
+export function validateSlotHistory(slotHistory: any): ValidationResult {
+  if (!slotHistory || typeof slotHistory !== "object") {
+    return { isValid: false, error: "slotHistory is not an object." };
+  }
+
+  for (const [key, val] of Object.entries(slotHistory)) {
+    if (!isString(key)) {
+      return { isValid: false, error: `slotHistory key must be a string. Got key type: ${typeof key}` };
+    }
+    if (!isStringArray(val)) {
+      return { isValid: false, error: `slotHistory[${key}] must be an array of strings.` };
+    }
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validate the entire BackupPayload schema and version compatibility
+ */
+export function validateBackupPayload(payload: any): ValidationResult {
+  if (!payload || typeof payload !== "object") {
+    return { isValid: false, error: "Backup data is not a valid JSON object." };
+  }
+
+  // Version Validation
+  if (payload.version === undefined) {
+    return { isValid: false, error: "Missing backup version metadata." };
+  }
+  if (!isNumber(payload.version)) {
+    return { isValid: false, error: `Backup version must be a number. Got: ${typeof payload.version}` };
+  }
+  
+  // Supplying a boundary for supported versions.
+  // Version 1 is the currently exported/supported format.
+  // If version is higher than 1, we consider it from a newer version of the extension and block it.
+  const SUPPORTED_VERSION = 1;
+  if (payload.version > SUPPORTED_VERSION) {
+    return { 
+      isValid: false, 
+      error: `Backup version (${payload.version}) is not supported. Max supported version is ${SUPPORTED_VERSION}. Please upgrade your extension.` 
+    };
+  }
+  if (payload.version < 1) {
+    return { isValid: false, error: `Invalid backup version: ${payload.version}.` };
+  }
+
+  // ExportedAt
+  if (!isNumber(payload.exportedAt)) {
+    return { isValid: false, error: "Missing or invalid 'exportedAt' timestamp." };
+  }
+
+  // Data Wrapper
+  if (!payload.data || typeof payload.data !== "object") {
+    return { isValid: false, error: "Missing or invalid 'data' property in backup payload." };
+  }
+
+  const { styleCards, categories, userSettings, historyItems, slotHistory } = payload.data;
+
+  // Validate StyleCards
+  if (!Array.isArray(styleCards)) {
+    return { isValid: false, error: "Missing or invalid 'data.styleCards' array." };
+  }
+  for (let i = 0; i < styleCards.length; i++) {
+    const res = validateStyleCard(styleCards[i], i);
+    if (!res.isValid) return res;
+  }
+
+  // Validate Categories
+  if (categories !== undefined) {
+    if (!Array.isArray(categories)) {
+      return { isValid: false, error: "Invalid 'data.categories': must be an array." };
+    }
+    for (let i = 0; i < categories.length; i++) {
+      const res = validateCustomCategory(categories[i], i);
+      if (!res.isValid) return res;
+    }
+  }
+
+  // Validate UserSettings
+  if (userSettings !== undefined) {
+    if (!Array.isArray(userSettings)) {
+      return { isValid: false, error: "Invalid 'data.userSettings': must be an array." };
+    }
+    for (let i = 0; i < userSettings.length; i++) {
+      const res = validateUserSettings(userSettings[i], i);
+      if (!res.isValid) return res;
+    }
+  }
+
+  // Validate HistoryItems
+  if (historyItems !== undefined) {
+    if (!Array.isArray(historyItems)) {
+      return { isValid: false, error: "Invalid 'data.historyItems': must be an array." };
+    }
+    for (let i = 0; i < historyItems.length; i++) {
+      const res = validateHistoryItem(historyItems[i], i);
+      if (!res.isValid) return res;
+    }
+  }
+
+  // Validate SlotHistory
+  if (slotHistory !== undefined) {
+    const res = validateSlotHistory(slotHistory);
+    if (!res.isValid) return res;
+  }
+
+  return { isValid: true };
+}

--- a/src/lib/google-drive.test.ts
+++ b/src/lib/google-drive.test.ts
@@ -97,15 +97,55 @@ describe("Google Drive Utilities (getAuthToken Flow)", () => {
   });
 
   describe("importDatabase", () => {
+    const mockStyleCard = {
+      id: "card-123",
+      name: "Mock Card",
+      createdAt: 123456789,
+      updatedAt: 123456789,
+      promptSegments: [{ type: "text", value: "test command" }],
+      parameters: { ar: "16:9" },
+      masking: { isSrefHidden: false, isPHidden: false },
+      tier: "Common",
+      isFavorite: false,
+      isPinned: false,
+      usageCount: 0,
+      tags: ["test"],
+      category: "cat1",
+      dominantColor: "#ffffff",
+      thumbnailData: "data:image/png;base64,abc",
+      frameId: "default",
+      genealogy: { generation: 1, parentIds: [] }
+    };
+
+    const mockCustomCategory = {
+      id: "cat1",
+      name: "Category 1",
+      createdAt: 123456789
+    };
+
+    const mockHistoryItem = {
+      id: "hist-123",
+      fullCommand: "full prompt",
+      imageUrl: "http://example.com/img.png",
+      timestamp: 123456789
+    };
+
+    const mockUserSettings = {
+      userId: "user-123",
+      isPro: false,
+      unlockedSkins: [],
+      branding: { enabled: false }
+    };
+
     it("should merge payload data into tables using bulkPut without clearing", async () => {
       const mockPayload = {
         version: 1,
         exportedAt: 123456,
         data: {
-          styleCards: [{ id: "c1", name: "Card C1" }],
-          categories: [{ id: "cat1", name: "Category 1" }],
-          userSettings: [{ userId: "u1", isPro: false }],
-          historyItems: [{ id: "h1", fullCommand: "cmd 1" }]
+          styleCards: [mockStyleCard],
+          categories: [mockCustomCategory],
+          userSettings: [mockUserSettings],
+          historyItems: [mockHistoryItem]
         }
       };
 
@@ -189,6 +229,38 @@ describe("Google Drive Utilities (getAuthToken Flow)", () => {
     it("should throw error if payload structure is invalid", async () => {
       const invalidPayload = { foo: "bar" };
       await expect(importDatabase(JSON.stringify(invalidPayload))).rejects.toThrow();
+    });
+
+    it("should throw error if backup version is unsupported", async () => {
+      const mockPayload = {
+        version: 2,
+        exportedAt: 123456,
+        data: {
+          styleCards: [],
+          categories: [],
+          userSettings: [],
+          historyItems: []
+        }
+      };
+      await expect(importDatabase(JSON.stringify(mockPayload))).rejects.toThrow(/version.*is not supported/);
+    });
+
+    it("should throw error if styleCards schema is invalid", async () => {
+      const invalidStyleCard = {
+        ...mockStyleCard,
+        tier: "UnknownTier"
+      };
+      const mockPayload = {
+        version: 1,
+        exportedAt: 123456,
+        data: {
+          styleCards: [invalidStyleCard],
+          categories: [],
+          userSettings: [],
+          historyItems: []
+        }
+      };
+      await expect(importDatabase(JSON.stringify(mockPayload))).rejects.toThrow(/invalid tier/);
     });
   });
 

--- a/src/lib/google-drive.ts
+++ b/src/lib/google-drive.ts
@@ -1,4 +1,6 @@
 import { db } from "./db";
+import { validateBackupPayload } from "./backup-validator";
+
 
 export interface BackupPayload {
   version: number;
@@ -98,13 +100,20 @@ export async function exportDatabase(): Promise<string> {
  * Clear existing IndexedDB tables and populate with imported JSON data
  */
 export async function importDatabase(jsonData: string): Promise<void> {
-  const payload = JSON.parse(jsonData) as BackupPayload;
-  
-  if (!payload.data || !payload.data.styleCards) {
-    throw new Error("Invalid backup data format: Missing styleCards.");
+  let payload: any;
+  try {
+    payload = JSON.parse(jsonData);
+  } catch (e) {
+    throw new Error("Invalid JSON format. Failed to parse backup file.");
+  }
+
+  const validation = validateBackupPayload(payload);
+  if (!validation.isValid) {
+    throw new Error(`Database validation failed: ${validation.error}`);
   }
 
   await db.transaction("rw", [db.styleCards, db.categories, db.userSettings, db.historyItems], async () => {
+
     if (payload.data.styleCards.length > 0) {
       await db.styleCards.bulkPut(payload.data.styleCards);
     }


### PR DESCRIPTION
Closes #184. Adds comprehensive unit tests for backup-validator.ts to cover all schema validation rules for custom categories, style cards, user settings, slot history, and backup payloads.