### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/src/lib/mj-parser.ts
+++ b/src/lib/mj-parser.ts
@@ -7,10 +7,16 @@ export const extractJobIdFromUrl = (url: string): string | undefined => {
     if (match) return match[1]
   }
 
-  // 2. Check for MJ CDN URL
-  if (url.includes("cdn.midjourney.com")) {
-    const match = url.match(uuidPattern)
-    if (match) return match[1]
+  // 2. Check for MJ CDN URL host
+  try {
+    const parsedUrl = new URL(url)
+    const allowedHosts = ["cdn.midjourney.com"]
+    if (allowedHosts.includes(parsedUrl.hostname.toLowerCase())) {
+      const match = url.match(uuidPattern)
+      if (match) return match[1]
+    }
+  } catch {
+    // Ignore invalid URLs and fall through
   }
   
   return undefined


### PR DESCRIPTION
Potential fix for [https://github.com/tmaeda11235/style-atelier/security/code-scanning/7](https://github.com/tmaeda11235/style-atelier/security/code-scanning/7)

Use URL parsing and hostname validation instead of substring matching on the raw URL string.

Best fix in this file:
- In `extractJobIdFromUrl` (lines 1–17), replace the `url.includes("cdn.midjourney.com")` branch with:
  - `new URL(url)` parsing in a `try/catch`.
  - Hostname check against an explicit allowlist (`cdn.midjourney.com`), optionally normalized to lowercase.
  - Keep existing UUID extraction behavior unchanged when host is allowed.
- Keep `/jobs/` logic intact to avoid changing existing behavior beyond the vulnerable check.
- No new dependency is required; `URL` is built-in.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
