### PR TITLE
feat(easy-mode): Easy Mode で画像ドロップ時に簡易Mintモーダルを表示し即座にカード化する (#180)

### DIFF
--- a/src/components/organisms/EasyModeView.tsx
+++ b/src/components/organisms/EasyModeView.tsx
@@ -3,7 +3,7 @@ import { useEasyModeView } from "../../hooks/useEasyModeView"
 import { SidePanelLayout } from "../templates/SidePanelLayout"
 import { LibraryTab } from "./LibraryTab"
 import { SettingsTab } from "./SettingsTab"
-import { MintingView } from "./MintingView"
+import { SimpleMintingView } from "./SimpleMintingView"
 import { CardDetailView } from "./CardDetailView"
 import { db } from "../../lib/db"
 
@@ -73,21 +73,15 @@ export function EasyModeView({ isEasyMode, onToggleEasyMode }: EasyModeViewProps
         isEasyMode={isEasyMode}
       >
         {(minting.mintingItem || minting.variationBase) && (
-          <MintingView
+          <SimpleMintingView
             mintingItem={minting.mintingItem}
             editedSegments={minting.editedSegments}
             setEditedSegments={minting.setEditedSegments}
-            isSrefHidden={minting.isSrefHidden}
-            setIsSrefHidden={minting.setIsSrefHidden}
-            isPHidden={minting.isPHidden}
-            setIsPHidden={minting.setIsPHidden}
             onCancelMinting={() => {
               minting.setMintingItem(null)
               minting.setVariationBase(null)
             }}
             onSaveMintedCard={minting.handleSaveMintedCard}
-            selectedRarity={minting.selectedRarity}
-            setSelectedRarity={minting.setSelectedRarity}
             suggestedKeywords={minting.suggestedKeywords}
             selectedKeywords={minting.selectedKeywords}
             setSelectedKeywords={minting.setSelectedKeywords}
@@ -95,11 +89,6 @@ export function EasyModeView({ isEasyMode, onToggleEasyMode }: EasyModeViewProps
             setCustomName={minting.setCustomName}
             selectedCategory={minting.selectedCategory}
             setSelectedCategory={minting.setSelectedCategory}
-            customTags={minting.customTags}
-            setCustomTags={minting.setCustomTags}
-            detectedDominantColor={minting.detectedDominantColor}
-            detectedAccentColor={minting.detectedAccentColor}
-            detectedColorTags={minting.detectedColorTags}
           />
         )}
         {activeDetailCard && (

--- a/src/components/organisms/SimpleMintingView.tsx
+++ b/src/components/organisms/SimpleMintingView.tsx
@@ -1,0 +1,198 @@
+import React from "react"
+import type { HistoryItem, PromptSegment } from "../../lib/db-schema"
+import { PromptBubbleEditor } from "./PromptBubbleEditor"
+import { Button } from "../atoms/Button"
+import { Input } from "../atoms/Input"
+import { useLiveQuery } from "dexie-react-hooks"
+import { db } from "../../lib/db"
+
+interface SimpleMintingViewProps {
+  mintingItem: HistoryItem | null
+  editedSegments: PromptSegment[]
+  setEditedSegments: (segments: PromptSegment[]) => void
+  onCancelMinting: () => void
+  onSaveMintedCard: () => Promise<void>
+  suggestedKeywords: string[]
+  selectedKeywords: string[]
+  setSelectedKeywords: (keywords: string[]) => void
+  customName: string
+  setCustomName: (name: string) => void
+  selectedCategory?: string
+  setSelectedCategory?: (category: string) => void
+}
+
+/**
+ * SimpleMintingView component
+ * Streamlined, elegant card-creation view designed specifically for Easy Mode.
+ * It features a minimal input form (Card Name, Prompt, and Category) to speed up card minting.
+ */
+export function SimpleMintingView({
+  mintingItem,
+  editedSegments,
+  setEditedSegments,
+  onCancelMinting,
+  onSaveMintedCard,
+  suggestedKeywords,
+  selectedKeywords,
+  setSelectedKeywords,
+  customName,
+  setCustomName,
+  selectedCategory = "",
+  setSelectedCategory = () => {},
+}: SimpleMintingViewProps) {
+  const categoriesList = useLiveQuery(() => db.categories.toArray()) || []
+
+  // Ensure a category is always selected if categories exist
+  React.useEffect(() => {
+    if (categoriesList.length > 0 && !selectedCategory) {
+      setSelectedCategory(categoriesList[0].id)
+    }
+  }, [categoriesList, selectedCategory, setSelectedCategory])
+
+  const toggleKeyword = (keyword: string) => {
+    if (selectedKeywords.includes(keyword)) {
+      setSelectedKeywords(selectedKeywords.filter((k) => k !== keyword))
+    } else {
+      setSelectedKeywords([...selectedKeywords, keyword])
+    }
+  }
+
+  const currentName =
+    selectedKeywords.length > 0
+      ? `${selectedKeywords.join(" ")}${customName ? ` (${customName})` : ""}`
+      : customName || "New Card"
+
+  return (
+    <div
+      data-testid="simple-minting-view-container"
+      className="absolute inset-0 bg-slate-900/95 backdrop-blur-md z-20 flex flex-col items-center justify-center p-4 font-sans"
+    >
+      <div className="w-full max-w-sm bg-white rounded-2xl shadow-2xl overflow-hidden border border-slate-100 flex flex-col max-h-[90vh]">
+        {/* Header */}
+        <div className="p-4 border-b border-slate-100 bg-gradient-to-r from-blue-50 to-indigo-50 flex items-center justify-between">
+          <div>
+            <h2 className="text-sm font-black text-slate-800 tracking-tight">Quick Card Creator</h2>
+            <p className="text-[10px] text-slate-500 font-medium">Mint your style instantly</p>
+          </div>
+          <span className="text-xs bg-blue-600/10 text-blue-600 px-2 py-0.5 rounded-full font-bold">
+            Easy Mode
+          </span>
+        </div>
+
+        {/* Scrollable Content */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {mintingItem && (
+            <>
+              {/* Thumbnail Preview */}
+              <div className="relative group rounded-xl overflow-hidden shadow-md border border-slate-100 aspect-video bg-slate-950">
+                <img
+                  src={mintingItem.imageUrl}
+                  className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                  alt="Minting Preview"
+                />
+                <div className="absolute inset-0 bg-gradient-to-t from-slate-950/40 to-transparent" />
+              </div>
+
+              {/* Identity Form */}
+              <div className="space-y-3">
+                {/* Auto Name Suggestions */}
+                {suggestedKeywords.length > 0 && (
+                  <div>
+                    <label className="block text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">
+                      Quick Keywords
+                    </label>
+                    <div className="flex flex-wrap gap-1">
+                      {suggestedKeywords.map((kw, i) => {
+                        const isSelected = selectedKeywords.includes(kw)
+                        return (
+                          <button
+                            key={i}
+                            type="button"
+                            onClick={() => toggleKeyword(kw)}
+                            className={`px-2 py-0.5 rounded-full text-[10px] font-bold border transition-all duration-150 ${
+                              isSelected
+                                ? "bg-blue-600 border-blue-600 text-white shadow-sm"
+                                : "bg-slate-50 border-slate-200 text-slate-600 hover:bg-slate-100"
+                            }`}
+                          >
+                            {kw}
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Custom Card Name */}
+                <div>
+                  <label className="block text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">
+                    Card Name
+                  </label>
+                  <Input
+                    type="text"
+                    value={customName}
+                    onChange={(e) => setCustomName(e.target.value)}
+                    placeholder="Enter custom card name..."
+                    className="h-9 text-xs focus-visible:ring-blue-600 rounded-xl"
+                  />
+                  <div className="mt-1 text-[9px] text-slate-400 font-medium">
+                    Preview: <span className="font-bold text-slate-700">{currentName}</span>
+                  </div>
+                </div>
+
+                {/* Category Dropdown (Required) */}
+                <div>
+                  <label className="block text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">
+                    Category (Required)
+                  </label>
+                  <select
+                    value={selectedCategory}
+                    onChange={(e) => setSelectedCategory(e.target.value)}
+                    className="w-full text-xs border border-slate-200 rounded-xl bg-white p-2 h-9 font-medium text-slate-700 focus:outline-none focus:border-blue-600 focus:ring-1 focus:ring-blue-600"
+                  >
+                    {categoriesList.map((cat) => (
+                      <option key={cat.id} value={cat.id}>
+                        {cat.iconEmoji || "🖼️"} {cat.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              {/* Prompt Bubble Editor */}
+              <div>
+                <label className="block text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">
+                  Prompt Segments
+                </label>
+                <div className="border border-slate-200 rounded-xl overflow-hidden bg-slate-50 p-2">
+                  <PromptBubbleEditor
+                    initialSegments={editedSegments}
+                    onChange={setEditedSegments}
+                    tier="Common"
+                  />
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Footer Actions */}
+        <div className="p-4 border-t border-slate-100 bg-slate-50 flex gap-2 justify-end">
+          <Button
+            variant="ghost"
+            onClick={onCancelMinting}
+            className="h-9 text-xs rounded-xl hover:bg-slate-200/50"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={onSaveMintedCard}
+            className="h-9 text-xs bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-xl shadow-md hover:from-blue-700 hover:to-indigo-700 font-bold px-4"
+          >
+            Save to Library
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useEasyModeView.ts
+++ b/src/hooks/useEasyModeView.ts
@@ -100,6 +100,11 @@ export function useEasyModeView({ isEasyMode, onToggleEasyMode }: UseEasyModeVie
     if (result) {
       if (result.isImport) {
         setActiveTab("library")
+      } else {
+        const existingCard = await db.getCardByJobId(result.id)
+        if (!existingCard) {
+          minting.handleStartMinting(result)
+        }
       }
     }
   }

--- a/tests/e2e/drag-and-drop.spec.ts
+++ b/tests/e2e/drag-and-drop.spec.ts
@@ -230,4 +230,97 @@ test.describe("Style Atelier Sandbox E2E Tests - Drag and Drop", () => {
       path: path.join(screenshotsDir, "same-job-success.png"),
     });
   });
+
+  test("should allow dragging a mock Midjourney image in Easy Mode to trigger Simple Mint Modal and save card directly to Library", async ({ page }) => {
+    const screenshotsDir = path.join(__dirname, "../../tests/screenshots");
+    
+    console.log("Navigating to sandbox page for Easy Mode drag-and-drop test...");
+    await page.goto("/tests/sandbox/index.html");
+
+    const spFrame = page.frameLocator("#sidepanel-frame");
+
+    // 1. Skip welcome dialog if exists
+    const skipButton = spFrame.locator("text=スキップ");
+    if (await skipButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await skipButton.click();
+    }
+
+    // 2. Enable Easy Mode first
+    const settingsNavBtn = spFrame.locator("#settings-nav-btn");
+    await expect(settingsNavBtn).toBeVisible({ timeout: 10000 });
+    await settingsNavBtn.click();
+
+    const easyModeToggle = spFrame.locator("#easy-mode-toggle-btn");
+    await expect(easyModeToggle).toBeVisible({ timeout: 10000 });
+    await easyModeToggle.click();
+    await page.waitForTimeout(500);
+
+    // 3. Verify Easy Mode active (History tab is hidden)
+    const historyTabBtn = spFrame.locator("nav button:has-text('History')");
+    await expect(historyTabBtn).not.toBeVisible();
+
+    // 4. Dispatch drop event (Simulate Image drop)
+    console.log("Simulating drag-and-drop of an image in Easy Mode...");
+    const dropZone = spFrame.locator(".h-full.relative.overflow-hidden");
+    const imgData = {
+      id: "easy-mode-drop-job-123",
+      fullCommand: "A peaceful forest with rays of sunlight --ar 16:9 --sref 123456789",
+      imageUrl: "./index_files/0_0_640_N.webp",
+      timestamp: Date.now()
+    };
+
+    await dropZone.evaluate(async (element, item) => {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData("application/json", JSON.stringify(item));
+      const dragOverEvent = new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer });
+      element.dispatchEvent(dragOverEvent);
+      const dropEvent = new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer });
+      element.dispatchEvent(dropEvent);
+    }, imgData);
+
+    // 5. Verify Simple Mint Modal (Quick Card Creator) is visible
+    console.log("Waiting for Simple Mint Modal to open...");
+    const simpleMintContainer = spFrame.locator("[data-testid='simple-minting-view-container']");
+    await expect(simpleMintContainer).toBeVisible({ timeout: 10000 });
+
+    // 6. Verify default preview name or auto-keywords
+    const previewNameText = spFrame.locator("text=Preview:").first();
+    await expect(previewNameText).toBeVisible();
+
+    // 7. Verify category dropdown is visible
+    const categorySelect = simpleMintContainer.locator("select");
+    await expect(categorySelect).toBeVisible();
+    
+    // 8. Capture screenshot of the Simple Mint Modal
+    await page.screenshot({
+      path: path.join(screenshotsDir, "simple-mint-modal-open.png"),
+    });
+
+    // 9. Change custom card name
+    const customNameInput = simpleMintContainer.locator("input[placeholder='Enter custom card name...']");
+    await expect(customNameInput).toBeVisible();
+    await customNameInput.fill("Sunny Forest");
+
+    // 10. Click "Save to Library"
+    const saveBtn = spFrame.locator("button:has-text('Save to Library')");
+    await saveBtn.click();
+
+    // 11. Verify Modal closes and card is in Library
+    await expect(simpleMintContainer).not.toBeVisible({ timeout: 10000 });
+
+    // 12. Check in DB if the card with name "Sunny Forest" was created
+    const createdCard = await spFrame.locator("body").evaluate(async () => {
+      const database = (window as any).db;
+      const cards = await database.getAllCards();
+      return cards.find((c: any) => c.name.includes("Sunny Forest"));
+    });
+    expect(createdCard).toBeDefined();
+    expect(createdCard.name).toContain("Sunny Forest");
+
+    // 13. Capture final screenshot showing card added in Library
+    await page.screenshot({
+      path: path.join(screenshotsDir, "simple-mint-saved.png"),
+    });
+    console.log("Easy Mode Drag-and-drop E2E test passed successfully!");
+  });
 });


### PR DESCRIPTION
Resolves #180

## 変更内容
かんたんモード（Easy Mode）において、画像をドラッグ・アンド・ドロップした際に即座に簡易Mintモーダル（SimpleMintingView）を表示し、そのまま直接ライブラリに保存できる機能を実装しました。
また、この挙動に対するE2Eテストを追加し、正常に機能することを確認しました。

## UX変更の検証（E2Eテスト時のスクリーンショット）
### 1. 簡易Mintモーダル表示時
![simple-mint-modal-open.png](https://github.com/user-attachments/assets/04812e74-64aa-4029-92a5-53efab5d207d)

### 2. 保存完了後（ライブラリに追加された状態）
![simple-mint-saved.png](https://github.com/user-attachments/assets/197cd023-4878-453b-9052-fc5090252f1a)