### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -2,6 +2,9 @@ name: "Submit to Web Store"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tmaeda11235/style-atelier/security/code-scanning/9](https://github.com/tmaeda11235/style-atelier/security/code-scanning/9)

Add an explicit `permissions` block to `.github/workflows/submit.yml` at the workflow root so it applies to all jobs (including `build`) unless overridden. The safest minimal fix that preserves behavior is:

- `contents: read`

This matches CodeQL’s recommended baseline and is typically sufficient for `actions/checkout`, dependency install, build/package steps, and many publish actions that rely on external secrets rather than `GITHUB_TOKEN` writes.

Edit region: directly under the `on` block (before `jobs`) in `.github/workflows/submit.yml`.  
No imports, methods, or definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
