### PR TITLE
refactor(easy-mode): decouple Easy Mode and Expert Mode logic into separate hooks and views

### DIFF
--- a/src/components/organisms/EasyModeView.tsx
+++ b/src/components/organisms/EasyModeView.tsx
@@ -1,0 +1,143 @@
+import React from "react"
+import { useEasyModeView } from "../../hooks/useEasyModeView"
+import { SidePanelLayout } from "../templates/SidePanelLayout"
+import { LibraryTab } from "./LibraryTab"
+import { SettingsTab } from "./SettingsTab"
+import { MintingView } from "./MintingView"
+import { CardDetailView } from "./CardDetailView"
+import { db } from "../../lib/db"
+
+interface EasyModeViewProps {
+  isEasyMode: boolean
+  onToggleEasyMode: (enabled: boolean) => void
+}
+
+/**
+ * EasyModeView component - acts as a simplified user interface displaying only
+ * the library and settings, optimized for basic operations.
+ */
+export function EasyModeView({ isEasyMode, onToggleEasyMode }: EasyModeViewProps) {
+  const {
+    activeTab,
+    setActiveTab,
+    logs,
+    alertType,
+    setAlertType,
+    activeDetailCard,
+    setActiveDetailCard,
+    isDragging,
+    isDraggingFile,
+    isImporting,
+    droppedItem,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    minting,
+    addLog,
+    handleSaveCardDetails,
+    handleDeleteCard,
+    handleInjectPrompt,
+    handleResetDb,
+    handleClearLogs,
+    handleRetryConnection,
+    handleDismissAlert,
+    handleToggleEasyMode,
+  } = useEasyModeView({ isEasyMode, onToggleEasyMode })
+
+  return (
+    <div
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className="h-full relative overflow-hidden"
+    >
+      <SidePanelLayout
+        activeTab={activeTab}
+        onTabChange={(tab) => {
+          setActiveTab(tab as any)
+          minting.setMintingItem(null)
+          minting.setVariationBase(null)
+          setActiveDetailCard(null)
+        }}
+        isDragging={isDragging}
+        isDraggingFile={isDraggingFile}
+        isImporting={isImporting}
+        logs={logs}
+        onClearLogs={handleClearLogs}
+        onResetDb={handleResetDb}
+        droppedItem={droppedItem}
+        alertType={alertType}
+        onRetryConnection={handleRetryConnection}
+        onDismissAlert={handleDismissAlert}
+        onOpenGuide={() => {}} // Guide is not supported in Easy Mode
+        isEasyMode={isEasyMode}
+      >
+        {(minting.mintingItem || minting.variationBase) && (
+          <MintingView
+            mintingItem={minting.mintingItem}
+            editedSegments={minting.editedSegments}
+            setEditedSegments={minting.setEditedSegments}
+            isSrefHidden={minting.isSrefHidden}
+            setIsSrefHidden={minting.setIsSrefHidden}
+            isPHidden={minting.isPHidden}
+            setIsPHidden={minting.setIsPHidden}
+            onCancelMinting={() => {
+              minting.setMintingItem(null)
+              minting.setVariationBase(null)
+            }}
+            onSaveMintedCard={minting.handleSaveMintedCard}
+            selectedRarity={minting.selectedRarity}
+            setSelectedRarity={minting.setSelectedRarity}
+            suggestedKeywords={minting.suggestedKeywords}
+            selectedKeywords={minting.selectedKeywords}
+            setSelectedKeywords={minting.setSelectedKeywords}
+            customName={minting.customName}
+            setCustomName={minting.setCustomName}
+            selectedCategory={minting.selectedCategory}
+            setSelectedCategory={minting.setSelectedCategory}
+            customTags={minting.customTags}
+            setCustomTags={minting.setCustomTags}
+            detectedDominantColor={minting.detectedDominantColor}
+            detectedAccentColor={minting.detectedAccentColor}
+            detectedColorTags={minting.detectedColorTags}
+          />
+        )}
+        {activeDetailCard && (
+          <CardDetailView
+            card={activeDetailCard}
+            onClose={() => setActiveDetailCard(null)}
+            onInject={handleInjectPrompt}
+            onSave={handleSaveCardDetails}
+            setAlertType={setAlertType}
+            onCardSelect={async (cardId) => {
+              const targetCard = await db.styleCards.get(cardId)
+              if (targetCard) {
+                setActiveDetailCard(targetCard)
+              } else {
+                addLog("Warning: Selected parent card could not be found.")
+              }
+            }}
+            onDelete={handleDeleteCard}
+          />
+        )}
+
+        {activeTab === "library" && (
+          <LibraryTab
+            addLog={addLog}
+            setAlertType={setAlertType}
+            onOpenDetailCard={setActiveDetailCard}
+            onNavigateToWorkbench={() => {}} // Workbench navigation is disabled in Easy Mode
+          />
+        )}
+        {activeTab === "settings" && (
+          <SettingsTab
+            addLog={addLog}
+            onResetDb={handleResetDb}
+            isEasyMode={isEasyMode}
+            onToggleEasyMode={handleToggleEasyMode}
+          />
+        )}
+      </SidePanelLayout>
+    </div>
+  )
+}

--- a/src/components/organisms/ExpertModeView.tsx
+++ b/src/components/organisms/ExpertModeView.tsx
@@ -1,0 +1,203 @@
+import React from "react"
+import { useExpertModeView } from "../../hooks/useExpertModeView"
+import { SidePanelLayout } from "../templates/SidePanelLayout"
+import { HistoryTab } from "./HistoryTab"
+import { LibraryTab } from "./LibraryTab"
+import { Workbench } from "./Workbench"
+import { SettingsTab } from "./SettingsTab"
+import { MintingView } from "./MintingView"
+import { CardDetailView } from "./CardDetailView"
+import { HandBar } from "./HandBar"
+import { InteractiveTutorial } from "./InteractiveTutorial"
+import { db } from "../../lib/db"
+
+interface ExpertModeViewProps {
+  isEasyMode: boolean
+  onToggleEasyMode: (enabled: boolean) => void
+}
+
+function WelcomeDialog({ onStart, onSkip }: { onStart: () => void; onSkip: () => void }) {
+  return (
+    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200">
+      <div className="w-full max-w-xs bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl overflow-hidden text-slate-200 animate-in zoom-in-95 duration-200">
+        <div className="p-5 flex flex-col items-center gap-3">
+          <div className="w-14 h-14 rounded-full bg-blue-600/10 border border-blue-500/30 flex items-center justify-center">
+            <span className="text-3xl">🎴</span>
+          </div>
+          <h2 className="text-base font-black text-white text-center">Style Atelierへようこそ！</h2>
+          <p className="text-xs text-slate-400 leading-relaxed text-center">
+            実際に操作しながら使い方を覚える<br />インタラクティブなガイドを開始しますか？
+          </p>
+        </div>
+        <div className="px-5 pb-5 flex flex-col gap-2">
+          <button
+            onClick={onStart}
+            className="w-full py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-bold rounded-xl shadow transition-all"
+          >
+            ガイドを開始する
+          </button>
+          <button
+            onClick={onSkip}
+            className="w-full py-2 text-slate-500 hover:text-slate-300 text-xs font-semibold transition-all"
+          >
+            スキップ（あとでGuideボタンから開始できます）
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * ExpertModeView component - acts as a fully featured user interface displaying all
+ * tabs (history, library, workbench, settings) and supporting tutorials, history minting, and mixing.
+ */
+export function ExpertModeView({ isEasyMode, onToggleEasyMode }: ExpertModeViewProps) {
+  const {
+    activeTab,
+    setActiveTab,
+    logs,
+    alertType,
+    setAlertType,
+    activeDetailCard,
+    setActiveDetailCard,
+    showWelcome,
+    isDragging,
+    isDraggingFile,
+    isImporting,
+    droppedItem,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    minting,
+    addLog,
+    handleStartMinting,
+    handleSaveCardDetails,
+    handleDeleteCard,
+    handleInjectPrompt,
+    handleResetDb,
+    handleClearLogs,
+    handleRetryConnection,
+    handleDismissAlert,
+    handleOpenGuide,
+    handleStartTutorial,
+    handleSkipTutorial,
+    handleToggleEasyMode,
+  } = useExpertModeView({ isEasyMode, onToggleEasyMode })
+
+  return (
+    <div
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className="h-full relative overflow-hidden"
+    >
+      <SidePanelLayout
+        activeTab={activeTab}
+        onTabChange={(tab) => {
+          setActiveTab(tab)
+          minting.setMintingItem(null)
+          minting.setVariationBase(null)
+          setActiveDetailCard(null)
+        }}
+        isDragging={isDragging}
+        isDraggingFile={isDraggingFile}
+        isImporting={isImporting}
+        logs={logs}
+        onClearLogs={handleClearLogs}
+        onResetDb={handleResetDb}
+        droppedItem={droppedItem}
+        alertType={alertType}
+        onRetryConnection={handleRetryConnection}
+        onDismissAlert={handleDismissAlert}
+        onOpenGuide={handleOpenGuide}
+        isEasyMode={isEasyMode}
+      >
+        {(minting.mintingItem || minting.variationBase) && (
+          <MintingView
+            mintingItem={minting.mintingItem}
+            editedSegments={minting.editedSegments}
+            setEditedSegments={minting.setEditedSegments}
+            isSrefHidden={minting.isSrefHidden}
+            setIsSrefHidden={minting.setIsSrefHidden}
+            isPHidden={minting.isPHidden}
+            setIsPHidden={minting.setIsPHidden}
+            onCancelMinting={() => {
+              minting.setMintingItem(null)
+              minting.setVariationBase(null)
+            }}
+            onSaveMintedCard={minting.handleSaveMintedCard}
+            selectedRarity={minting.selectedRarity}
+            setSelectedRarity={minting.setSelectedRarity}
+            suggestedKeywords={minting.suggestedKeywords}
+            selectedKeywords={minting.selectedKeywords}
+            setSelectedKeywords={minting.setSelectedKeywords}
+            customName={minting.customName}
+            setCustomName={minting.setCustomName}
+            selectedCategory={minting.selectedCategory}
+            setSelectedCategory={minting.setSelectedCategory}
+            customTags={minting.customTags}
+            setCustomTags={minting.setCustomTags}
+            detectedDominantColor={minting.detectedDominantColor}
+            detectedAccentColor={minting.detectedAccentColor}
+            detectedColorTags={minting.detectedColorTags}
+          />
+        )}
+        {activeDetailCard && (
+          <CardDetailView
+            card={activeDetailCard}
+            onClose={() => setActiveDetailCard(null)}
+            onInject={handleInjectPrompt}
+            onSave={handleSaveCardDetails}
+            setAlertType={setAlertType}
+            onCardSelect={async (cardId) => {
+              const targetCard = await db.styleCards.get(cardId)
+              if (targetCard) {
+                setActiveDetailCard(targetCard)
+              } else {
+                addLog("Warning: Selected parent card could not be found.")
+              }
+            }}
+            onDelete={handleDeleteCard}
+          />
+        )}
+
+        {activeTab === "history" && <HistoryTab onStartMinting={handleStartMinting} />}
+        {activeTab === "library" && (
+          <LibraryTab
+            addLog={addLog}
+            setAlertType={setAlertType}
+            onOpenDetailCard={setActiveDetailCard}
+            onNavigateToWorkbench={() => setActiveTab("workbench")}
+          />
+        )}
+        {activeTab === "workbench" && (
+          <Workbench
+            onStartVariationMinting={minting.handleStartVariationMinting}
+            addLog={addLog}
+            setAlertType={setAlertType}
+          />
+        )}
+        {activeTab === "settings" && (
+          <SettingsTab
+            addLog={addLog}
+            onResetDb={handleResetDb}
+            isEasyMode={isEasyMode}
+            onToggleEasyMode={handleToggleEasyMode}
+          />
+        )}
+
+        <HandBar
+          onNavigateToWorkbench={() => setActiveTab("workbench")}
+          onOpenDetailCard={setActiveDetailCard}
+        />
+      </SidePanelLayout>
+
+      {showWelcome && (
+        <WelcomeDialog onStart={handleStartTutorial} onSkip={handleSkipTutorial} />
+      )}
+
+      <InteractiveTutorial />
+    </div>
+  )
+}

--- a/src/hooks/useEasyModeView.test.tsx
+++ b/src/hooks/useEasyModeView.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { useEasyModeView } from "./useEasyModeView"
+import { db } from "../lib/db"
+import { renderHook, act } from "@testing-library/react"
+
+vi.mock("../lib/db", () => ({
+  db: {
+    styleCards: {
+      put: vi.fn().mockResolvedValue("card-id"),
+      update: vi.fn().mockResolvedValue(1),
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    historyItems: {
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    userSettings: {
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    categories: {
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    deleteStyleCardAndCleanup: vi.fn().mockResolvedValue(undefined),
+  },
+  seedDefaultCategories: vi.fn().mockResolvedValue(undefined),
+}))
+
+const confirmSpy = vi.spyOn(window, "confirm")
+
+describe("useEasyModeView hook", () => {
+  const mockOnToggleEasyMode = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    confirmSpy.mockReset()
+    
+    // Mock chrome APIs
+    global.chrome = {
+      tabs: {
+        query: vi.fn().mockResolvedValue([{ id: 123 }]),
+        sendMessage: vi.fn().mockResolvedValue({ status: "success" }),
+        reload: vi.fn(),
+      },
+    } as any
+  })
+
+  it("should initialize with default states", () => {
+    const { result } = renderHook(() =>
+      useEasyModeView({ isEasyMode: true, onToggleEasyMode: mockOnToggleEasyMode })
+    )
+
+    expect(result.current.activeTab).toBe("library")
+    expect(result.current.logs).toEqual([])
+    expect(result.current.alertType).toBeNull()
+    expect(result.current.activeDetailCard).toBeNull()
+  })
+
+  it("should switch tab to settings", () => {
+    const { result } = renderHook(() =>
+      useEasyModeView({ isEasyMode: true, onToggleEasyMode: mockOnToggleEasyMode })
+    )
+
+    act(() => {
+      result.current.setActiveTab("settings")
+    })
+
+    expect(result.current.activeTab).toBe("settings")
+  })
+
+  it("should call onToggleEasyMode and reset tab to library when toggled", () => {
+    const { result } = renderHook(() =>
+      useEasyModeView({ isEasyMode: true, onToggleEasyMode: mockOnToggleEasyMode })
+    )
+
+    act(() => {
+      result.current.setActiveTab("settings")
+    })
+    expect(result.current.activeTab).toBe("settings")
+
+    act(() => {
+      result.current.handleToggleEasyMode(true)
+    })
+
+    expect(mockOnToggleEasyMode).toHaveBeenCalledWith(true)
+    expect(result.current.activeTab).toBe("library")
+  })
+
+  it("should handle saving card details", async () => {
+    const { result } = renderHook(() =>
+      useEasyModeView({ isEasyMode: true, onToggleEasyMode: mockOnToggleEasyMode })
+    )
+
+    const mockCard = { id: "card-123", name: "Test Card" } as any
+
+    await act(async () => {
+      await result.current.handleSaveCardDetails(mockCard)
+    })
+
+    expect(db.styleCards.put).toHaveBeenCalledWith(mockCard)
+    expect(result.current.logs[0]).toContain("updated successfully")
+    expect(result.current.activeDetailCard).toBeNull()
+  })
+
+  it("should handle deleting a card", async () => {
+    const { result } = renderHook(() =>
+      useEasyModeView({ isEasyMode: true, onToggleEasyMode: mockOnToggleEasyMode })
+    )
+
+    await act(async () => {
+      await result.current.handleDeleteCard("card-123")
+    })
+
+    expect(db.deleteStyleCardAndCleanup).toHaveBeenCalledWith("card-123")
+    expect(result.current.logs[0]).toContain("deleted successfully")
+  })
+
+  it("should handle injecting prompt successfully", async () => {
+    const { result } = renderHook(() =>
+      useEasyModeView({ isEasyMode: true, onToggleEasyMode: mockOnToggleEasyMode })
+    )
+
+    await act(async () => {
+      await result.current.handleInjectPrompt("sunset cyberpunk")
+    })
+
+    expect(global.chrome.tabs.query).toHaveBeenCalled()
+    expect(global.chrome.tabs.sendMessage).toHaveBeenCalledWith(123, {
+      type: "INJECT_PROMPT",
+      prompt: "sunset cyberpunk",
+    })
+    expect(result.current.logs[0]).toContain("Sent prompt")
+  })
+
+  it("should set alertType to no_input if content script returns error for chat input", async () => {
+    global.chrome.tabs.sendMessage = vi.fn().mockResolvedValue({
+      status: "error",
+      message: "Could not find chat input",
+    })
+
+    const { result } = renderHook(() =>
+      useEasyModeView({ isEasyMode: true, onToggleEasyMode: mockOnToggleEasyMode })
+    )
+
+    await act(async () => {
+      await result.current.handleInjectPrompt("sunset cyberpunk")
+    })
+
+    expect(result.current.alertType).toBe("no_input")
+  })
+
+  it("should clear logs", () => {
+    const { result } = renderHook(() =>
+      useEasyModeView({ isEasyMode: true, onToggleEasyMode: mockOnToggleEasyMode })
+    )
+
+    act(() => {
+      result.current.addLog("test log")
+    })
+    expect(result.current.logs).toHaveLength(1)
+
+    act(() => {
+      result.current.handleClearLogs()
+    })
+    expect(result.current.logs).toEqual([])
+  })
+})

--- a/src/hooks/useEasyModeView.ts
+++ b/src/hooks/useEasyModeView.ts
@@ -1,0 +1,161 @@
+import { useState } from "react"
+import { db, seedDefaultCategories } from "../lib/db"
+import { useDragAndDrop } from "./useDragAndDrop"
+import { useMinting } from "./useMinting"
+import type { AlertType } from "../components/molecules/ConnectionAlert"
+import type { StyleCard } from "../lib/db-schema"
+
+interface UseEasyModeViewProps {
+  isEasyMode: boolean
+  onToggleEasyMode: (enabled: boolean) => void
+}
+
+/**
+ * Custom hook encapsulating the logic and state for the Easy Mode of the Style Atelier Sidepanel.
+ */
+export function useEasyModeView({ isEasyMode, onToggleEasyMode }: UseEasyModeViewProps) {
+  const [activeTab, setActiveTab] = useState<"library" | "settings">("library")
+  const [logs, setLogs] = useState<string[]>([])
+  const [alertType, setAlertType] = useState<AlertType>(null)
+  const [activeDetailCard, setActiveDetailCard] = useState<StyleCard | null>(null)
+
+  const addLog = (log: string) => {
+    setLogs((prev) => [log, ...prev].slice(0, 20))
+  }
+
+  const handleToggleEasyModeInternal = (enabled: boolean) => {
+    onToggleEasyMode(enabled)
+    if (enabled) {
+      setActiveTab("library")
+    }
+  }
+
+  const handleSaveCardDetails = async (updatedCard: StyleCard) => {
+    try {
+      await db.styleCards.put(updatedCard)
+      addLog(`StyleCard "${updatedCard.name}" updated successfully!`)
+      setActiveDetailCard(null)
+    } catch (err) {
+      console.error("Failed to save style card updates:", err)
+      addLog("Error: Failed to save style card updates.")
+    }
+  }
+
+  const handleDeleteCard = async (cardId: string) => {
+    try {
+      await db.deleteStyleCardAndCleanup(cardId)
+      addLog("StyleCard deleted successfully.")
+      setActiveDetailCard(null)
+    } catch (err) {
+      console.error("Failed to delete style card:", err)
+      addLog("Error: Failed to delete style card.")
+    }
+  }
+
+  const handleInjectPrompt = async (prompt: string) => {
+    setAlertType(null)
+    try {
+      const tabs = await chrome.tabs.query({ active: true, currentWindow: true })
+      const activeTabEl = tabs[0]
+      if (!activeTabEl?.id) {
+        throw new Error("No active tab found")
+      }
+      const response = await chrome.tabs.sendMessage(activeTabEl.id, {
+        type: "INJECT_PROMPT",
+        prompt: prompt,
+      })
+      if (response && response.status === "error") {
+        if (response.message && response.message.includes("Could not find chat input")) {
+          setAlertType("no_input")
+        } else {
+          setAlertType("disconnected")
+        }
+      } else {
+        addLog(`Sent prompt: ${prompt.substring(0, 30)}...`)
+        if (activeDetailCard) {
+          db.styleCards.update(activeDetailCard.id, {
+            usageCount: (activeDetailCard.usageCount || 0) + 1
+          }).catch(err => console.error("Failed to update usage count on details inject:", err))
+        }
+      }
+    } catch (err: any) {
+      console.error("Injection failed:", err)
+      setAlertType("disconnected")
+      addLog(`Note: ${err.message || "Could not send to tab"}`)
+    }
+  }
+
+  const {
+    isDragging,
+    isDraggingFile,
+    isImporting,
+    droppedItem,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop: rawHandleDrop
+  } = useDragAndDrop(addLog)
+
+  const handleDrop = async (e: React.DragEvent) => {
+    const result = (await rawHandleDrop(e)) as any
+    if (result) {
+      if (result.isImport) {
+        setActiveTab("library")
+      }
+    }
+  }
+
+  const minting = useMinting(addLog, (tab) => {
+    if (tab === "library") {
+      setActiveTab("library")
+    }
+  })
+
+  const handleResetDb = async () => {
+    if (window.confirm("Are you sure you want to delete ALL DATA?")) {
+      await Promise.all([db.historyItems.clear(), db.styleCards.clear(), db.userSettings.clear(), db.categories.clear()])
+      await seedDefaultCategories()
+      localStorage.removeItem("style-atelier-onboarding-seen")
+      addLog("All data cleared.")
+    }
+  }
+
+  const handleClearLogs = () => {
+    setLogs([])
+  }
+
+  const handleRetryConnection = () => {
+    chrome.tabs.reload()
+    setAlertType(null)
+  }
+
+  const handleDismissAlert = () => {
+    setAlertType(null)
+  }
+
+  return {
+    activeTab,
+    setActiveTab,
+    logs,
+    alertType,
+    setAlertType,
+    activeDetailCard,
+    setActiveDetailCard,
+    isDragging,
+    isDraggingFile,
+    isImporting,
+    droppedItem,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    minting,
+    addLog,
+    handleSaveCardDetails,
+    handleDeleteCard,
+    handleInjectPrompt,
+    handleResetDb,
+    handleClearLogs,
+    handleRetryConnection,
+    handleDismissAlert,
+    handleToggleEasyMode: handleToggleEasyModeInternal
+  }
+}

--- a/src/hooks/useExpertModeView.test.tsx
+++ b/src/hooks/useExpertModeView.test.tsx
@@ -1,0 +1,119 @@
+import React from "react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { useExpertModeView } from "./useExpertModeView"
+import { db } from "../lib/db"
+import { renderHook, act } from "@testing-library/react"
+import { TutorialProvider } from "../contexts/TutorialContext"
+
+vi.mock("../lib/db", () => ({
+  db: {
+    styleCards: {
+      put: vi.fn().mockResolvedValue("card-id"),
+      update: vi.fn().mockResolvedValue(1),
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    historyItems: {
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    userSettings: {
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    categories: {
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    deleteStyleCardAndCleanup: vi.fn().mockResolvedValue(undefined),
+  },
+  seedDefaultCategories: vi.fn().mockResolvedValue(undefined),
+}))
+
+const confirmSpy = vi.spyOn(window, "confirm")
+
+describe("useExpertModeView hook", () => {
+  const mockOnToggleEasyMode = vi.fn()
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TutorialProvider>{children}</TutorialProvider>
+  )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    confirmSpy.mockReset()
+    localStorage.clear()
+
+    // Mock chrome APIs
+    global.chrome = {
+      tabs: {
+        query: vi.fn().mockResolvedValue([{ id: 123 }]),
+        sendMessage: vi.fn().mockResolvedValue({ status: "success" }),
+        reload: vi.fn(),
+      },
+    } as any
+  })
+
+  it("should initialize with default states and check onboarding status", () => {
+    const { result } = renderHook(() =>
+      useExpertModeView({ isEasyMode: false, onToggleEasyMode: mockOnToggleEasyMode }),
+      { wrapper }
+    )
+
+    expect(result.current.activeTab).toBe("history")
+    expect(result.current.logs).toEqual([])
+    expect(result.current.alertType).toBeNull()
+    expect(result.current.activeDetailCard).toBeNull()
+    expect(result.current.showWelcome).toBe(true)
+  })
+
+  it("should start tutorial and transition tab to history", () => {
+    const { result } = renderHook(() =>
+      useExpertModeView({ isEasyMode: false, onToggleEasyMode: mockOnToggleEasyMode }),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.handleStartTutorial()
+    })
+
+    expect(localStorage.getItem("style-atelier-onboarding-seen")).toBe("true")
+    expect(result.current.showWelcome).toBe(false)
+    expect(result.current.activeTab).toBe("history")
+  })
+
+  it("should skip tutorial and save seen status", () => {
+    const { result } = renderHook(() =>
+      useExpertModeView({ isEasyMode: false, onToggleEasyMode: mockOnToggleEasyMode }),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.handleSkipTutorial()
+    })
+
+    expect(localStorage.getItem("style-atelier-onboarding-seen")).toBe("true")
+    expect(result.current.showWelcome).toBe(false)
+  })
+
+  it("should handle toggling Easy Mode", () => {
+    const { result } = renderHook(() =>
+      useExpertModeView({ isEasyMode: false, onToggleEasyMode: mockOnToggleEasyMode }),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.handleToggleEasyMode(true)
+    })
+
+    expect(mockOnToggleEasyMode).toHaveBeenCalledWith(true)
+  })
+
+  it("should handle starting tutorial via guide", () => {
+    const { result } = renderHook(() =>
+      useExpertModeView({ isEasyMode: false, onToggleEasyMode: mockOnToggleEasyMode }),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.handleOpenGuide()
+    })
+
+    expect(result.current.activeTab).toBe("history")
+  })
+})

--- a/src/hooks/useExpertModeView.ts
+++ b/src/hooks/useExpertModeView.ts
@@ -1,0 +1,211 @@
+import { useState, useEffect } from "react"
+import { db, seedDefaultCategories } from "../lib/db"
+import { useTabs } from "./useTabs"
+import { useTutorial } from "../contexts/TutorialContext"
+import { useDragAndDrop } from "./useDragAndDrop"
+import { useMinting } from "./useMinting"
+import type { AlertType } from "../components/molecules/ConnectionAlert"
+import type { StyleCard } from "../lib/db-schema"
+
+interface UseExpertModeViewProps {
+  isEasyMode: boolean
+  onToggleEasyMode: (enabled: boolean) => void
+}
+
+/**
+ * Custom hook encapsulating the logic and state for the Expert Mode of the Style Atelier Sidepanel.
+ */
+export function useExpertModeView({ isEasyMode, onToggleEasyMode }: UseExpertModeViewProps) {
+  const { startTutorial, advanceIfStep } = useTutorial()
+  const { activeTab, setActiveTab } = useTabs()
+  const [logs, setLogs] = useState<string[]>([])
+  const [alertType, setAlertType] = useState<AlertType>(null)
+  const [activeDetailCard, setActiveDetailCard] = useState<StyleCard | null>(null)
+  const [showWelcome, setShowWelcome] = useState(false)
+
+  useEffect(() => {
+    const seen = localStorage.getItem("style-atelier-onboarding-seen")
+    if (!seen) {
+      setShowWelcome(true)
+    }
+  }, [])
+
+  const addLog = (log: string) => {
+    setLogs((prev) => [log, ...prev].slice(0, 20))
+  }
+
+  const handleToggleEasyModeInternal = (enabled: boolean) => {
+    onToggleEasyMode(enabled)
+    if (enabled) {
+      setActiveTab("library")
+    }
+  }
+
+  const handleStartTutorial = () => {
+    localStorage.setItem("style-atelier-onboarding-seen", "true")
+    setShowWelcome(false)
+    setActiveTab("history")
+    startTutorial()
+  }
+
+  const handleSkipTutorial = () => {
+    localStorage.setItem("style-atelier-onboarding-seen", "true")
+    setShowWelcome(false)
+  }
+
+  const handleSaveCardDetails = async (updatedCard: StyleCard) => {
+    try {
+      await db.styleCards.put(updatedCard)
+      addLog(`StyleCard "${updatedCard.name}" updated successfully!`)
+      setActiveDetailCard(null)
+    } catch (err) {
+      console.error("Failed to save style card updates:", err)
+      addLog("Error: Failed to save style card updates.")
+    }
+  }
+
+  const handleDeleteCard = async (cardId: string) => {
+    try {
+      await db.deleteStyleCardAndCleanup(cardId)
+      addLog("StyleCard deleted successfully.")
+      setActiveDetailCard(null)
+    } catch (err) {
+      console.error("Failed to delete style card:", err)
+      addLog("Error: Failed to delete style card.")
+    }
+  }
+
+  const handleInjectPrompt = async (prompt: string) => {
+    setAlertType(null)
+    try {
+      const tabs = await chrome.tabs.query({ active: true, currentWindow: true })
+      const activeTabEl = tabs[0]
+      if (!activeTabEl?.id) {
+        throw new Error("No active tab found")
+      }
+      const response = await chrome.tabs.sendMessage(activeTabEl.id, {
+        type: "INJECT_PROMPT",
+        prompt: prompt,
+      })
+      if (response && response.status === "error") {
+        if (response.message && response.message.includes("Could not find chat input")) {
+          setAlertType("no_input")
+        } else {
+          setAlertType("disconnected")
+        }
+      } else {
+        addLog(`Sent prompt: ${prompt.substring(0, 30)}...`)
+        if (activeDetailCard) {
+          db.styleCards.update(activeDetailCard.id, {
+            usageCount: (activeDetailCard.usageCount || 0) + 1
+          }).catch(err => console.error("Failed to update usage count on details inject:", err))
+        }
+      }
+    } catch (err: any) {
+      console.error("Injection failed:", err)
+      setAlertType("disconnected")
+      addLog(`Note: ${err.message || "Could not send to tab"}`)
+    }
+  }
+
+  const {
+    isDragging,
+    isDraggingFile,
+    isImporting,
+    droppedItem,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop: rawHandleDrop
+  } = useDragAndDrop(addLog)
+
+  const handleDrop = async (e: React.DragEvent) => {
+    const result = (await rawHandleDrop(e)) as any
+    if (result) {
+      if (result.isImport) {
+        setActiveTab("library")
+      } else {
+        advanceIfStep("drop-history")
+      }
+    }
+  }
+
+  const minting = useMinting(addLog, setActiveTab)
+
+  const handleStartMinting = (historyItem: any) => {
+    minting.handleStartMinting(historyItem)
+    advanceIfStep("mint-button")
+  }
+
+  const handleResetDb = async () => {
+    if (window.confirm("Are you sure you want to delete ALL DATA?")) {
+      await Promise.all([db.historyItems.clear(), db.styleCards.clear(), db.userSettings.clear(), db.categories.clear()])
+      await seedDefaultCategories()
+      localStorage.removeItem("style-atelier-onboarding-seen")
+      addLog("All data cleared.")
+    }
+  }
+
+  const handleClearLogs = () => {
+    setLogs([])
+  }
+
+  const handleRetryConnection = () => {
+    chrome.tabs.reload()
+    setAlertType(null)
+  }
+
+  const handleDismissAlert = () => {
+    setAlertType(null)
+  }
+
+  const handleOpenMidjourney = () => {
+    if (typeof chrome !== "undefined" && chrome.tabs && chrome.tabs.update) {
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        if (tabs[0]?.id) {
+          chrome.tabs.update(tabs[0].id, { url: "https://www.midjourney.com/imagine" })
+        }
+      })
+    } else {
+      window.open("https://www.midjourney.com/imagine", "_blank")
+    }
+  }
+
+  const handleOpenGuide = () => {
+    setActiveTab("history")
+    startTutorial()
+  }
+
+  return {
+    activeTab,
+    setActiveTab,
+    logs,
+    alertType,
+    setAlertType,
+    activeDetailCard,
+    setActiveDetailCard,
+    showWelcome,
+    setShowWelcome,
+    isDragging,
+    isDraggingFile,
+    isImporting,
+    droppedItem,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    minting,
+    addLog,
+    handleStartMinting,
+    handleSaveCardDetails,
+    handleDeleteCard,
+    handleInjectPrompt,
+    handleResetDb,
+    handleClearLogs,
+    handleRetryConnection,
+    handleDismissAlert,
+    handleOpenMidjourney,
+    handleOpenGuide,
+    handleStartTutorial,
+    handleSkipTutorial,
+    handleToggleEasyMode: handleToggleEasyModeInternal
+  }
+}

--- a/src/pages/SidePanel.tsx
+++ b/src/pages/SidePanel.tsx
@@ -1,238 +1,27 @@
 import React, { useState, useEffect } from "react"
-import { db, seedDefaultCategories } from "../lib/db"
-import { SidePanelLayout } from "../components/templates/SidePanelLayout"
-import { HistoryTab } from "../components/organisms/HistoryTab"
-import { LibraryTab } from "../components/organisms/LibraryTab"
-import { Workbench } from "../components/organisms/Workbench"
-import { MintingView } from "../components/organisms/MintingView"
-import { CardDetailView } from "../components/organisms/CardDetailView"
-import { HandBar } from "../components/organisms/HandBar"
-import { InteractiveTutorial } from "../components/organisms/InteractiveTutorial"
-import { useTabs } from "../hooks/useTabs"
-import { SettingsTab } from "../components/organisms/SettingsTab"
-import { useDragAndDrop } from "../hooks/useDragAndDrop"
-import { useMinting } from "../hooks/useMinting"
 import { useActiveTabUrl } from "../hooks/useActiveTabUrl"
 import { NonTargetSiteView } from "../components/organisms/NonTargetSiteView"
 import { WorkbenchProvider } from "../contexts/WorkbenchContext"
-import { TutorialProvider, useTutorial } from "../contexts/TutorialContext"
-import type { AlertType } from "../components/molecules/ConnectionAlert"
-import type { StyleCard } from "../lib/db-schema"
+import { TutorialProvider } from "../contexts/TutorialContext"
+import { EasyModeView } from "../components/organisms/EasyModeView"
+import { ExpertModeView } from "../components/organisms/ExpertModeView"
 
 /**
- * First-launch welcome dialog (non-interactive) triggering the tutorial.
+ * Main inner container for the side panel. It manages site target detection
+ * and handles top-level routing between Easy Mode and Expert Mode.
  */
-function WelcomeDialog({ onStart, onSkip }: { onStart: () => void; onSkip: () => void }) {
-  return (
-    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200">
-      <div className="w-full max-w-xs bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl overflow-hidden text-slate-200 animate-in zoom-in-95 duration-200">
-        <div className="p-5 flex flex-col items-center gap-3">
-          <div className="w-14 h-14 rounded-full bg-blue-600/10 border border-blue-500/30 flex items-center justify-center">
-            <span className="text-3xl">🎴</span>
-          </div>
-          <h2 className="text-base font-black text-white text-center">Style Atelierへようこそ！</h2>
-          <p className="text-xs text-slate-400 leading-relaxed text-center">
-            実際に操作しながら使い方を覚える<br />インタラクティブなガイドを開始しますか？
-          </p>
-        </div>
-        <div className="px-5 pb-5 flex flex-col gap-2">
-          <button
-            onClick={onStart}
-            className="w-full py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-bold rounded-xl shadow transition-all"
-          >
-            ガイドを開始する
-          </button>
-          <button
-            onClick={onSkip}
-            className="w-full py-2 text-slate-500 hover:text-slate-300 text-xs font-semibold transition-all"
-          >
-            スキップ（あとでGuideボタンから開始できます）
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
 function SidePanelInner() {
   const { isTargetSite, isLoading } = useActiveTabUrl()
-  const { startTutorial, advanceIfStep } = useTutorial()
-  const { activeTab, setActiveTab } = useTabs()
-  const [logs, setLogs] = useState<string[]>([])
-  // New global state for connection alerts
-  const [alertType, setAlertType] = useState<AlertType>(null)
-  const [activeDetailCard, setActiveDetailCard] = useState<StyleCard | null>(null)
-  const [showWelcome, setShowWelcome] = useState(false)
   const [isEasyMode, setIsEasyMode] = useState(false)
 
   useEffect(() => {
-    const seen = localStorage.getItem("style-atelier-onboarding-seen")
-    if (!seen) {
-      setShowWelcome(true)
-    }
     const easyMode = localStorage.getItem("style-atelier-easy-mode") === "true"
     setIsEasyMode(easyMode)
-    if (easyMode) {
-      setActiveTab("library")
-    }
   }, [])
 
   const handleToggleEasyMode = (enabled: boolean) => {
     setIsEasyMode(enabled)
     localStorage.setItem("style-atelier-easy-mode", enabled ? "true" : "false")
-    addLog(`Interface mode changed: ${enabled ? "EASY" : "EXPERT"}`)
-    if (enabled) {
-      setActiveTab("library")
-    }
-  }
-
-  const handleStartTutorial = () => {
-    localStorage.setItem("style-atelier-onboarding-seen", "true")
-    setShowWelcome(false)
-    setActiveTab("history")
-    startTutorial()
-  }
-
-  const handleSkipTutorial = () => {
-    localStorage.setItem("style-atelier-onboarding-seen", "true")
-    setShowWelcome(false)
-  }
-
-  const addLog = (log: string) => {
-    setLogs((prev) => [log, ...prev].slice(0, 20))
-  }
-
-  const handleSaveCardDetails = async (updatedCard: StyleCard) => {
-    try {
-      await db.styleCards.put(updatedCard)
-      addLog(`StyleCard "${updatedCard.name}" updated successfully!`)
-      setActiveDetailCard(null)
-    } catch (err) {
-      console.error("Failed to save style card updates:", err)
-      addLog("Error: Failed to save style card updates.")
-    }
-  }
-
-  const handleDeleteCard = async (cardId: string) => {
-    try {
-      await db.deleteStyleCardAndCleanup(cardId);
-      addLog("StyleCard deleted successfully.");
-      setActiveDetailCard(null);
-    } catch (err) {
-      console.error("Failed to delete style card:", err);
-      addLog("Error: Failed to delete style card.");
-    }
-  };
-
-  const handleInjectPrompt = async (prompt: string) => {
-    setAlertType(null);
-    try {
-      const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-      const activeTab = tabs[0];
-      if (!activeTab?.id) {
-        throw new Error("No active tab found");
-      }
-      const response = await chrome.tabs.sendMessage(activeTab.id, {
-        type: "INJECT_PROMPT",
-        prompt: prompt,
-      });
-      if (response && response.status === "error") {
-        if (response.message && response.message.includes("Could not find chat input")) {
-          setAlertType("no_input");
-        } else {
-          setAlertType("disconnected");
-        }
-      } else {
-        addLog(`Sent prompt: ${prompt.substring(0, 30)}...`)
-        if (activeDetailCard) {
-          db.styleCards.update(activeDetailCard.id, {
-            usageCount: (activeDetailCard.usageCount || 0) + 1
-          }).catch(err => console.error("Failed to update usage count on details inject:", err));
-        }
-      }
-    } catch (err: any) {
-      console.error("Injection failed:", err);
-      setAlertType("disconnected");
-      addLog(`Note: ${err.message || "Could not send to tab"}`)
-    }
-  }
-  const { 
-    isDragging, 
-    isDraggingFile, 
-    isImporting, 
-    droppedItem, 
-    handleDragOver, 
-    handleDragLeave, 
-    handleDrop: rawHandleDrop 
-  } = useDragAndDrop(addLog)
- 
-  const handleDrop = async (e: React.DragEvent) => {
-    const result = (await rawHandleDrop(e)) as any
-    if (result) {
-      if (result.isImport) {
-        setActiveTab("library")
-      } else {
-        advanceIfStep("drop-history")
-      }
-    }
-  }
-
-  const {
-    mintingItem,
-    variationBase,
-    editedSegments,
-    setEditedSegments,
-    isSrefHidden,
-    setIsSrefHidden,
-    isPHidden,
-    setIsPHidden,
-    handleStartMinting: rawStartMinting,
-    handleStartVariationMinting,
-    handleSaveMintedCard,
-    setMintingItem,
-    setVariationBase,
-    selectedRarity,
-    setSelectedRarity,
-    suggestedKeywords,
-    selectedKeywords,
-    setSelectedKeywords,
-    customName,
-    setCustomName,
-    selectedCategory,
-    setSelectedCategory,
-    customTags,
-    setCustomTags,
-    detectedDominantColor,
-    detectedAccentColor,
-    detectedColorTags,
-  } = useMinting(addLog, setActiveTab)
-
-  const handleStartMinting = (historyItem: any) => {
-    rawStartMinting(historyItem)
-    advanceIfStep("mint-button")
-  }
-
-  const handleResetDb = async () => {
-    if (window.confirm("Are you sure you want to delete ALL DATA?")) {
-      await Promise.all([db.historyItems.clear(), db.styleCards.clear(), db.userSettings.clear(), db.categories.clear()])
-      await seedDefaultCategories()
-      localStorage.removeItem("style-atelier-onboarding-seen")
-      addLog("All data cleared.")
-    }
-  }
-
-  const handleClearLogs = () => {
-    setLogs([])
-  }
-
-  // Global retry handler - usually just reload
-  const handleRetryConnection = () => {
-    chrome.tabs.reload();
-    setAlertType(null);
-  }
-
-  const handleDismissAlert = () => {
-    setAlertType(null);
   }
 
   const handleOpenMidjourney = () => {
@@ -252,129 +41,23 @@ function SidePanelInner() {
   }
 
   if (!isTargetSite) {
-    return (
-      <NonTargetSiteView
-        onOpenMidjourney={handleOpenMidjourney}
-      />
-    )
+    return <NonTargetSiteView onOpenMidjourney={handleOpenMidjourney} />
   }
 
   return (
-    <div onDragOver={handleDragOver} onDragLeave={handleDragLeave} onDrop={handleDrop} className="h-full relative overflow-hidden">
-      <WorkbenchProvider>
-        <SidePanelLayout
-          activeTab={activeTab}
-          onTabChange={(tab) => {
-            setActiveTab(tab)
-            setMintingItem(null)
-            setVariationBase(null)
-            setActiveDetailCard(null)
-          }}
-          isDragging={isDragging}
-          isDraggingFile={isDraggingFile}
-          isImporting={isImporting}
-          logs={logs}
-          onClearLogs={handleClearLogs}
-          onResetDb={handleResetDb}
-          droppedItem={droppedItem}
-          alertType={alertType}
-          onRetryConnection={handleRetryConnection}
-          onDismissAlert={handleDismissAlert}
-          onOpenGuide={() => {
-            setActiveTab("history")
-            startTutorial()
-          }}
-          isEasyMode={isEasyMode}
-        >
-          {(mintingItem || variationBase) && (
-            <MintingView
-              mintingItem={mintingItem}
-              editedSegments={editedSegments}
-              setEditedSegments={setEditedSegments}
-              isSrefHidden={isSrefHidden}
-              setIsSrefHidden={setIsSrefHidden}
-              isPHidden={isPHidden}
-              setIsPHidden={setIsPHidden}
-              onCancelMinting={() => {
-                setMintingItem(null)
-                setVariationBase(null)
-              }}
-              onSaveMintedCard={handleSaveMintedCard}
-              selectedRarity={selectedRarity}
-              setSelectedRarity={setSelectedRarity}
-              suggestedKeywords={suggestedKeywords}
-              selectedKeywords={selectedKeywords}
-              setSelectedKeywords={setSelectedKeywords}
-              customName={customName}
-              setCustomName={setCustomName}
-              selectedCategory={selectedCategory}
-              setSelectedCategory={setSelectedCategory}
-              customTags={customTags}
-              setCustomTags={setCustomTags}
-              detectedDominantColor={detectedDominantColor}
-              detectedAccentColor={detectedAccentColor}
-              detectedColorTags={detectedColorTags}
-            />
-          )}
-          {activeDetailCard && (
-            <CardDetailView
-              card={activeDetailCard}
-              onClose={() => setActiveDetailCard(null)}
-              onInject={handleInjectPrompt}
-              onSave={handleSaveCardDetails}
-              setAlertType={setAlertType}
-              onCardSelect={async (cardId) => {
-                const targetCard = await db.styleCards.get(cardId);
-                if (targetCard) {
-                  setActiveDetailCard(targetCard);
-                } else {
-                  addLog("Warning: Selected parent card could not be found.");
-                }
-              }}
-              onDelete={handleDeleteCard}
-            />
-          )}
-          {activeTab === "history" && <HistoryTab onStartMinting={handleStartMinting} />}
-          {activeTab === "library" && (
-            <LibraryTab
-              addLog={addLog}
-              setAlertType={setAlertType}
-              onOpenDetailCard={setActiveDetailCard}
-              onNavigateToWorkbench={() => setActiveTab("workbench")}
-            />
-          )}
-          {activeTab === "workbench" && <Workbench onStartVariationMinting={handleStartVariationMinting} addLog={addLog} setAlertType={setAlertType} />}
-          {activeTab === "settings" && (
-            <SettingsTab 
-              addLog={addLog} 
-              onResetDb={handleResetDb} 
-              isEasyMode={isEasyMode}
-              onToggleEasyMode={handleToggleEasyMode}
-            />
-          )}
-
-          {/* HandBar is now inside SidePanelLayout children to ensure it stays in same context */}
-          <HandBar 
-            onNavigateToWorkbench={() => setActiveTab("workbench")}
-            onOpenDetailCard={setActiveDetailCard}
-          />
-        </SidePanelLayout>
-      </WorkbenchProvider>
-
-      {/* Welcome dialog on first launch */}
-      {showWelcome && (
-        <WelcomeDialog onStart={handleStartTutorial} onSkip={handleSkipTutorial} />
+    <WorkbenchProvider>
+      {isEasyMode ? (
+        <EasyModeView isEasyMode={isEasyMode} onToggleEasyMode={handleToggleEasyMode} />
+      ) : (
+        <ExpertModeView isEasyMode={isEasyMode} onToggleEasyMode={handleToggleEasyMode} />
       )}
-
-      {/* Interactive tutorial overlay */}
-      <InteractiveTutorial />
-    </div>
+    </WorkbenchProvider>
   )
 }
 
 /**
  * Root page component – wraps everything in TutorialProvider so useTutorial
- * is available both in SidePanelInner and InteractiveTutorial.
+ * is available within both the SidePanelInner router and underlying views.
  */
 function SidePanelPage() {
   return (


### PR DESCRIPTION
Resolves #250

## 概要
かんたんモードとエキスパートモードの開発を並列で進められるよう、SidePanel.tsx などで密結合になっていた状態管理・ビジネスロジック・UI表示をそれぞれ専用のカスタムフックとコンポーネントに分離し、疎結合化しました。

## 変更内容
- 各モード専用のロジック用カスタムフックを作成：useEasyModeView.ts, useExpertModeView.ts`n- 各モード専用のプレゼンターコンポーネントを作成：EasyModeView.tsx, ExpertModeView.tsx`n- SidePanel.tsx をルーターとしてのみ機能する薄いコンポーネントにリファクタリング
- それぞれのカスタムフックの動作を検証する単体テストを追加：useEasyModeView.test.tsx, useExpertModeView.test.tsx`n- 既存の全ユニットテストおよびE2Eテストがパスすることを確認