### PR TITLE
feat: データ復元（Restore）実行前にGoogle Drive上のバックアップ日時・サイズを表示するプレビュー機能 (#122)

### DIFF
--- a/src/components/organisms/SettingsTab.test.tsx
+++ b/src/components/organisms/SettingsTab.test.tsx
@@ -292,7 +292,9 @@ describe("SettingsTab", () => {
 
     // First restore attempt
     fireEvent.click(restoreBtn);
-    expect(window.confirm).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledTimes(1);
+    });
     expect(vi.mocked(window.confirm).mock.calls[0][0]).toContain("クラウド上のバックアップ情報");
     expect(vi.mocked(window.confirm).mock.calls[0][0]).toContain("150.0 KB");
 
@@ -306,7 +308,9 @@ describe("SettingsTab", () => {
 
     // Second restore attempt - should still prompt confirmation
     fireEvent.click(restoreBtn);
-    expect(window.confirm).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("shows confirmation dialog in English when language is English", async () => {
@@ -340,7 +344,9 @@ describe("SettingsTab", () => {
     expect(restoreBtn).not.toBeDisabled();
 
     fireEvent.click(restoreBtn);
-    expect(window.confirm).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledTimes(1);
+    });
     expect(vi.mocked(window.confirm).mock.calls[0][0]).toContain("[Cloud Backup Information]");
     expect(vi.mocked(window.confirm).mock.calls[0][0]).toContain("150.0 KB");
   });
@@ -364,7 +370,9 @@ describe("SettingsTab", () => {
     const restoreBtn = screen.getByRole("button", { name: /Google Driveから強制リカバリ/i });
     fireEvent.click(restoreBtn);
 
-    expect(window.confirm).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledTimes(1);
+    });
     expect(googleDrive.downloadBackup).not.toHaveBeenCalled();
     expect(googleDrive.importDatabase).not.toHaveBeenCalled();
   });

--- a/src/components/organisms/SettingsTab.test.tsx
+++ b/src/components/organisms/SettingsTab.test.tsx
@@ -84,6 +84,13 @@ describe("SettingsTab", () => {
       configurable: true,
       writable: true
     });
+
+    // Mock navigator.language to default to Japanese for existing tests
+    Object.defineProperty(window.navigator, "language", {
+      value: "ja-JP",
+      configurable: true,
+      writable: true
+    });
   });
 
   afterEach(() => {
@@ -300,6 +307,42 @@ describe("SettingsTab", () => {
     // Second restore attempt - should still prompt confirmation
     fireEvent.click(restoreBtn);
     expect(window.confirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows confirmation dialog in English when language is English", async () => {
+    // Override navigator.language to English
+    Object.defineProperty(window.navigator, "language", {
+      value: "en-US",
+      configurable: true,
+      writable: true
+    });
+
+    vi.mocked(googleDrive.authorize).mockResolvedValue("mock-token-123");
+    vi.mocked(googleDrive.getBackupMetadata).mockResolvedValue({
+      id: "file-123",
+      modifiedTime: "2026-06-03T12:00:00.000Z",
+      size: "153600",
+    });
+    vi.mocked(googleDrive.downloadBackup).mockResolvedValue("mock-backup-data");
+    vi.mocked(googleDrive.importDatabase).mockResolvedValue(undefined);
+
+    render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
+
+    // Enable sync
+    const toggleBtn = screen.getByRole("button", { name: "" });
+    fireEvent.click(toggleBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Cloud Backup Preview")).toBeDefined();
+    });
+
+    const restoreBtn = screen.getByRole("button", { name: /Force Restore from Google Drive/i });
+    expect(restoreBtn).not.toBeDisabled();
+
+    fireEvent.click(restoreBtn);
+    expect(window.confirm).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(window.confirm).mock.calls[0][0]).toContain("[Cloud Backup Information]");
+    expect(vi.mocked(window.confirm).mock.calls[0][0]).toContain("150.0 KB");
   });
 
   it("aborts force recovery if user cancels confirmation dialog", async () => {

--- a/src/components/organisms/SettingsTab.tsx
+++ b/src/components/organisms/SettingsTab.tsx
@@ -268,25 +268,45 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
   };
 
   const handleForceRecovery = async () => {
-    if (!isSyncEnabled) return;
+    if (!isSyncEnabled || isSyncing || isRestoring) return;
     
-    let confirmMsg = t.restoreConfirmMsg;
-    if (cloudBackup) {
-      confirmMsg += `\n\n${t.restoreConfirmHeader}\n${t.restoreConfirmTime}${cloudBackup.modifiedTime}\n${t.restoreConfirmSize}${cloudBackup.size}`;
-    }
-    
-    const ok = window.confirm(confirmMsg);
-    if (!ok) return;
-
     setIsRestoring(true);
-    setRestoreProgress(0);
-    setStatusMessage({ text: "Google Driveから強制リカバリ中 (0%)...", type: "info" });
-
+    setStatusMessage({ text: t.loadingCloudBackup, type: "info" });
+    
     const controller = new AbortController();
     abortControllerRef.current = controller;
 
     try {
       const token = await getOrRequestToken();
+      
+      // Fetch latest backup metadata before confirmation to ensure accuracy
+      const meta = await getBackupMetadata(token, setAccessToken, undefined, { signal: controller.signal });
+      let currentBackup = cloudBackup;
+      if (meta) {
+        const dateStr = new Date(meta.modifiedTime).toLocaleString();
+        const sizeKB = (parseInt(meta.size) / 1024).toFixed(1);
+        currentBackup = {
+          modifiedTime: dateStr,
+          size: `${sizeKB} KB`
+        };
+        setCloudBackup(currentBackup);
+      } else {
+        setCloudBackup(null);
+        currentBackup = null;
+      }
+
+      let confirmMsg = t.restoreConfirmMsg;
+      if (currentBackup) {
+        confirmMsg += `\n\n${t.restoreConfirmHeader}\n${t.restoreConfirmTime}${currentBackup.modifiedTime}\n${t.restoreConfirmSize}${currentBackup.size}`;
+      }
+      
+      setStatusMessage({ text: "", type: null });
+      const ok = window.confirm(confirmMsg);
+      if (!ok) return;
+
+      setRestoreProgress(0);
+      setStatusMessage({ text: "Google Driveから強制リカバリ中 (0%)...", type: "info" });
+      
       const backupData = await downloadBackup(token, setAccessToken, (percent) => {
         setRestoreProgress(percent);
         setStatusMessage({ text: `データをダウンロード中 (${percent}%)...`, type: "info" });

--- a/src/components/organisms/SettingsTab.tsx
+++ b/src/components/organisms/SettingsTab.tsx
@@ -39,6 +39,25 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
   const abortControllerRef = useRef<AbortController | null>(null);
   const { estimate, checkStorage } = useStorageEstimate();
 
+  const isJapanese = typeof navigator !== "undefined" && navigator.language?.startsWith("ja");
+  const t = {
+    cloudBackupLabel: isJapanese ? "クラウド上のバックアップ: " : "Cloud Backup: ",
+    loadingCloudBackup: isJapanese ? "クラウド情報を取得中..." : "Fetching cloud backup info...",
+    noCloudBackup: isJapanese ? "クラウド上のバックアップファイルが見つかりません" : "No cloud backup file found",
+    lastBackupLabel: isJapanese ? "ローカル最終バックアップ: " : "Last Local Backup: ",
+    syncingText: isJapanese ? "同期中..." : "Syncing...",
+    syncButtonText: isJapanese ? "Google Driveと同期 (Sync)" : "Sync with Google Drive",
+    restoreConfirmMsg: isJapanese
+      ? "Google Driveからデータを強制リカバリ（ロード）し、現在のローカルデータを完全に削除してバックアップの内容で置き換えます。\n現在のローカルデータ（この端末で新規作成したカードも含む）はすべて失われます。この操作は取り消せません。本当によろしいですか？"
+      : "Force recover database from Google Drive. This will completely overwrite all local data. Your current cards and configurations will be lost forever. This action cannot be undone. Are you sure?",
+    restoreConfirmHeader: isJapanese
+      ? "【クラウド上のバックアップ情報】"
+      : "[Cloud Backup Information]",
+    restoreConfirmTime: isJapanese ? "更新日時: " : "Modified Time: ",
+    restoreConfirmSize: isJapanese ? "サイズ: " : "Size: ",
+    restoreBtnText: isJapanese ? "Google Driveから強制リカバリ" : "Force Restore from Google Drive"
+  };
+
   // Sync toggle state
   const [isSyncEnabled, setIsSyncEnabled] = useState(false);
 
@@ -251,9 +270,9 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
   const handleForceRecovery = async () => {
     if (!isSyncEnabled) return;
     
-    let confirmMsg = "Google Driveからデータを強制リカバリ（ロード）し、現在のローカルデータを完全に削除してバックアップの内容で置き換えます。\n現在のローカルデータ（この端末で新規作成したカードも含む）はすべて失われます。この操作は取り消せません。本当によろしいですか？";
+    let confirmMsg = t.restoreConfirmMsg;
     if (cloudBackup) {
-      confirmMsg += `\n\n【クラウド上のバックアップ情報】\n更新日時: ${cloudBackup.modifiedTime}\nサイズ: ${cloudBackup.size}`;
+      confirmMsg += `\n\n${t.restoreConfirmHeader}\n${t.restoreConfirmTime}${cloudBackup.modifiedTime}\n${t.restoreConfirmSize}${cloudBackup.size}`;
     }
     
     const ok = window.confirm(confirmMsg);
@@ -441,6 +460,7 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
           </div>
           <button
             type="button"
+            id="google-drive-toggle-btn"
             onClick={() => handleToggleSync(!isSyncEnabled)}
             className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
               isSyncEnabled ? "bg-blue-600" : "bg-slate-200"
@@ -701,23 +721,41 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
             <p className="text-[10px] text-red-600/80 leading-relaxed">
               Reset the database to its pristine state, or force recover database from Google Drive by overwriting local changes.
             </p>
-            <div className="flex flex-wrap gap-2 mt-2">
-              <button
-                onClick={handleResetDbClick}
-                className="px-3 py-2 bg-red-600 hover:bg-red-700 hover:shadow-sm text-white text-[10px] font-bold rounded-xl transition-all duration-150 flex items-center gap-1.5"
-              >
-                <Database className="w-3.5 h-3.5" />
-                Reset Local Database
-              </button>
-              <button
-                onClick={handleForceRecovery}
-                disabled={!isSyncEnabled || isSyncing || isRestoring}
-                className="px-3 py-2 bg-white hover:bg-red-50 border border-red-200 text-red-700 text-[10px] font-bold rounded-xl transition-all duration-150 flex items-center gap-1.5 disabled:opacity-30"
-                id="force-recovery-btn"
-              >
-                <DownloadCloud className="w-3.5 h-3.5 text-red-500" />
-                Google Driveから強制リカバリ
-              </button>
+            <div className="flex flex-col gap-2 mt-2">
+              {isSyncEnabled && (
+                <div className="text-[10px] text-slate-500 font-medium mb-1 flex items-center gap-1">
+                  {isLoadingCloudBackup ? (
+                    <span className="text-blue-500 animate-pulse flex items-center gap-1">
+                      <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+                      {t.loadingCloudBackup}
+                    </span>
+                  ) : cloudBackup ? (
+                    <span>
+                      {t.cloudBackupLabel}{cloudBackup.modifiedTime} ({cloudBackup.size})
+                    </span>
+                  ) : (
+                    <span className="text-slate-400">{t.noCloudBackup}</span>
+                  )}
+                </div>
+              )}
+              <div className="flex flex-wrap gap-2">
+                <button
+                  onClick={handleResetDbClick}
+                  className="px-3 py-2 bg-red-600 hover:bg-red-700 hover:shadow-sm text-white text-[10px] font-bold rounded-xl transition-all duration-150 flex items-center gap-1.5"
+                >
+                  <Database className="w-3.5 h-3.5" />
+                  Reset Local Database
+                </button>
+                <button
+                  onClick={handleForceRecovery}
+                  disabled={!isSyncEnabled || isSyncing || isRestoring}
+                  className="px-3 py-2 bg-white hover:bg-red-50 border border-red-200 text-red-700 text-[10px] font-bold rounded-xl transition-all duration-150 flex items-center gap-1.5 disabled:opacity-30"
+                  id="force-recovery-btn"
+                >
+                  <DownloadCloud className="w-3.5 h-3.5 text-red-500" />
+                  {t.restoreBtnText}
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -1139,6 +1139,24 @@ test.describe("Style Atelier Sandbox E2E Tests", () => {
 
   test("should allow selecting restore mode and verify replace/merge behavior", async ({ page }) => {
     const screenshotsDir = path.join(__dirname, "../../tests/screenshots");
+
+    // Mock Google Drive API response
+    await page.route("https://www.googleapis.com/drive/v3/files*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          files: [
+            {
+              id: "mock-file-123",
+              modifiedTime: "2026-06-03 12:00:00",
+              size: "153600" // 150.0 KB
+            }
+          ]
+        })
+      });
+    });
+
     console.log("Navigating to sandbox page for Restore Mode E2E test...");
     await page.goto("/tests/sandbox/index.html");
 
@@ -1160,6 +1178,20 @@ test.describe("Style Atelier Sandbox E2E Tests", () => {
     const forceRecoveryBtn = spFrame.locator("#force-recovery-btn");
     await expect(syncBtn).toBeVisible({ timeout: 10000 });
     await expect(forceRecoveryBtn).toBeVisible();
+
+    // Enable Google Drive synchronization
+    console.log("Enabling Google Drive sync...");
+    const toggleBtn = spFrame.locator("#google-drive-toggle-btn");
+    await expect(toggleBtn).toBeVisible();
+    await toggleBtn.click();
+
+    // Wait for the cloud backup preview to appear
+    console.log("Waiting for cloud backup preview...");
+    const previewEl = spFrame.locator("text=150.0 KB").first();
+    await expect(previewEl).toBeVisible({ timeout: 10000 });
+
+    // Scroll to the Force Recovery button to bring the Danger Zone preview into view
+    await forceRecoveryBtn.scrollIntoViewIfNeeded();
 
     // 4. Capture screenshot of Settings tab with new UI
     await page.screenshot({

--- a/tests/sandbox/main.tsx
+++ b/tests/sandbox/main.tsx
@@ -123,6 +123,16 @@ if (typeof window !== "undefined") {
         addListener: () => {},
         removeListener: () => {},
       }
+    },
+    identity: {
+      getAuthToken: (details: any, callback: any) => {
+        if (callback) callback("mock-token-123");
+        return Promise.resolve("mock-token-123");
+      },
+      removeCachedAuthToken: (details: any, callback: any) => {
+        if (callback) callback();
+        return Promise.resolve();
+      }
     }
   };
 }


### PR DESCRIPTION
Google Driveからの強制リカバリ実行前に、クラウド上のバックアップ情報の更新日時とサイズを表示するプレビュー機能を追加しました。

### 変更内容
1. **バックアッププレビューUIの追加**:
   - `SettingsTab.tsx` の Danger Zone (強制リカバリボタン直上) に、クラウドバックアップ情報のプレビュー表示を追加しました。
   - バックアップ情報の読み込み中・存在しない場合の表示にも対応。
2. **多言語化 (i18n) 対応**:
   - ロケール（日本語/英語）に応じて、表示テキストおよび確認ダイアログのメッセージを動的に切り替えるようにしました。
3. **テストの追加と更新**:
   - ユニットテスト (`SettingsTab.test.tsx`) において、英語ロケール時の確認メッセージの検証を追加。
   - E2Eテスト (`extension.spec.ts`) において、実際にGoogle Drive同期を有効化し、プレビュー情報が正しく表示されるかのシナリオを追加。

### UXスクリーンショット (E2Eテスト時の撮影結果)
![restore-mode-ui.png](https://github.com/user-attachments/assets/61939dd1-91e6-4566-9701-fe6ecd17931a)

Closes #122
