### PR TITLE
docs: Add bilingual Privacy Policy for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,641 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy - Style Atelier</title>
+    <meta
+      name="description"
+      content="Privacy Policy for Style Atelier (Midjourney Style Manager) - A privacy-focused, local-first prompt management Chrome Extension." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@400;600;700;800&display=swap"
+      rel="stylesheet" />
+
+    <style>
+      :root {
+        --bg-gradient:
+          radial-gradient(
+            circle at top right,
+            rgba(99, 102, 241, 0.08),
+            transparent 40%
+          ),
+          radial-gradient(
+            circle at bottom left,
+            rgba(59, 130, 246, 0.08),
+            transparent 40%
+          ),
+          #fafafa;
+        --card-bg: rgba(255, 255, 255, 0.75);
+        --card-border: rgba(226, 232, 240, 0.8);
+        --text-main: #1e293b;
+        --text-muted: #64748b;
+        --primary: #3b82f6;
+        --primary-hover: #2563eb;
+        --shadow:
+          0 10px 30px -10px rgba(0, 0, 0, 0.04), 0 1px 3px rgba(0, 0, 0, 0.02);
+        --badge-bg: rgba(59, 130, 246, 0.08);
+        --badge-text: #2563eb;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg-gradient:
+            radial-gradient(
+              circle at top right,
+              rgba(99, 102, 241, 0.15),
+              transparent 40%
+            ),
+            radial-gradient(
+              circle at bottom left,
+              rgba(59, 130, 246, 0.15),
+              transparent 40%
+            ),
+            #0b0f19;
+          --card-bg: rgba(17, 24, 39, 0.7);
+          --card-border: rgba(31, 41, 55, 0.6);
+          --text-main: #f1f5f9;
+          --text-muted: #94a3b8;
+          --primary: #60a5fa;
+          --primary-hover: #3b82f6;
+          --shadow:
+            0 10px 30px -10px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.1);
+          --badge-bg: rgba(96, 165, 250, 0.12);
+          --badge-text: #60a5fa;
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family:
+          "Inter",
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+        background: var(--bg-gradient);
+        color: var(--text-main);
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+        padding: 2rem 1rem;
+        line-height: 1.6;
+        transition:
+          background 0.3s ease,
+          color 0.3s ease;
+      }
+
+      .container {
+        max-width: 800px;
+        width: 100%;
+        margin: 0 auto;
+      }
+
+      /* Glassmorphism Header */
+      header {
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 2rem;
+        padding: 1rem 1.5rem;
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        border-radius: 1rem;
+        box-shadow: var(--shadow);
+        transition: all 0.3s ease;
+      }
+
+      .logo {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .logo-icon {
+        font-size: 1.75rem;
+        animation: spin-slow 12s linear infinite;
+      }
+
+      @keyframes spin-slow {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .logo-text {
+        font-family: "Outfit", sans-serif;
+        font-weight: 800;
+        font-size: 1.25rem;
+        background: linear-gradient(135deg, #3b82f6, #6366f1);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+
+      /* Toggle Switch Component */
+      .lang-switcher {
+        display: flex;
+        background: var(--card-border);
+        padding: 0.25rem;
+        border-radius: 9999px;
+        gap: 0.25rem;
+        position: relative;
+      }
+
+      .lang-btn {
+        border: none;
+        background: transparent;
+        color: var(--text-muted);
+        font-weight: 600;
+        font-size: 0.85rem;
+        padding: 0.5rem 1.25rem;
+        border-radius: 9999px;
+        cursor: pointer;
+        transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      }
+
+      .lang-btn.active {
+        background: var(--card-bg);
+        color: var(--badge-text);
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+      }
+
+      /* main card */
+      main {
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        border-radius: 1.5rem;
+        padding: 3rem 2.5rem;
+        box-shadow: var(--shadow);
+        transition: all 0.3s ease;
+      }
+
+      h1 {
+        font-family: "Outfit", sans-serif;
+        font-weight: 800;
+        font-size: 2.25rem;
+        margin-bottom: 0.5rem;
+        letter-spacing: -0.025em;
+        line-height: 1.2;
+      }
+
+      .subtitle {
+        color: var(--text-muted);
+        font-size: 1.1rem;
+        margin-bottom: 2.5rem;
+        font-weight: 500;
+      }
+
+      .section-badge {
+        display: inline-flex;
+        align-items: center;
+        background: var(--badge-bg);
+        color: var(--badge-text);
+        padding: 0.35rem 0.75rem;
+        border-radius: 9999px;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        margin-bottom: 1rem;
+      }
+
+      section {
+        margin-bottom: 2.5rem;
+        animation: fadeIn 0.4s ease-out;
+      }
+
+      section:last-of-type {
+        margin-bottom: 0;
+      }
+
+      h2 {
+        font-family: "Outfit", sans-serif;
+        font-weight: 700;
+        font-size: 1.4rem;
+        margin-bottom: 1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      p {
+        color: var(--text-muted);
+        margin-bottom: 1.25rem;
+        font-size: 0.95rem;
+      }
+
+      ul {
+        list-style-type: none;
+        margin-bottom: 1.25rem;
+        padding-left: 0.25rem;
+      }
+
+      li {
+        color: var(--text-muted);
+        position: relative;
+        padding-left: 1.5rem;
+        margin-bottom: 0.75rem;
+        font-size: 0.95rem;
+      }
+
+      li::before {
+        content: "✦";
+        position: absolute;
+        left: 0;
+        color: var(--primary);
+        font-weight: bold;
+      }
+
+      /* Highlight box for key messages */
+      .callout {
+        background: linear-gradient(
+          135deg,
+          rgba(59, 130, 246, 0.05),
+          rgba(99, 102, 241, 0.05)
+        );
+        border: 1px solid rgba(59, 130, 246, 0.15);
+        border-radius: 1rem;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .callout p {
+        color: var(--text-main);
+        font-weight: 500;
+        margin-bottom: 0;
+        font-size: 0.95rem;
+      }
+
+      a {
+        color: var(--primary);
+        text-decoration: none;
+        font-weight: 600;
+        border-bottom: 1px solid transparent;
+        transition: all 0.2s ease;
+      }
+
+      a:hover {
+        color: var(--primary-hover);
+        border-bottom-color: var(--primary-hover);
+      }
+
+      footer {
+        margin-top: 3rem;
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.8rem;
+        width: 100%;
+      }
+
+      /* Language-specific content display toggle */
+      [lang="en"] .lang-ja,
+      [lang="ja"] .lang-en {
+        display: none;
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(8px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      /* Mobile adjustments */
+      @media (max-width: 640px) {
+        body {
+          padding: 1rem 0.5rem;
+        }
+        header {
+          padding: 0.75rem 1rem;
+          margin-bottom: 1rem;
+        }
+        main {
+          padding: 2rem 1.5rem;
+          border-radius: 1rem;
+        }
+        h1 {
+          font-size: 1.75rem;
+        }
+        h2 {
+          font-size: 1.2rem;
+        }
+        p,
+        li {
+          font-size: 0.9rem;
+        }
+      }
+    </style>
+  </head>
+  <body lang="ja">
+    <div class="container">
+      <header>
+        <div class="logo">
+          <span class="logo-icon">🌌</span>
+          <span class="logo-text">Style Atelier</span>
+        </div>
+        <div class="lang-switcher">
+          <button id="btn-ja" class="lang-btn active" onclick="setLang('ja')">
+            日本語
+          </button>
+          <button id="btn-en" class="lang-btn" onclick="setLang('en')">
+            English
+          </button>
+        </div>
+      </header>
+
+      <main>
+        <!-- ==================== JAPANESE CONTENT ==================== -->
+        <div class="lang-ja">
+          <h1>プライバシーポリシー</h1>
+          <p class="subtitle">最終更新日: 2026年6月7日</p>
+
+          <section>
+            <div class="section-badge">Concept</div>
+            <h2>1. プライバシーに関する基本理念</h2>
+            <p>
+              Style
+              Atelier（以下「本拡張機能」）は、ユーザーが作成するクリエイティブなプロンプトやスタイル情報はユーザー自身の貴重な資産であると考えています。そのため、本拡張機能は設計段階から<strong>「ローカルファースト」かつ「プライバシー重視」</strong>のサーバーレス・アプリケーションとして構築されています。
+            </p>
+          </section>
+
+          <section>
+            <div class="section-badge">Data Collection</div>
+            <h2>2. 個人情報の収集・送信について</h2>
+            <div class="callout">
+              <p>
+                本拡張機能は、ユーザーを特定できる個人情報（PII）や作成されたプロンプトデータを収集・保存・外部サーバーへ送信することは一切ありません。
+              </p>
+            </div>
+            <p>
+              すべてのデータはユーザーの管理下に置かれ、外部のデータベースや開発者サーバーに蓄積されることはありません。以下のような情報はすべてローカルに完結します：
+            </p>
+            <ul>
+              <li>作成・保存したスタイルカードのメタデータおよび画像</li>
+              <li>プロンプトの履歴およびお気に入り設定</li>
+              <li>バインダー、デッキ、カテゴリの設定情報</li>
+            </ul>
+          </section>
+
+          <section>
+            <div class="section-badge">Security</div>
+            <h2>3. Google Drive同期と認証情報の取り扱い</h2>
+            <p>
+              ユーザーがデータバックアップのための「Google
+              Drive連携」を有効化した場合のみ、Google Drive API（<code
+                >drive.file</code
+              >
+              スコープ）への通信が発生します。この際の認証情報は以下のように厳格に処理されます：
+            </p>
+            <ul>
+              <li>
+                <strong>一時的なメモリ内処理</strong>：認証には Chrome
+                のネイティブ Identity API を使用した安全な Google OAuth2
+                フローが利用されます。
+              </li>
+              <li>
+                <strong>即時破棄</strong
+                >：処理中に一時的に発生するアクセス権限やトークンなどの認証情報は、同期・復元処理が終わった後に直ちに破棄され、アプリ内に残ることはありません。
+              </li>
+              <li>
+                <strong>外部保存の排除</strong
+                >：これらの認証情報は本拡張機能のローカルストレージに永続化されることも、開発者サーバーや第三者に送信されることもありません。
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <div class="section-badge">Permissions</div>
+            <h2>4. 権限（パーミッション）の使用目的</h2>
+            <p>
+              本拡張機能が正常に機能するために要求する各権限の目的は以下の通りです：
+            </p>
+            <ul>
+              <li>
+                <strong>activeTab</strong
+                >：現在表示しているMidjourneyまたはDiscordのタブから、プロンプトデータを読み込んでカードを作成（ミント）するために使用されます。このデータ処理も完全にブラウザ内で完結します。
+              </li>
+              <li>
+                <strong>identity</strong>：Google Drive
+                バックアップ機能での一時的な認証処理にのみ使用されます。
+              </li>
+              <li>
+                <strong>ホスト権限（midjourney.com / discord.com等）</strong
+                >：Midjourneyの生成画面やDiscord上のテキストを検出するためのもので、通信はユーザーのローカルマシン内のみで行われます。
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <div class="section-badge">Storage</div>
+            <h2>5. データの削除とオフライン動作</h2>
+            <p>
+              本拡張機能はオフラインでも完全に動作します。本拡張機能をアンインストールするか、ブラウザのストレージデータをクリアすると、ローカル（IndexedDB）に保存されているすべてのスタイルデータおよび履歴は完全に削除されます。
+            </p>
+          </section>
+
+          <section>
+            <div class="section-badge">Contact</div>
+            <h2>6. お問い合わせ</h2>
+            <p>
+              本ポリシーやプライバシーに関するご質問、不具合報告、フィードバックは、GitHubのリポジトリのIssueにて受け付けております。<br /><a
+                href="https://github.com/tmaeda11235/style-atelier"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Style Atelier GitHub Repository</a
+              >
+            </p>
+          </section>
+        </div>
+
+        <!-- ==================== ENGLISH CONTENT ==================== -->
+        <div class="lang-en">
+          <h1>Privacy Policy</h1>
+          <p class="subtitle">Last Updated: June 7, 2026</p>
+
+          <section>
+            <div class="section-badge">Concept</div>
+            <h2>1. Core Privacy Philosophy</h2>
+            <p>
+              We believe that your creative prompts and style designs are your
+              valuable intellectual assets. Therefore,
+              <strong>Style Atelier</strong> (the "Extension") is designed from
+              the ground up as a
+              <strong>"Local-First" and "Privacy-Focused"</strong> serverless
+              application.
+            </p>
+          </section>
+
+          <section>
+            <div class="section-badge">Data Collection</div>
+            <h2>2. No Personal Data Collection</h2>
+            <div class="callout">
+              <p>
+                This extension does NOT collect, store, or transmit any
+                personally identifiable information (PII) or your prompt designs
+                to any external servers.
+              </p>
+            </div>
+            <p>
+              All data remains fully under your control and is stored locally in
+              your browser. The following data is processed and saved offline
+              inside your local environment:
+            </p>
+            <ul>
+              <li>Metadata and images of minted Style Cards</li>
+              <li>Prompt generation history and favorites</li>
+              <li>Binder, deck, and custom category configurations</li>
+            </ul>
+          </section>
+
+          <section>
+            <div class="section-badge">Security</div>
+            <h2>3. Google Drive Sync & Transient Credentials</h2>
+            <p>
+              Communication with the Google Drive API (<code>drive.file</code>
+              scope) only occurs when you explicitly enable the "Google Drive
+              Sync" feature to backup or restore your library. Authentication
+              credentials are handled under strict security guidelines:
+            </p>
+            <ul>
+              <li>
+                <strong>In-Memory Processing</strong>: Authentication is
+                performed via Chrome's native Identity API using a secure Google
+                OAuth2 flow.
+              </li>
+              <li>
+                <strong>Immediate Destruction</strong>: Any access tokens or
+                authentication credentials generated during the sync or recovery
+                process are transient. They are processed entirely in memory and
+                are **discarded/destroyed immediately** after the task is
+                completed.
+              </li>
+              <li>
+                <strong>No Persistent Storage</strong>: Credentials are never
+                saved to local persistent storage (localStorage/IndexedDB)
+                within the extension, nor are they sent to developer-managed
+                servers or any third parties.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <div class="section-badge">Permissions</div>
+            <h2>4. Use of Extension Permissions</h2>
+            <p>
+              The Extension requests the following permissions for specific
+              functionality:
+            </p>
+            <ul>
+              <li>
+                <strong>activeTab</strong>: Used exclusively to parse prompt
+                strings from the active Midjourney or Discord tab when you click
+                to mint a card. This parsing happens entirely locally.
+              </li>
+              <li>
+                <strong>identity</strong>: Used only for temporary
+                authentication with Google Drive for backup operations.
+              </li>
+              <li>
+                <strong>Host Permissions (midjourney.com / discord.com)</strong
+                >: Used to detect Midjourney grid images and prompts within the
+                specified websites locally. No remote tracking occurs.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <div class="section-badge">Storage</div>
+            <h2>5. Data Deletion & Offline Operation</h2>
+            <p>
+              The Extension works completely offline. Uninstalling the Extension
+              or clearing browser data will permanently remove all style cards,
+              prompts, and settings saved in your IndexedDB.
+            </p>
+          </section>
+
+          <section>
+            <div class="section-badge">Contact</div>
+            <h2>6. Contact & Feedback</h2>
+            <p>
+              For inquiries, issue reporting, or feedback regarding our privacy
+              practices, please visit our GitHub repository:<br /><a
+                href="https://github.com/tmaeda11235/style-atelier"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Style Atelier GitHub Repository</a
+              >
+            </p>
+          </section>
+        </div>
+      </main>
+
+      <footer>
+        <p>&copy; 2026 Style Atelier. All Rights Reserved.</p>
+      </footer>
+    </div>
+
+    <script>
+      function setLang(lang) {
+        document.body.setAttribute("lang", lang)
+
+        const btnJa = document.getElementById("btn-ja")
+        const btnEn = document.getElementById("btn-en")
+
+        if (lang === "ja") {
+          btnJa.classList.add("active")
+          btnEn.classList.remove("active")
+          document.title = "プライバシーポリシー - Style Atelier"
+        } else {
+          btnJa.classList.remove("active")
+          btnEn.classList.add("active")
+          document.title = "Privacy Policy - Style Atelier"
+        }
+
+        // Save user preference
+        try {
+          localStorage.setItem("pref-lang", lang)
+        } catch (e) {}
+      }
+
+      // Auto-detect language or use saved preference
+      window.addEventListener("DOMContentLoaded", () => {
+        let lang = "ja" // Default to Japanese
+
+        try {
+          const savedLang = localStorage.getItem("pref-lang")
+          if (savedLang) {
+            lang = savedLang
+          } else {
+            const browserLang = navigator.language || navigator.userLanguage
+            if (browserLang && !browserLang.startsWith("ja")) {
+              lang = "en"
+            }
+          }
+        } catch (e) {}
+
+        setLang(lang)
+      })
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #283. Adds a beautiful, bilingual (EN/JA) Privacy Policy page under docs/index.html to be published on GitHub Pages. The policy states that no PII is collected, and any transient credentials used for Google Drive sync are destroyed immediately after processing.