### PR TITLE
feat(easy-mode): implement easy mode library layout and toggle

### DIFF
--- a/src/components/organisms/SettingsTab.test.tsx
+++ b/src/components/organisms/SettingsTab.test.tsx
@@ -248,9 +248,9 @@ describe("SettingsTab", () => {
       size: "153600", // 150 KB
     });
 
-    render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
+    const { container } = render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
 
-    const toggleBtn = screen.getByRole("button", { name: "" }); // Switch button has no name text inside but is a button
+    const toggleBtn = container.querySelector("#google-drive-toggle-btn")!;
     fireEvent.click(toggleBtn);
 
     await waitFor(() => {
@@ -276,10 +276,10 @@ describe("SettingsTab", () => {
     vi.mocked(googleDrive.downloadBackup).mockResolvedValue("mock-backup-data");
     vi.mocked(googleDrive.importDatabase).mockResolvedValue(undefined);
 
-    render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
+    const { container } = render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
 
     // Enable sync
-    const toggleBtn = screen.getByRole("button", { name: "" });
+    const toggleBtn = container.querySelector("#google-drive-toggle-btn")!;
     fireEvent.click(toggleBtn);
 
     // Wait for sync to be enabled
@@ -330,10 +330,10 @@ describe("SettingsTab", () => {
     vi.mocked(googleDrive.downloadBackup).mockResolvedValue("mock-backup-data");
     vi.mocked(googleDrive.importDatabase).mockResolvedValue(undefined);
 
-    render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
+    const { container } = render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
 
     // Enable sync
-    const toggleBtn = screen.getByRole("button", { name: "" });
+    const toggleBtn = container.querySelector("#google-drive-toggle-btn")!;
     fireEvent.click(toggleBtn);
 
     await waitFor(() => {
@@ -356,10 +356,10 @@ describe("SettingsTab", () => {
     vi.mocked(googleDrive.authorize).mockResolvedValue("mock-token-123");
     vi.mocked(googleDrive.getBackupMetadata).mockResolvedValue(null);
 
-    render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
+    const { container } = render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
 
     // Enable sync
-    const toggleBtn = screen.getByRole("button", { name: "" });
+    const toggleBtn = container.querySelector("#google-drive-toggle-btn")!;
     fireEvent.click(toggleBtn);
 
     await waitFor(() => {
@@ -393,10 +393,10 @@ describe("SettingsTab", () => {
       });
       vi.mocked(googleDrive.downloadBackup).mockReturnValue(downloadPromise);
 
-      render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
+      const { container } = render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
 
       // Enable sync
-      const toggleBtn = screen.getByRole("button", { name: "" });
+      const toggleBtn = container.querySelector("#google-drive-toggle-btn")!;
       fireEvent.click(toggleBtn);
 
       await waitFor(() => {
@@ -428,10 +428,10 @@ describe("SettingsTab", () => {
     it("handles connection timeout error gracefully", async () => {
       vi.mocked(googleDrive.downloadBackup).mockRejectedValue(new googleDrive.GDriveTimeoutError());
 
-      render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
+      const { container } = render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
 
       // Enable sync
-      const toggleBtn = screen.getByRole("button", { name: "" });
+      const toggleBtn = container.querySelector("#google-drive-toggle-btn")!;
       fireEvent.click(toggleBtn);
 
       await waitFor(() => {
@@ -528,10 +528,10 @@ describe("SettingsTab", () => {
       }
     );
 
-    render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
+    const { container } = render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
 
     // Enable sync
-    const toggleBtn = screen.getByRole("button", { name: "" });
+    const toggleBtn = container.querySelector("#google-drive-toggle-btn")!;
     fireEvent.click(toggleBtn);
 
     // Wait for sync to be enabled
@@ -568,10 +568,10 @@ describe("SettingsTab", () => {
       }
     );
 
-    render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
+    const { container } = render(<SettingsTab addLog={mockAddLog} onResetDb={mockResetDb} />);
 
     // Enable sync
-    const toggleBtn = screen.getByRole("button", { name: "" });
+    const toggleBtn = container.querySelector("#google-drive-toggle-btn")!;
     fireEvent.click(toggleBtn);
 
     // Wait for sync to be enabled
@@ -595,5 +595,41 @@ describe("SettingsTab", () => {
 
     // Check status message displays progress
     expect(screen.getByText("データをダウンロード中 (60%)...")).toBeDefined();
+  });
+
+  // --- Easy Mode Tests ---
+
+  it("renders Interface Mode Settings card correctly", () => {
+    render(
+      <SettingsTab
+        addLog={mockAddLog}
+        onResetDb={mockResetDb}
+        isEasyMode={false}
+      />
+    );
+
+    expect(screen.getByText("かんたんモード (Easy Mode)")).toBeDefined();
+    expect(screen.getByText("かんたんモードを有効にする")).toBeDefined();
+  });
+
+  it("calls onToggleEasyMode when the toggle button is clicked", () => {
+    const mockToggleEasyMode = vi.fn();
+    const { container } = render(
+      <SettingsTab
+        addLog={mockAddLog}
+        onResetDb={mockResetDb}
+        isEasyMode={false}
+        onToggleEasyMode={mockToggleEasyMode}
+      />
+    );
+
+    const toggleBtn = container.querySelector("#easy-mode-toggle-btn");
+    expect(toggleBtn).not.toBeNull();
+    
+    if (toggleBtn) {
+      fireEvent.click(toggleBtn);
+    }
+
+    expect(mockToggleEasyMode).toHaveBeenCalledWith(true);
   });
 });

--- a/src/components/organisms/SettingsTab.tsx
+++ b/src/components/organisms/SettingsTab.tsx
@@ -32,9 +32,16 @@ import { db } from "../../lib/db";
 interface SettingsTabProps {
   addLog: (log: string) => void;
   onResetDb: () => void;
+  isEasyMode?: boolean;
+  onToggleEasyMode?: (checked: boolean) => void;
 }
 
-export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
+export function SettingsTab({ 
+  addLog, 
+  onResetDb, 
+  isEasyMode = false, 
+  onToggleEasyMode = () => {} 
+}: SettingsTabProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const { estimate, checkStorage } = useStorageEstimate();
@@ -55,7 +62,13 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
       : "[Cloud Backup Information]",
     restoreConfirmTime: isJapanese ? "更新日時: " : "Modified Time: ",
     restoreConfirmSize: isJapanese ? "サイズ: " : "Size: ",
-    restoreBtnText: isJapanese ? "Google Driveから強制リカバリ" : "Force Restore from Google Drive"
+    restoreBtnText: isJapanese ? "Google Driveから強制リカバリ" : "Force Restore from Google Drive",
+    easyModeLabel: isJapanese ? "かんたんモード (Easy Mode)" : "Easy Mode",
+    easyModeDesc: isJapanese 
+      ? "UIをシンプルにし、Libraryタブのみを表示します。設定には右上の歯車アイコンからいつでも戻ることができます。" 
+      : "Simplifies the UI by showing only the Library tab. You can return to Settings anytime via the gear icon.",
+    easyModeToggleLabel: isJapanese ? "かんたんモードを有効にする" : "Enable Easy Mode",
+    easyModeToggleSub: isJapanese ? "不要なタブを非表示にし、操作ミスを防ぎます" : "Hide tabs to focus on Style Card management"
   };
 
   // Sync toggle state
@@ -446,6 +459,52 @@ export function SettingsTab({ addLog, onResetDb }: SettingsTabProps) {
           <Settings2 className="w-5 h-5 text-blue-600" />
         </div>
         <h2 className="text-base font-bold text-slate-800">Settings</h2>
+      </div>
+
+      {/* Interface Mode Settings (Easy Mode Toggle) */}
+      <div className="bg-white border border-slate-200/80 rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow relative overflow-hidden">
+        <div className="absolute top-0 right-0 w-24 h-24 bg-gradient-to-br from-blue-500/5 to-transparent rounded-full -mr-8 -mt-8 pointer-events-none" />
+
+        <div className="flex items-start gap-4 mb-4">
+          <div className={`p-3 rounded-xl ${isEasyMode ? "bg-blue-50 text-blue-600 border border-blue-100" : "bg-slate-50 text-slate-400 border border-slate-100"}`}>
+            <Settings2 className="w-6 h-6" />
+          </div>
+          <div className="space-y-1 flex-1">
+            <h3 className="text-sm font-bold text-slate-800 flex items-center gap-1.5">
+              {t.easyModeLabel}
+              {isEasyMode && (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-green-100 text-green-700">
+                  Active
+                </span>
+              )}
+            </h3>
+            <p className="text-xs text-slate-500 leading-relaxed">
+              {t.easyModeDesc}
+            </p>
+          </div>
+        </div>
+
+        {/* Easy Mode Toggle Switch */}
+        <div className="flex items-center justify-between bg-slate-50/80 border border-slate-100/80 rounded-xl px-4 py-3 transition-all hover:bg-slate-50">
+          <div className="space-y-0.5">
+            <span className="text-xs font-bold text-slate-700">{t.easyModeToggleLabel}</span>
+            <p className="text-[10px] text-slate-400">{t.easyModeToggleSub}</p>
+          </div>
+          <button
+            type="button"
+            id="easy-mode-toggle-btn"
+            onClick={() => onToggleEasyMode(!isEasyMode)}
+            className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
+              isEasyMode ? "bg-blue-600" : "bg-slate-200"
+            }`}
+          >
+            <span
+              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                isEasyMode ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
       </div>
 
       {/* Google Drive Card */}

--- a/src/components/templates/SidePanelLayout.tsx
+++ b/src/components/templates/SidePanelLayout.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { HelpCircle } from "lucide-react"
+import { HelpCircle, Settings } from "lucide-react"
 import type { Tab } from "../../hooks/useTabs"
 import { ConnectionAlert, type AlertType } from "../molecules/ConnectionAlert"
 
@@ -19,6 +19,7 @@ interface SidePanelLayoutProps {
   onOpenGuide: () => void
   isDraggingFile?: boolean
   isImporting?: boolean
+  isEasyMode?: boolean
 }
 
 export function SidePanelLayout({
@@ -35,7 +36,8 @@ export function SidePanelLayout({
   onDismissAlert,
   onOpenGuide,
   isDraggingFile,
-  isImporting
+  isImporting,
+  isEasyMode
 }: SidePanelLayoutProps) {
   return (
     <div
@@ -47,53 +49,74 @@ export function SidePanelLayout({
 
       <div className="p-4 bg-white shadow-sm z-10">
         <div className="mt-2">
-          <div className="flex justify-between items-center border-b border-slate-200">
-            <nav className="-mb-px flex space-x-4">
-              <button
-                onClick={() => onTabChange("history")}
-                className={`whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${activeTab === "history"
-                  ? "border-blue-500 text-blue-600"
-                  : "border-transparent text-slate-500 hover:text-slate-700"
-                  }`}
-              >
-                History
-              </button>
-              <button
-                onClick={() => onTabChange("library")}
-                className={`whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${activeTab === "library"
-                  ? "border-blue-500 text-blue-600"
-                  : "border-transparent text-slate-500 hover:text-slate-700"
-                  }`}
-              >
-                Library
-              </button>
-              <button
-                onClick={() => onTabChange("workbench")}
-                data-tutorial="workbench-tab"
-                className={`whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${activeTab === "workbench"
-                  ? "border-blue-500 text-blue-600"
-                  : "border-transparent text-slate-500 hover:text-slate-700"
-                  }`}
-              >
-                Workbench
-              </button>
+          <div className="flex justify-between items-center border-b border-slate-200 pb-2">
+            {isEasyMode ? (
+              <div className="flex items-center gap-2 py-2">
+                <span className="text-sm font-black text-slate-800 flex items-center gap-1.5">
+                  <span className="text-lg">🎴</span> Library
+                </span>
+              </div>
+            ) : (
+              <nav className="-mb-px flex space-x-4">
+                <button
+                  onClick={() => onTabChange("history")}
+                  className={`whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${activeTab === "history"
+                    ? "border-blue-500 text-blue-600"
+                    : "border-transparent text-slate-500 hover:text-slate-700"
+                    }`}
+                >
+                  History
+                </button>
+                <button
+                  onClick={() => onTabChange("library")}
+                  className={`whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${activeTab === "library"
+                    ? "border-blue-500 text-blue-600"
+                    : "border-transparent text-slate-500 hover:text-slate-700"
+                    }`}
+                >
+                  Library
+                </button>
+                <button
+                  onClick={() => onTabChange("workbench")}
+                  data-tutorial="workbench-tab"
+                  className={`whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${activeTab === "workbench"
+                    ? "border-blue-500 text-blue-600"
+                    : "border-transparent text-slate-500 hover:text-slate-700"
+                    }`}
+                >
+                  Workbench
+                </button>
+                <button
+                  onClick={() => onTabChange("settings")}
+                  className={`whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${activeTab === "settings"
+                    ? "border-blue-500 text-blue-600"
+                    : "border-transparent text-slate-500 hover:text-slate-700"
+                    }`}
+                >
+                  Settings
+                </button>
+              </nav>
+            )}
+            <div className="flex items-center gap-1.5">
               <button
                 onClick={() => onTabChange("settings")}
-                className={`whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${activeTab === "settings"
-                  ? "border-blue-500 text-blue-600"
-                  : "border-transparent text-slate-500 hover:text-slate-700"
-                  }`}
+                id="settings-nav-btn"
+                className={`text-xs text-slate-500 hover:text-slate-700 flex items-center gap-1 py-1 px-2 hover:bg-slate-100 rounded-lg transition-all font-semibold ${
+                  activeTab === "settings" ? "bg-blue-50 text-blue-600 hover:bg-blue-50" : ""
+                }`}
+                title="Settings"
               >
-                Settings
+                <Settings className="w-4 h-4 text-slate-500" />
+                <span className="sr-only">Settings</span>
               </button>
-            </nav>
-            <button
-              onClick={onOpenGuide}
-              className="text-xs text-slate-500 hover:text-slate-700 flex items-center gap-1 py-1 px-2 hover:bg-slate-100 rounded-lg transition-all font-semibold"
-              title="Show Guide"
-            >
-              <HelpCircle className="w-4 h-4 text-blue-500" /> Guide
-            </button>
+              <button
+                onClick={onOpenGuide}
+                className="text-xs text-slate-500 hover:text-slate-700 flex items-center gap-1 py-1 px-2 hover:bg-slate-100 rounded-lg transition-all font-semibold"
+                title="Show Guide"
+              >
+                <HelpCircle className="w-4 h-4 text-blue-500" /> Guide
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/SidePanel.tsx
+++ b/src/pages/SidePanel.tsx
@@ -57,18 +57,34 @@ function WelcomeDialog({ onStart, onSkip }: { onStart: () => void; onSkip: () =>
 function SidePanelInner() {
   const { isTargetSite, isLoading } = useActiveTabUrl()
   const { startTutorial, advanceIfStep } = useTutorial()
+  const { activeTab, setActiveTab } = useTabs()
   const [logs, setLogs] = useState<string[]>([])
   // New global state for connection alerts
   const [alertType, setAlertType] = useState<AlertType>(null)
   const [activeDetailCard, setActiveDetailCard] = useState<StyleCard | null>(null)
   const [showWelcome, setShowWelcome] = useState(false)
+  const [isEasyMode, setIsEasyMode] = useState(false)
 
   useEffect(() => {
     const seen = localStorage.getItem("style-atelier-onboarding-seen")
     if (!seen) {
       setShowWelcome(true)
     }
+    const easyMode = localStorage.getItem("style-atelier-easy-mode") === "true"
+    setIsEasyMode(easyMode)
+    if (easyMode) {
+      setActiveTab("library")
+    }
   }, [])
+
+  const handleToggleEasyMode = (enabled: boolean) => {
+    setIsEasyMode(enabled)
+    localStorage.setItem("style-atelier-easy-mode", enabled ? "true" : "false")
+    addLog(`Interface mode changed: ${enabled ? "EASY" : "EXPERT"}`)
+    if (enabled) {
+      setActiveTab("library")
+    }
+  }
 
   const handleStartTutorial = () => {
     localStorage.setItem("style-atelier-onboarding-seen", "true")
@@ -140,8 +156,6 @@ function SidePanelInner() {
       addLog(`Note: ${err.message || "Could not send to tab"}`)
     }
   }
-
-  const { activeTab, setActiveTab } = useTabs()
   const { 
     isDragging, 
     isDraggingFile, 
@@ -270,6 +284,7 @@ function SidePanelInner() {
             setActiveTab("history")
             startTutorial()
           }}
+          isEasyMode={isEasyMode}
         >
           {(mintingItem || variationBase) && (
             <MintingView
@@ -329,7 +344,14 @@ function SidePanelInner() {
             />
           )}
           {activeTab === "workbench" && <Workbench onStartVariationMinting={handleStartVariationMinting} addLog={addLog} setAlertType={setAlertType} />}
-          {activeTab === "settings" && <SettingsTab addLog={addLog} onResetDb={handleResetDb} />}
+          {activeTab === "settings" && (
+            <SettingsTab 
+              addLog={addLog} 
+              onResetDb={handleResetDb} 
+              isEasyMode={isEasyMode}
+              onToggleEasyMode={handleToggleEasyMode}
+            />
+          )}
 
           {/* HandBar is now inside SidePanelLayout children to ensure it stays in same context */}
           <HandBar 

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -1169,7 +1169,7 @@ test.describe("Style Atelier Sandbox E2E Tests", () => {
     }
 
     // 2. Switch to Settings tab
-    const settingsTabButton = spFrame.locator("button:has-text('Settings')");
+    const settingsTabButton = spFrame.locator("nav button:has-text('Settings')");
     await expect(settingsTabButton).toBeVisible();
     await settingsTabButton.click();
 
@@ -1398,5 +1398,66 @@ test.describe("Style Atelier Sandbox E2E Tests", () => {
     });
 
     console.log("Sync and logical delete E2E logic verification passed successfully!");
+  });
+
+  test("should toggle Easy Mode and restrict tab visibility to Library only", async ({ page }) => {
+    const screenshotsDir = path.join(__dirname, "../../tests/screenshots");
+    console.log("Navigating to sandbox page for Easy Mode E2E test...");
+    await page.goto("/tests/sandbox/index.html");
+
+    const spFrame = page.frameLocator("#sidepanel-frame");
+
+    // 1. Skip welcome dialog if exists
+    const skipButton = spFrame.locator("text=スキップ");
+    if (await skipButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await skipButton.click();
+    }
+
+    // 2. Verify History tab is visible initially
+    const historyTabBtn = spFrame.locator("nav button:has-text('History')");
+    await expect(historyTabBtn).toBeVisible({ timeout: 10000 });
+
+    // 3. Click Settings icon in header to navigate to Settings
+    const settingsNavBtn = spFrame.locator("#settings-nav-btn");
+    await expect(settingsNavBtn).toBeVisible({ timeout: 10000 });
+    await settingsNavBtn.click();
+
+    // 4. Verify Easy Mode toggle button exists in SettingsTab
+    const easyModeToggle = spFrame.locator("#easy-mode-toggle-btn");
+    await expect(easyModeToggle).toBeVisible({ timeout: 10000 });
+
+    // 5. Toggle Easy Mode to ON
+    console.log("Enabling Easy Mode...");
+    await easyModeToggle.click();
+    await page.waitForTimeout(500);
+
+    // 6. Verify tabs are hidden and Library title is displayed
+    const libraryTitle = spFrame.locator("span:has-text('Library')");
+    await expect(libraryTitle).toBeVisible({ timeout: 10000 });
+    await expect(historyTabBtn).not.toBeVisible();
+
+    // 7. Save screenshot of active Easy Mode
+    await page.screenshot({
+      path: path.join(screenshotsDir, "easy-mode-active.png"),
+    });
+    console.log("Easy Mode active screenshot saved.");
+
+    // 8. Re-open settings via header settings button
+    await settingsNavBtn.click();
+    await page.waitForTimeout(500);
+
+    // 9. Toggle Easy Mode to OFF
+    console.log("Disabling Easy Mode...");
+    await easyModeToggle.click();
+    await page.waitForTimeout(500);
+
+    // 10. Verify typical tabs are restored (e.g. History tab visible)
+    await expect(historyTabBtn).toBeVisible({ timeout: 10000 });
+
+    // 11. Save screenshot of restored standard mode
+    await page.screenshot({
+      path: path.join(screenshotsDir, "easy-mode-deactivated.png"),
+    });
+    console.log("Easy Mode E2E test passed successfully!");
   });
 });


### PR DESCRIPTION
Resolves #178

## Overview
This PR implements **Easy Mode** (Issue #178) which provides a simplified UI option for users. When enabled, it hides most advanced tab navigation and restricts the view to the Library only.

## Key Changes
- **State Management**: Added `isEasyMode` state in `SidePanel.tsx` persisted via `localStorage` as "easyMode".
- **Conditional Rendering**: Updated `SidePanelLayout` to hide tabs (History, Workbench, Settings) and show a static header for Library when Easy Mode is active.
- **Easy Mode Toggle**: Added a toggle button in `SettingsTab` under "Interface Settings" with support for localizations.
- **Testing**: Added unit tests to `SettingsTab.test.tsx` and a full E2E scenario in `tests/e2e/extension.spec.ts`.

## Screenshots
### 1. Easy Mode Enabled (Only Library Tab Visible)
![easy-mode-active.png](https://github.com/user-attachments/assets/5b6aedbf-b505-4afd-8f53-1089dbb5a621)

### 2. Standard Mode Restored (Normal Tabs Displayed)
![easy-mode-deactivated.png](https://github.com/user-attachments/assets/39f4db1b-9fb8-4632-84e0-850991e78bd2)
