### PR TITLE
feat(library): implement style card deletion and category cover cleanup (fixes #193)

### DIFF
--- a/src/components/organisms/CardDetailView.test.tsx
+++ b/src/components/organisms/CardDetailView.test.tsx
@@ -168,4 +168,46 @@ describe("CardDetailView", () => {
     const { exportCardAsImage } = await import("../../lib/export-utils")
     expect(exportCardAsImage).toHaveBeenCalled()
   })
+
+  it("does not show delete button if onDelete is not provided", () => {
+    render(<CardDetailView {...defaultProps} onDelete={undefined} />)
+    expect(screen.queryByTestId("delete-card-button")).toBeNull()
+  })
+
+  it("shows delete button, opens confirmation modal, and cancels properly", () => {
+    const onDeleteMock = vi.fn().mockResolvedValue(undefined)
+    render(<CardDetailView {...defaultProps} onDelete={onDeleteMock} />)
+
+    const deleteButton = screen.getByTestId("delete-card-button")
+    expect(deleteButton).toBeDefined()
+
+    // Confirmation modal should not be visible initially
+    expect(screen.queryByTestId("delete-confirm-modal")).toBeNull()
+
+    // Click Delete -> should show confirm modal
+    fireEvent.click(deleteButton)
+    expect(screen.getByTestId("delete-confirm-modal")).toBeDefined()
+
+    // Click cancel -> modal closes, onDelete not called
+    const cancelButton = screen.getByTestId("delete-confirm-cancel-button")
+    fireEvent.click(cancelButton)
+    expect(screen.queryByTestId("delete-confirm-modal")).toBeNull()
+    expect(onDeleteMock).not.toHaveBeenCalled()
+  })
+
+  it("calls onDelete when confirmed in modal", async () => {
+    const onDeleteMock = vi.fn().mockResolvedValue(undefined)
+    render(<CardDetailView {...defaultProps} onDelete={onDeleteMock} />)
+
+    const deleteButton = screen.getByTestId("delete-card-button")
+    fireEvent.click(deleteButton)
+
+    const okButton = screen.getByTestId("delete-confirm-ok-button")
+    await act(async () => {
+      fireEvent.click(okButton)
+    })
+
+    expect(onDeleteMock).toHaveBeenCalledWith("card-uuid-1")
+    expect(screen.queryByTestId("delete-confirm-modal")).toBeNull()
+  })
 })

--- a/src/components/organisms/CardDetailView.tsx
+++ b/src/components/organisms/CardDetailView.tsx
@@ -9,7 +9,7 @@ import { Input } from "../atoms/Input";
 import { useHand } from "../../hooks/useHand";
 import { db } from "../../lib/db";
 import { buildPromptString } from "../../lib/prompt-utils";
-import { X, Send, Save, Download } from "lucide-react";
+import { X, Send, Save, Download, Trash2 } from "lucide-react";
 import type { AlertType } from "../molecules/ConnectionAlert";
 import { useLiveQuery } from "dexie-react-hooks";
 import { exportCardAsImage } from "../../lib/export-utils";
@@ -30,6 +30,8 @@ interface CardDetailViewProps {
   onSave: (updatedCard: StyleCard) => Promise<void>;
   /** Callback to update the alert state */
   setAlertType: (type: AlertType) => void;
+  /** Callback to delete the StyleCard */
+  onDelete?: (cardId: string) => Promise<void>;
 }
 
 /**
@@ -43,6 +45,7 @@ export function CardDetailView({
   onInject,
   onSave,
   setAlertType,
+  onDelete,
 }: CardDetailViewProps) {
   const { pinnedCards } = useHand();
   const hasPinnedCards = pinnedCards.length > 0;
@@ -64,6 +67,7 @@ export function CardDetailView({
   const images = card.images && card.images.length > 0 ? card.images : [card.thumbnailData].filter(Boolean);
   const [selectedThumbs, setSelectedThumbs] = useState<string[]>(card.selectedThumbnails || (card.thumbnailData ? [card.thumbnailData] : []));
   const [isExporting, setIsExporting] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const handleExportCard = async () => {
     setIsExporting(true);
@@ -299,6 +303,17 @@ export function CardDetailView({
       {/* Footer Actions */}
       <div className="p-4 bg-white shadow-t-sm flex justify-between gap-2 border-t z-10">
         <div className="flex gap-2">
+          {onDelete && (
+            <Button
+              variant="danger"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="flex items-center gap-1.5"
+              data-testid="delete-card-button"
+            >
+              <Trash2 className="w-4 h-4" />
+              Delete
+            </Button>
+          )}
           <Button variant="ghost" onClick={onClose}>
             Cancel
           </Button>
@@ -331,6 +346,51 @@ export function CardDetailView({
           </Button>
         </div>
       </div>
+
+      {/* Confirmation Modal */}
+      {showDeleteConfirm && (
+        <div
+          data-testid="delete-confirm-modal"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 backdrop-blur-sm p-4 animate-in fade-in duration-200"
+        >
+          <div className="w-full max-w-sm bg-white border border-slate-200 rounded-2xl shadow-2xl overflow-hidden p-6 space-y-4 animate-in zoom-in-95 duration-200">
+            <div className="flex flex-col items-center gap-3">
+              <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center text-red-600">
+                <Trash2 className="w-6 h-6" />
+              </div>
+              <h3 className="text-lg font-bold text-slate-900 text-center">
+                Cardを削除しますか？
+              </h3>
+              <p className="text-xs text-slate-500 leading-relaxed text-center">
+                この操作は取り消せません。"{name}" をライブラリから完全に削除します。
+              </p>
+            </div>
+            <div className="flex gap-3">
+              <Button
+                variant="outline"
+                fullWidth
+                onClick={() => setShowDeleteConfirm(false)}
+                data-testid="delete-confirm-cancel-button"
+              >
+                キャンセル
+              </Button>
+              <Button
+                variant="danger"
+                fullWidth
+                onClick={async () => {
+                  if (onDelete) {
+                    await onDelete(card.id);
+                  }
+                  setShowDeleteConfirm(false);
+                }}
+                data-testid="delete-confirm-ok-button"
+              >
+                削除する
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { seedDefaultCategories, upgradeToVersion8 } from "./db";
+import { seedDefaultCategories, upgradeToVersion8, StyleAtelierDatabase } from "./db";
 
 describe("db utilities", () => {
   describe("upgradeToVersion8", () => {
@@ -63,6 +63,60 @@ describe("db utilities", () => {
         iconEmoji: "👤",
       });
       expect(categoriesPassed[0].createdAt).toBeTypeOf("number");
+    });
+  });
+
+  describe("deleteStyleCardAndCleanup", () => {
+    it("should delete the card and clear category cover references if it is used as iconCardId", async () => {
+      // Mock db implementation for this test case
+      const mockCategories = [
+        { id: "cat-1", name: "Cat 1", iconCardId: "card-delete-me", iconUrl: "data:image/png;..." },
+        { id: "cat-2", name: "Cat 2", iconCardId: "card-keep-me", iconUrl: "data:image/png;..." },
+      ];
+
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      const mockFilter = vi.fn().mockReturnValue({
+        toArray: vi.fn().mockResolvedValue([mockCategories[0]]),
+      });
+      const mockDelete = vi.fn().mockResolvedValue(undefined);
+
+      const mockDbInstance = {
+        categories: {
+          filter: mockFilter,
+          update: mockUpdate,
+        },
+        styleCards: {
+          delete: mockDelete,
+        },
+        transaction: vi.fn(async (mode, tables, callback) => {
+          return callback();
+        }),
+      } as any;
+
+      // Call the method on our mocked DB instance
+      await StyleAtelierDatabase.prototype.deleteStyleCardAndCleanup.call(mockDbInstance, "card-delete-me");
+
+      // Verify the transaction was called correctly
+      expect(mockDbInstance.transaction).toHaveBeenCalledWith(
+        "rw",
+        [mockDbInstance.styleCards, mockDbInstance.categories],
+        expect.any(Function)
+      );
+
+      // Verify category filter queried for the correct cardId
+      expect(mockFilter).toHaveBeenCalled();
+      const filterFn = mockFilter.mock.calls[0][0];
+      expect(filterFn({ iconCardId: "card-delete-me" })).toBe(true);
+      expect(filterFn({ iconCardId: "card-keep-me" })).toBe(false);
+
+      // Verify category update cleared the references
+      expect(mockUpdate).toHaveBeenCalledWith("cat-1", {
+        iconCardId: undefined,
+        iconUrl: undefined,
+      });
+
+      // Verify card was deleted
+      expect(mockDelete).toHaveBeenCalledWith("card-delete-me");
     });
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -55,7 +55,22 @@ export class StyleAtelierDatabase extends Dexie {
     }).upgrade(upgradeToVersion8);
   }
 
-  // TODO: Implement new data access methods
+  async deleteStyleCardAndCleanup(cardId: string) {
+    return this.transaction("rw", [this.styleCards, this.categories], async () => {
+      // 1. categories で iconCardId === cardId を持つものをクリーンアップ
+      const affectedCategories = await this.categories
+        .filter((cat) => cat.iconCardId === cardId)
+        .toArray();
+      for (const cat of affectedCategories) {
+        await this.categories.update(cat.id, {
+          iconCardId: undefined,
+          iconUrl: undefined,
+        });
+      }
+      // 2. styleCards から削除
+      await this.styleCards.delete(cardId);
+    });
+  }
 }
 
 export const db = new StyleAtelierDatabase();

--- a/src/pages/SidePanel.tsx
+++ b/src/pages/SidePanel.tsx
@@ -97,6 +97,17 @@ function SidePanelInner() {
     }
   }
 
+  const handleDeleteCard = async (cardId: string) => {
+    try {
+      await db.deleteStyleCardAndCleanup(cardId);
+      addLog("StyleCard deleted successfully.");
+      setActiveDetailCard(null);
+    } catch (err) {
+      console.error("Failed to delete style card:", err);
+      addLog("Error: Failed to delete style card.");
+    }
+  };
+
   const handleInjectPrompt = async (prompt: string) => {
     setAlertType(null);
     try {
@@ -297,6 +308,7 @@ function SidePanelInner() {
               onInject={handleInjectPrompt}
               onSave={handleSaveCardDetails}
               setAlertType={setAlertType}
+              onDelete={handleDeleteCard}
             />
           )}
           {activeTab === "history" && <HistoryTab onStartMinting={handleStartMinting} />}


### PR DESCRIPTION
## Overview
ライブラリから不要になったスタイルカードを個別に削除する機能を追加し、関連するカテゴリ（削除対象のカードをカバー画像に指定しているもの）のクリーンアップ処理を実装しました。

## Changes
- **データベース層 (`src/lib/db.ts`)**: 指定されたカードを `styleCards` から削除し、同時に `categories` のカバー画像参照 (`iconCardId`, `iconUrl`) を安全にクリアする `deleteStyleCardAndCleanup` トランザクションメソッドを実装しました。
- **UI (`src/components/organisms/CardDetailView.tsx`)**: 詳細ビューのフッターに「Delete」ボタンを追加し、グラスモフィズム背景のプレミアムな削除確認ダイアログ（Confirmation Modal）を実装しました。
- **結合部 (`src/pages/SidePanel.tsx`)**: `CardDetailView` に削除用ハンドラーを繋ぎ込みました。
- **テスト (`CardDetailView.test.tsx`, `db.test.ts`)**: 削除ボタンの挙動、確認モーダルの動作、およびデータベース層でのクリーンアップトランザクションのユニットテストを追加しました。

Fixes #193
