### PR TITLE
feat: Resolve hardcoded Japanese/English text in UI tabs (#294)

### DIFF
--- a/src/components/organisms/HistoryTab.test.tsx
+++ b/src/components/organisms/HistoryTab.test.tsx
@@ -1,12 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen } from "@testing-library/react"
 import React from "react"
-import { HistoryTab } from "./HistoryTab"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { LanguageProvider } from "../../contexts/LanguageContext"
 import { useHistory } from "../../hooks/useHistory"
 import type { HistoryItem } from "../../lib/db-schema"
+import { HistoryTab } from "./HistoryTab"
 
 vi.mock("../../hooks/useHistory", () => ({
-  useHistory: vi.fn(),
+  useHistory: vi.fn()
 }))
 
 const mockHistoryItems: HistoryItem[] = [
@@ -20,8 +22,8 @@ const mockHistoryItems: HistoryItem[] = [
     imagePrompts: [],
     promptSegments: [],
     parameters: {},
-    dominantColor: "#000000",
-  },
+    dominantColor: "#000000"
+  }
 ]
 
 describe("HistoryTab", () => {
@@ -29,18 +31,25 @@ describe("HistoryTab", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.setItem("style-atelier-language", "ja")
   })
 
   it("renders empty container while loading", () => {
     vi.mocked(useHistory).mockReturnValue({
       historyItems: undefined,
       loadMore: vi.fn(),
-      hasMore: false,
+      hasMore: false
     })
 
-    const { container } = render(<HistoryTab onStartMinting={mockStartMinting} />)
+    const { container } = render(
+      <LanguageProvider>
+        <HistoryTab onStartMinting={mockStartMinting} />
+      </LanguageProvider>
+    )
     expect(container.firstChild).not.toBeNull()
-    const dropZone = container.querySelector('[data-tutorial="history-drop-zone"]')
+    const dropZone = container.querySelector(
+      '[data-tutorial="history-drop-zone"]'
+    )
     expect(dropZone).toBeDefined()
     expect(dropZone?.childNodes.length).toBe(0)
   })
@@ -49,12 +58,18 @@ describe("HistoryTab", () => {
     vi.mocked(useHistory).mockReturnValue({
       historyItems: [],
       loadMore: vi.fn(),
-      hasMore: false,
+      hasMore: false
     })
 
-    render(<HistoryTab onStartMinting={mockStartMinting} />)
+    render(
+      <LanguageProvider>
+        <HistoryTab onStartMinting={mockStartMinting} />
+      </LanguageProvider>
+    )
     expect(screen.getByText("履歴がありません")).toBeDefined()
-    expect(screen.getByText(/Midjourneyのプロンプト入力エリアから画像/)).toBeDefined()
+    expect(
+      screen.getByText(/Midjourneyのプロンプト入力エリアから画像/)
+    ).toBeDefined()
     expect(screen.getByRole("link", { name: "Midjourneyを開く" })).toBeDefined()
   })
 
@@ -62,10 +77,14 @@ describe("HistoryTab", () => {
     vi.mocked(useHistory).mockReturnValue({
       historyItems: mockHistoryItems,
       loadMore: vi.fn(),
-      hasMore: false,
+      hasMore: false
     })
 
-    render(<HistoryTab onStartMinting={mockStartMinting} />)
+    render(
+      <LanguageProvider>
+        <HistoryTab onStartMinting={mockStartMinting} />
+      </LanguageProvider>
+    )
     expect(screen.getByText("a majestic golden castle")).toBeDefined()
   })
 })

--- a/src/components/organisms/HistoryTab.tsx
+++ b/src/components/organisms/HistoryTab.tsx
@@ -1,8 +1,10 @@
+import { ExternalLink, History } from "lucide-react"
 import React, { useEffect, useRef } from "react"
+
+import { useLanguage } from "../../contexts/LanguageContext"
 import { useHistory } from "../../hooks/useHistory"
 import type { HistoryItem } from "../../lib/db-schema"
 import { HistoryCard } from "../molecules/HistoryCard"
-import { History, ExternalLink } from "lucide-react"
 
 interface HistoryTabProps {
   onStartMinting: (item: HistoryItem) => void
@@ -11,6 +13,8 @@ interface HistoryTabProps {
 export function HistoryTab({ onStartMinting }: HistoryTabProps) {
   const { historyItems, loadMore, hasMore } = useHistory()
   const sentinelRef = useRef<HTMLDivElement>(null)
+  const { t: i18n } = useLanguage()
+  const t = i18n.historyTab
 
   useEffect(() => {
     if (!hasMore || !historyItems || historyItems.length < 50) return
@@ -22,7 +26,7 @@ export function HistoryTab({ onStartMinting }: HistoryTabProps) {
         }
       },
       {
-        rootMargin: "100px",
+        rootMargin: "100px"
       }
     )
 
@@ -41,24 +45,24 @@ export function HistoryTab({ onStartMinting }: HistoryTabProps) {
 
   if (historyItems !== undefined && historyItems.length === 0) {
     return (
-      <div 
+      <div
         className="flex flex-col items-center justify-center text-center p-8 bg-slate-50/50 rounded-xl border border-slate-200 border-dashed backdrop-blur-sm animate-in fade-in duration-300"
-        data-tutorial="history-drop-zone"
-      >
+        data-tutorial="history-drop-zone">
         <div className="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mb-4 text-slate-400">
           <History className="w-6 h-6 text-slate-500" />
         </div>
-        <h3 className="text-sm font-bold text-slate-800 mb-1">履歴がありません</h3>
+        <h3 className="text-sm font-bold text-slate-800 mb-1">
+          {t.emptyTitle}
+        </h3>
         <p className="text-xs text-slate-500 max-w-[240px] leading-relaxed mb-4">
-          Midjourneyのプロンプト入力エリアから画像をドラッグ＆ドロップするか、MidjourneyのWebサイトからスタイルを連携してください。
+          {t.emptyDesc}
         </p>
         <a
           href="https://www.midjourney.com/explore"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors shadow-sm"
-        >
-          <span>Midjourneyを開く</span>
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors shadow-sm">
+          <span>{t.openMidjourney}</span>
           <ExternalLink className="w-3.5 h-3.5" />
         </a>
       </div>
@@ -68,21 +72,19 @@ export function HistoryTab({ onStartMinting }: HistoryTabProps) {
   return (
     <div className="space-y-3 pb-4" data-tutorial="history-drop-zone">
       {historyItems?.map((item, idx) => (
-        <div key={item.id} data-tutorial={idx === 0 ? "mint-button" : undefined}>
-          <HistoryCard
-            item={item}
-            onMintClick={onStartMinting}
-          />
+        <div
+          key={item.id}
+          data-tutorial={idx === 0 ? "mint-button" : undefined}>
+          <HistoryCard item={item} onMintClick={onStartMinting} />
         </div>
       ))}
 
       {hasMore && historyItems && historyItems.length >= 50 && (
         <div
           ref={sentinelRef}
-          className="py-4 text-center text-xs text-zinc-500 font-medium flex items-center justify-center gap-2"
-        >
+          className="py-4 text-center text-xs text-zinc-500 font-medium flex items-center justify-center gap-2">
           <span className="w-4 h-4 border-2 border-zinc-500 border-t-transparent rounded-full animate-spin"></span>
-          <span>読み込み中...</span>
+          <span>{t.loading}</span>
         </div>
       )}
     </div>

--- a/src/components/organisms/LibraryTab.test.tsx
+++ b/src/components/organisms/LibraryTab.test.tsx
@@ -1,18 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render as tlRender, screen, fireEvent } from "@testing-library/react"
-import { SettingsProvider } from "../../contexts/SettingsContext"
+import { fireEvent, screen, render as tlRender } from "@testing-library/react"
 import React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const render = (ui: React.ReactElement, options?: any) => {
-  return tlRender(ui, { wrapper: SettingsProvider, ...options })
-}
-import { LibraryTab } from "./LibraryTab"
+import { LanguageProvider } from "../../contexts/LanguageContext"
+import { SettingsProvider } from "../../contexts/SettingsContext"
+import { TutorialProvider } from "../../contexts/TutorialContext"
 import { useLibrary } from "../../hooks/useLibrary"
 import type { StyleCard } from "../../lib/db-schema"
-import { TutorialProvider } from "../../contexts/TutorialContext"
+import { LibraryTab } from "./LibraryTab"
+
+const render = (ui: React.ReactElement, options?: any) => {
+  return tlRender(
+    <LanguageProvider>
+      <SettingsProvider>{ui}</SettingsProvider>
+    </LanguageProvider>,
+    options
+  )
+}
 
 vi.mock("../../hooks/useLibrary", () => ({
-  useLibrary: vi.fn(),
+  useLibrary: vi.fn()
 }))
 
 const mockCards: StyleCard[] = [
@@ -32,8 +39,8 @@ const mockCards: StyleCard[] = [
     dominantColor: "#d4af37",
     thumbnailData: "data:image/png;base64,123",
     frameId: "default",
-    genealogy: { generation: 1, parentIds: [] },
-  },
+    genealogy: { generation: 1, parentIds: [] }
+  }
 ]
 
 describe("LibraryTab", () => {
@@ -44,13 +51,14 @@ describe("LibraryTab", () => {
   const defaultProps = {
     addLog: mockAddLog,
     setAlertType: mockSetAlertType,
-    onOpenDetailCard: mockOpenDetailCard,
+    onOpenDetailCard: mockOpenDetailCard
   }
 
   const mockTogglePin = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.setItem("style-atelier-language", "ja")
     vi.mocked(useLibrary).mockReturnValue({
       styleCards: mockCards,
       handleCardClick: vi.fn(),
@@ -67,37 +75,55 @@ describe("LibraryTab", () => {
       setSortBy: vi.fn(),
       allSrefs: [],
       categories: [],
-      allCards: mockCards,
+      allCards: mockCards
     })
   })
 
   it("renders search field, filters, and cards", () => {
-    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
-    expect(screen.getByPlaceholderText("Search by tag, name or sref...")).toBeDefined()
+    render(
+      <TutorialProvider>
+        <LibraryTab {...defaultProps} />
+      </TutorialProvider>
+    )
+    expect(
+      screen.getByPlaceholderText("Search by tag, name or sref...")
+    ).toBeDefined()
     expect(screen.getByText("Golden Dragon")).toBeDefined()
   })
 
   it("triggers togglePin when clicking the card itself", () => {
-    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
+    render(
+      <TutorialProvider>
+        <LibraryTab {...defaultProps} />
+      </TutorialProvider>
+    )
     const cardElement = screen.getByText("Golden Dragon").closest(".group")
     expect(cardElement).toBeDefined()
-    
+
     fireEvent.click(cardElement!)
     expect(mockTogglePin).toHaveBeenCalledWith(mockCards[0], expect.any(Object))
   })
 
   it("triggers onOpenDetailCard when clicking the edit button on the card", () => {
-    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
+    render(
+      <TutorialProvider>
+        <LibraryTab {...defaultProps} />
+      </TutorialProvider>
+    )
     const editBtn = screen.getByTestId("edit-card-button")
     expect(editBtn).toBeDefined()
-    
+
     fireEvent.click(editBtn)
     expect(mockOpenDetailCard).toHaveBeenCalledWith(mockCards[0])
     expect(mockTogglePin).not.toHaveBeenCalled()
   })
 
   it("opens ShareCardModal when clicking the share button on the card", () => {
-    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
+    render(
+      <TutorialProvider>
+        <LibraryTab {...defaultProps} />
+      </TutorialProvider>
+    )
     const shareBtn = screen.getByTestId("share-card-button")
     expect(shareBtn).toBeDefined()
 
@@ -130,13 +156,17 @@ describe("LibraryTab", () => {
       setSortBy: vi.fn(),
       allSrefs: [],
       categories: [],
-      allCards: mockCards,
+      allCards: mockCards
     })
 
-    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
-    
+    render(
+      <TutorialProvider>
+        <LibraryTab {...defaultProps} />
+      </TutorialProvider>
+    )
+
     expect(screen.getByText("Color:")).toBeDefined()
-    
+
     const redButton = screen.getByTitle("Red")
     expect(redButton).toBeDefined()
     fireEvent.click(redButton)
@@ -160,12 +190,18 @@ describe("LibraryTab", () => {
       setSortBy: vi.fn(),
       allSrefs: [],
       categories: [],
-      allCards: [],
+      allCards: []
     })
 
-    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
+    render(
+      <TutorialProvider>
+        <LibraryTab {...defaultProps} />
+      </TutorialProvider>
+    )
     expect(screen.getByText("スタイルカードがありません")).toBeDefined()
-    expect(screen.getByText(/Historyタブから画像をドラッグ＆ドロップ/)).toBeDefined()
+    expect(
+      screen.getByText(/Historyタブから画像をドラッグ＆ドロップ/)
+    ).toBeDefined()
   })
 
   it("renders empty state when search filters return no cards and allows clearing filters", () => {
@@ -189,14 +225,22 @@ describe("LibraryTab", () => {
       setSortBy: vi.fn(),
       allSrefs: [],
       categories: [],
-      allCards: mockCards,
+      allCards: mockCards
     })
 
-    render(<TutorialProvider><LibraryTab {...defaultProps} /></TutorialProvider>)
+    render(
+      <TutorialProvider>
+        <LibraryTab {...defaultProps} />
+      </TutorialProvider>
+    )
     expect(screen.getByText("カードが見つかりません")).toBeDefined()
-    expect(screen.getByText(/検索キーワードやフィルターの条件を変更するか/)).toBeDefined()
+    expect(
+      screen.getByText(/検索キーワードやフィルターの条件を変更するか/)
+    ).toBeDefined()
 
-    const clearButton = screen.getByRole("button", { name: "フィルターをクリア" })
+    const clearButton = screen.getByRole("button", {
+      name: "フィルターをクリア"
+    })
     expect(clearButton).toBeDefined()
     fireEvent.click(clearButton)
 

--- a/src/components/organisms/LibraryTab.tsx
+++ b/src/components/organisms/LibraryTab.tsx
@@ -1,15 +1,17 @@
+import { BookUp2, Search, Tag } from "lucide-react"
 import React, { useState } from "react"
+
+import { useLanguage } from "../../contexts/LanguageContext"
+import { useSettings } from "../../contexts/SettingsContext"
+import { useTutorial } from "../../contexts/TutorialContext"
 import { useLibrary } from "../../hooks/useLibrary"
-import { RARITY_CONFIG } from "../../lib/rarity-config"
-import { SearchField } from "../molecules/SearchField"
-import { CardThumbnail } from "../molecules/CardThumbnail"
 import type { StyleCard } from "../../lib/db-schema"
-import { Tag, BookUp2, Search } from "lucide-react"
+import { RARITY_CONFIG } from "../../lib/rarity-config"
+import { CardThumbnail } from "../molecules/CardThumbnail"
+import { ConnectionAlert, type AlertType } from "../molecules/ConnectionAlert"
+import { SearchField } from "../molecules/SearchField"
 import { CategoryManagerModal } from "./CategoryManagerModal"
 import { ShareCardModal } from "./ShareCardModal"
-import { ConnectionAlert, type AlertType } from "../molecules/ConnectionAlert"
-import { useTutorial } from "../../contexts/TutorialContext"
-import { useSettings } from "../../contexts/SettingsContext"
 
 interface LibraryTabProps {
   addLog: (msg: string) => void
@@ -26,12 +28,14 @@ export function LibraryTab({
   onOpenDetailCard,
   onNavigateToWorkbench,
   isEasyMode = false,
-  onOpenSimpleWorkbench,
+  onOpenSimpleWorkbench
 }: LibraryTabProps) {
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false)
   const [sharingCard, setSharingCard] = useState<StyleCard | null>(null)
   const { advanceIfStep } = useTutorial()
   const { expertFeatures } = useSettings()
+  const { t: i18n } = useLanguage()
+  const t = i18n.libraryTab
 
   const {
     styleCards,
@@ -49,11 +53,15 @@ export function LibraryTab({
     setSortBy,
     allSrefs,
     categories,
-    allCards,
+    allCards
   } = useLibrary(addLog, setAlertType, onNavigateToWorkbench)
 
   const colorOptions = [
-    { value: "All", label: "All Colors", bg: "linear-gradient(45deg, #ef4444, #f97316, #eab308, #22c55e, #3b82f6, #a855f7)" },
+    {
+      value: "All",
+      label: "All Colors",
+      bg: "linear-gradient(45deg, #ef4444, #f97316, #eab308, #22c55e, #3b82f6, #a855f7)"
+    },
     { value: "Red", label: "Red", bg: "#ef4444" },
     { value: "Orange", label: "Orange", bg: "#f97316" },
     { value: "Yellow", label: "Yellow", bg: "#eab308" },
@@ -65,7 +73,7 @@ export function LibraryTab({
     { value: "Brown", label: "Brown", bg: "#78350f" },
     { value: "White", label: "White", bg: "#ffffff" },
     { value: "Gray", label: "Gray", bg: "#6b7280" },
-    { value: "Black", label: "Black", bg: "#09090b" },
+    { value: "Black", label: "Black", bg: "#09090b" }
   ]
 
   return (
@@ -83,8 +91,7 @@ export function LibraryTab({
             <select
               value={rarityFilter}
               onChange={(e) => setRarityFilter(e.target.value as any)}
-              className="flex-1 px-1 py-1 text-[10px] border rounded bg-white"
-            >
+              className="flex-1 px-1 py-1 text-[10px] border rounded bg-white">
               <option value="All">All Rarities</option>
               <option value="Common">Common</option>
               <option value="Rare">Rare</option>
@@ -95,8 +102,7 @@ export function LibraryTab({
           <select
             value={sortBy}
             onChange={(e) => setSortBy(e.target.value as any)}
-            className="flex-1 px-1 py-1 text-[10px] border rounded bg-white"
-          >
+            className="flex-1 px-1 py-1 text-[10px] border rounded bg-white">
             <option value="newest">Newest</option>
             <option value="oldest">Oldest</option>
             {expertFeatures.rarity && <option value="rarity">Rarity</option>}
@@ -107,7 +113,9 @@ export function LibraryTab({
 
         {/* Color Palette Filter */}
         <div className="flex gap-1 items-center overflow-x-auto pb-1 mt-1.5 scrollbar-none">
-          <span className="text-[9px] text-slate-400 font-bold mr-1 flex-shrink-0">Color:</span>
+          <span className="text-[9px] text-slate-400 font-bold mr-1 flex-shrink-0">
+            Color:
+          </span>
           {colorOptions.map((colorOpt) => {
             const isSelected = colorFilter === colorOpt.value
             return (
@@ -115,20 +123,23 @@ export function LibraryTab({
                 key={colorOpt.value}
                 onClick={() => setColorFilter(colorOpt.value as any)}
                 className={`w-3.5 h-3.5 rounded-full flex-shrink-0 transition-all border relative ${
-                  isSelected ? "scale-110 ring-1.5 ring-blue-500 ring-offset-0.5" : "hover:scale-105"
+                  isSelected
+                    ? "scale-110 ring-1.5 ring-blue-500 ring-offset-0.5"
+                    : "hover:scale-105"
                 }`}
                 style={{
                   background: colorOpt.bg,
-                  borderColor: colorOpt.value === "White" ? "#cbd5e1" : "transparent",
+                  borderColor:
+                    colorOpt.value === "White" ? "#cbd5e1" : "transparent"
                 }}
-                title={colorOpt.label}
-              >
+                title={colorOpt.label}>
                 {isSelected && (
                   <span
                     className={`absolute inset-0 flex items-center justify-center text-[7px] font-black ${
-                      colorOpt.value === "White" || colorOpt.value === "Yellow" ? "text-slate-800" : "text-white"
-                    }`}
-                  >
+                      colorOpt.value === "White" || colorOpt.value === "Yellow"
+                        ? "text-slate-800"
+                        : "text-white"
+                    }`}>
                     ✓
                   </span>
                 )}
@@ -147,8 +158,7 @@ export function LibraryTab({
               categoryFilter === "All"
                 ? "bg-slate-800 border-slate-800 text-white shadow-sm"
                 : "bg-white border-slate-200 text-slate-600 hover:border-slate-300"
-            }`}
-          >
+            }`}>
             All
           </button>
           {categories.map((cat) => (
@@ -159,8 +169,7 @@ export function LibraryTab({
                 categoryFilter === cat.id
                   ? "bg-blue-600 border-blue-600 text-white shadow-sm"
                   : "bg-white border-slate-200 text-slate-600 hover:border-slate-300"
-              }`}
-            >
+              }`}>
               {cat.iconUrl ? (
                 <img
                   src={cat.iconUrl}
@@ -168,7 +177,9 @@ export function LibraryTab({
                   alt={cat.name}
                 />
               ) : (
-                <span className="text-[11px] leading-none">{cat.iconEmoji || "🖼️"}</span>
+                <span className="text-[11px] leading-none">
+                  {cat.iconEmoji || "🖼️"}
+                </span>
               )}
               <span>{cat.name}</span>
             </button>
@@ -177,15 +188,16 @@ export function LibraryTab({
           <button
             onClick={() => setIsCategoryModalOpen(true)}
             className="flex items-center justify-center w-6 h-6 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-500 hover:text-slate-800 border border-dashed border-slate-300 transition-colors flex-shrink-0"
-            title="Manage Categories"
-          >
+            title="Manage Categories">
             <Tag className="w-3.5 h-3.5" />
           </button>
         </div>
       )}
 
       {styleCards !== undefined && styleCards.length > 0 ? (
-        <div className="grid grid-cols-2 gap-3" data-tutorial="library-card-grid">
+        <div
+          className="grid grid-cols-2 gap-3"
+          data-tutorial="library-card-grid">
           {styleCards.map((card, idx) => {
             const config = RARITY_CONFIG[card.tier]
             const cardCategory = categories.find((c) => c.id === card.category)
@@ -201,9 +213,9 @@ export function LibraryTab({
                     advanceIfStep("card-to-hand")
                   }
                 }}
-                className={`group bg-white border-2 rounded-lg shadow-sm cursor-pointer overflow-hidden transition-all hover:scale-[1.02] active:scale-[0.98] ${config?.borderClass || "border-slate-200"
-                  } ${config?.glowClass || ""}`}
-              >
+                className={`group bg-white border-2 rounded-lg shadow-sm cursor-pointer overflow-hidden transition-all hover:scale-[1.02] active:scale-[0.98] ${
+                  config?.borderClass || "border-slate-200"
+                } ${config?.glowClass || ""}`}>
                 <CardThumbnail
                   imageUrl={card.thumbnailData}
                   thumbnailImages={card.selectedThumbnails}
@@ -211,7 +223,9 @@ export function LibraryTab({
                   tier={card.tier}
                   isPinned={card.isPinned}
                   usageCount={card.usageCount}
-                  onPinClick={isEasyMode ? undefined : (e) => togglePin(card, e)}
+                  onPinClick={
+                    isEasyMode ? undefined : (e) => togglePin(card, e)
+                  }
                   onEditClick={(e) => {
                     e.stopPropagation()
                     onOpenDetailCard(card)
@@ -226,8 +240,11 @@ export function LibraryTab({
                   }}
                   category={cardCategory}
                 />
-                <div className={`p-2 border-t ${config.borderClass} bg-opacity-5 ${config.bgClass}`}>
-                  <p className="text-xs font-bold text-slate-800 truncate">{card.name}</p>
+                <div
+                  className={`p-2 border-t ${config.borderClass} bg-opacity-5 ${config.bgClass}`}>
+                  <p className="text-xs font-bold text-slate-800 truncate">
+                    {card.name}
+                  </p>
                 </div>
               </div>
             )
@@ -235,14 +252,17 @@ export function LibraryTab({
         </div>
       ) : styleCards !== undefined ? (
         <div className="flex flex-col items-center justify-center text-center p-8 bg-slate-50/50 rounded-xl border border-slate-200 border-dashed backdrop-blur-sm animate-in fade-in duration-300">
-          {allCards !== undefined && allCards.filter(c => !c.isVariable).length === 0 ? (
+          {allCards !== undefined &&
+          allCards.filter((c) => !c.isVariable).length === 0 ? (
             <>
               <div className="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mb-4 text-slate-400">
                 <BookUp2 className="w-6 h-6 text-slate-500" />
               </div>
-              <h3 className="text-sm font-bold text-slate-800 mb-1">スタイルカードがありません</h3>
+              <h3 className="text-sm font-bold text-slate-800 mb-1">
+                {t.emptyTitle}
+              </h3>
               <p className="text-xs text-slate-500 max-w-[240px] leading-relaxed">
-                Historyタブから画像をドラッグ＆ドロップして、あなただけの特別なスタイルカードを作成しましょう！
+                {t.emptyDesc}
               </p>
             </>
           ) : (
@@ -250,9 +270,11 @@ export function LibraryTab({
               <div className="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mb-4 text-slate-400">
                 <Search className="w-6 h-6 text-slate-500" />
               </div>
-              <h3 className="text-sm font-bold text-slate-800 mb-1">カードが見つかりません</h3>
+              <h3 className="text-sm font-bold text-slate-800 mb-1">
+                {t.notFoundTitle}
+              </h3>
               <p className="text-xs text-slate-500 max-w-[240px] leading-relaxed mb-4">
-                検索キーワードやフィルターの条件を変更するか、クリアしてください。
+                {t.notFoundDesc}
               </p>
               <button
                 onClick={() => {
@@ -260,9 +282,8 @@ export function LibraryTab({
                   setRarityFilter("All")
                   setCategoryFilter("All")
                 }}
-                className="px-3 py-1.5 text-xs font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-md transition-colors shadow-sm"
-              >
-                フィルターをクリア
+                className="px-3 py-1.5 text-xs font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-md transition-colors shadow-sm">
+                {t.clearFilters}
               </button>
             </>
           )}

--- a/src/components/organisms/Workbench.test.tsx
+++ b/src/components/organisms/Workbench.test.tsx
@@ -7,6 +7,7 @@ import {
 import React from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import { LanguageProvider } from "../../contexts/LanguageContext"
 import { SettingsProvider } from "../../contexts/SettingsContext"
 import { useEvolution } from "../../hooks/useEvolution"
 import { useWorkbench } from "../../hooks/useWorkbench"
@@ -15,7 +16,12 @@ import type { StyleCard } from "../../lib/db-schema"
 import { Workbench } from "./Workbench"
 
 const render = (ui: React.ReactElement, options?: any) => {
-  return tlRender(ui, { wrapper: SettingsProvider, ...options })
+  return tlRender(
+    <LanguageProvider>
+      <SettingsProvider>{ui}</SettingsProvider>
+    </LanguageProvider>,
+    options
+  )
 }
 
 vi.mock("../../hooks/useWorkbench", () => ({
@@ -98,6 +104,7 @@ describe("Workbench", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+    localStorage.setItem("style-atelier-language", "ja")
     vi.mocked(useEvolution).mockReturnValue({
       canEvolve: vi.fn().mockReturnValue(false),
       evolveCard: vi.fn(),
@@ -333,7 +340,7 @@ describe("Workbench", () => {
     )
 
     // Verify button is rendered
-    const mintButton = screen.getByText("Mint Blended Variation")
+    const mintButton = screen.getByText("調合したカードを作成する")
     expect(mintButton).toBeDefined()
 
     // Click button

--- a/src/components/organisms/Workbench.tsx
+++ b/src/components/organisms/Workbench.tsx
@@ -1,200 +1,237 @@
-import React, { useState, useEffect } from "react";
-import { useWorkbench } from "../../hooks/useWorkbench";
-import { useEvolution } from "../../hooks/useEvolution";
-import { CardThumbnail } from "../molecules/CardThumbnail";
-import { RarityBadge } from "../atoms/RarityBadge";
-import { Button } from "../atoms/Button";
-import { Sparkles, X, Send, BookUp2, Layers } from "lucide-react";
-import { buildPromptString, mergePromptSegments } from "../../lib/prompt-utils";
-import { PromptBubbleEditor } from "./PromptBubbleEditor";
-import { PromptBubble } from "../molecules/PromptBubble";
-import { ParameterEditor } from "./ParameterEditor";
-import { type AlertType } from "../molecules/ConnectionAlert";
-import { db } from "../../lib/db";
-import { MergeStackModal } from "./MergeStackModal";
-import { SlotVariablesSection } from "./SlotVariablesSection";
-import { useSettings } from "../../contexts/SettingsContext";
+import { BookUp2, Layers, Send, Sparkles, X } from "lucide-react"
+import React, { useEffect, useState } from "react"
 
-import type { PromptSegment } from "../../lib/db-schema";
+import { useLanguage } from "../../contexts/LanguageContext"
+import { useSettings } from "../../contexts/SettingsContext"
+import { useEvolution } from "../../hooks/useEvolution"
+import { useWorkbench } from "../../hooks/useWorkbench"
+import { db } from "../../lib/db"
+import type { PromptSegment } from "../../lib/db-schema"
+import { buildPromptString, mergePromptSegments } from "../../lib/prompt-utils"
+import { Button } from "../atoms/Button"
+import { RarityBadge } from "../atoms/RarityBadge"
+import { CardThumbnail } from "../molecules/CardThumbnail"
+import { type AlertType } from "../molecules/ConnectionAlert"
+import { PromptBubble } from "../molecules/PromptBubble"
+import { MergeStackModal } from "./MergeStackModal"
+import { ParameterEditor } from "./ParameterEditor"
+import { PromptBubbleEditor } from "./PromptBubbleEditor"
+import { SlotVariablesSection } from "./SlotVariablesSection"
 
 /**
  * Props for the Workbench component.
  */
 interface WorkbenchProps {
   /** Callback triggered when a variation minting starts */
-  onStartVariationMinting?: (base: any) => void;
+  onStartVariationMinting?: (base: any) => void
   /** Callback to add log messages */
-  addLog?: (msg: string) => void;
+  addLog?: (msg: string) => void
   /** Callback to set system alert type */
-  setAlertType: (type: AlertType | null) => void;
+  setAlertType: (type: AlertType | null) => void
 }
 
 /**
  * Workbench component acts as the main sandbox where users can blend multiple style cards,
  * evolve rare cards, fill slot variables, and inject prompts directly into Midjourney.
  */
-export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, addLog, setAlertType }) => {
-  const { workbenchCards, handCards, toggleCardSelection, clearWorkbench } = useWorkbench();
-  const { canEvolve, evolveCard } = useEvolution();
-  const { expertFeatures } = useSettings();
+export const Workbench: React.FC<WorkbenchProps> = ({
+  onStartVariationMinting,
+  addLog,
+  setAlertType
+}) => {
+  const { workbenchCards, handCards, toggleCardSelection, clearWorkbench } =
+    useWorkbench()
+  const { canEvolve, evolveCard } = useEvolution()
+  const { expertFeatures } = useSettings()
+  const { t: i18n } = useLanguage()
+  const t = i18n.workbench
 
-  const [editedSegments, setEditedSegments] = useState<PromptSegment[]>([]);
-  const [editedParams, setEditedParams] = useState<any>({});
-  const [isInjecting, setIsInjecting] = useState(false);
-  const [slotValues, setSlotValues] = useState<Record<string, string>>({});
-  const [slotHistory, setSlotHistory] = useState<Record<string, string[]>>({});
-  
-  const hasParams = Object.values(editedParams).some(v => Array.isArray(v) ? v.length > 0 : !!v);
+  const [editedSegments, setEditedSegments] = useState<PromptSegment[]>([])
+  const [editedParams, setEditedParams] = useState<any>({})
+  const [isInjecting, setIsInjecting] = useState(false)
+  const [slotValues, setSlotValues] = useState<Record<string, string>>({})
+  const [slotHistory, setSlotHistory] = useState<Record<string, string[]>>({})
 
+  const hasParams = Object.values(editedParams).some((v) =>
+    Array.isArray(v) ? v.length > 0 : !!v
+  )
 
-  const isEvolutionMode = workbenchCards.length === 1;
-  const isMixingMode = workbenchCards.length >= 2;
-  const targetCard = workbenchCards[0];
-  const canEvolveTarget = targetCard && canEvolve(targetCard);
+  const isEvolutionMode = workbenchCards.length === 1
+  const isMixingMode = workbenchCards.length >= 2
+  const targetCard = workbenchCards[0]
+  const canEvolveTarget = targetCard && canEvolve(targetCard)
 
-  const workbenchCardsDependency = workbenchCards.map(c => `${c.id}-${c.updatedAt || 0}`).join(",");
+  const workbenchCardsDependency = workbenchCards
+    .map((c) => `${c.id}-${c.updatedAt || 0}`)
+    .join(",")
 
   // Load slot history from localStorage
   const loadSlotHistory = () => {
     try {
-      const stored = localStorage.getItem("style_atelier_slot_history");
+      const stored = localStorage.getItem("style_atelier_slot_history")
       if (stored) {
-        setSlotHistory(JSON.parse(stored));
+        setSlotHistory(JSON.parse(stored))
       }
     } catch (e) {
-      console.error("Failed to load slot history:", e);
+      console.error("Failed to load slot history:", e)
     }
-  };
+  }
 
   useEffect(() => {
-    loadSlotHistory();
-  }, []);
-
+    loadSlotHistory()
+  }, [])
 
   // Check connection on mount
   useEffect(() => {
-    let retryCount = 0;
-    const maxRetries = 3;
-    let timerId: any = null;
-    let isCancelled = false;
+    let retryCount = 0
+    const maxRetries = 3
+    let timerId: any = null
+    let isCancelled = false
 
     const checkConnection = async () => {
-      if (isCancelled) return;
+      if (isCancelled) return
       try {
-        const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-        const activeTab = tabs[0];
-        if (isCancelled) return;
+        const tabs = await chrome.tabs.query({
+          active: true,
+          currentWindow: true
+        })
+        const activeTab = tabs[0]
+        if (isCancelled) return
         if (!activeTab) {
-          addLog?.("Check Connection: No active tab returned from query.");
-          return;
+          addLog?.("Check Connection: No active tab returned from query.")
+          return
         }
         if (!activeTab.id) {
-          addLog?.(`Check Connection: Active tab has no ID. URL: ${activeTab.url}`);
-          return;
+          addLog?.(
+            `Check Connection: Active tab has no ID. URL: ${activeTab.url}`
+          )
+          return
         }
 
         // If the tab is still loading, wait and retry
         if (activeTab.status !== "complete") {
-          addLog?.(`Check Connection: Tab is still loading (status: ${activeTab.status}). Retrying in 1s...`);
-          timerId = setTimeout(checkConnection, 1000);
-          return;
+          addLog?.(
+            `Check Connection: Tab is still loading (status: ${activeTab.status}). Retrying in 1s...`
+          )
+          timerId = setTimeout(checkConnection, 1000)
+          return
         }
 
-        addLog?.(`Checking connection to Tab ${activeTab.id} (${activeTab.url})...`);
+        addLog?.(
+          `Checking connection to Tab ${activeTab.id} (${activeTab.url})...`
+        )
         // Simple PING to check if content script is alive
-        const response = await chrome.tabs.sendMessage(activeTab.id, { type: "PING" });
-        if (isCancelled) return;
-        addLog?.(`Check Connection: Success! Ping response: ${JSON.stringify(response)}`);
-        setAlertType(null);
+        const response = await chrome.tabs.sendMessage(activeTab.id, {
+          type: "PING"
+        })
+        if (isCancelled) return
+        addLog?.(
+          `Check Connection: Success! Ping response: ${JSON.stringify(response)}`
+        )
+        setAlertType(null)
       } catch (err: any) {
-        if (isCancelled) return;
-        console.log("Connection check failed:", err);
-        addLog?.(`Connection check failed (attempt ${retryCount + 1}/${maxRetries}): ${err?.message || JSON.stringify(err)}`);
-        
+        if (isCancelled) return
+        console.log("Connection check failed:", err)
+        addLog?.(
+          `Connection check failed (attempt ${retryCount + 1}/${maxRetries}): ${err?.message || JSON.stringify(err)}`
+        )
+
         if (retryCount < maxRetries) {
-          retryCount++;
-          timerId = setTimeout(checkConnection, 1500); // Wait 1.5s and retry
+          retryCount++
+          timerId = setTimeout(checkConnection, 1500) // Wait 1.5s and retry
         } else {
-          setAlertType("disconnected");
+          setAlertType("disconnected")
         }
       }
-    };
+    }
 
-    checkConnection();
+    checkConnection()
 
     return () => {
-      isCancelled = true;
+      isCancelled = true
       if (timerId) {
-        clearTimeout(timerId);
+        clearTimeout(timerId)
       }
-    };
-  }, [workbenchCardsDependency]);
+    }
+  }, [workbenchCardsDependency])
 
   // Load segments, parameters, and initialize slotValues when workbenchCards changes
   useEffect(() => {
     if (workbenchCards.length === 0) {
-      setEditedSegments([]);
-      setEditedParams({});
-      setSlotValues({});
-      return;
+      setEditedSegments([])
+      setEditedParams({})
+      setSlotValues({})
+      return
     }
 
-    let nextSegments: PromptSegment[] = [];
-    let nextParams: any = {};
+    let nextSegments: PromptSegment[] = []
+    let nextParams: any = {}
 
     if (workbenchCards.length === 1) {
-      const target = workbenchCards[0];
-      nextSegments = target.promptSegments || [];
-      nextParams = target.parameters || {};
+      const target = workbenchCards[0]
+      nextSegments = target.promptSegments || []
+      nextParams = target.parameters || {}
     } else {
-      const allSegments = workbenchCards.flatMap(p => p.promptSegments || []);
-      nextSegments = mergePromptSegments(allSegments);
-      
-      const mainParent = workbenchCards[0];
-      nextParams = { ...mainParent.parameters };
-      workbenchCards.slice(1).forEach(parent => {
+      const allSegments = workbenchCards.flatMap((p) => p.promptSegments || [])
+      nextSegments = mergePromptSegments(allSegments)
+
+      const mainParent = workbenchCards[0]
+      nextParams = { ...mainParent.parameters }
+      workbenchCards.slice(1).forEach((parent) => {
         if (parent.parameters?.sref) {
-          const combinedSref = [...(parent.parameters.sref || []), ...(nextParams.sref || [])];
-          nextParams.sref = Array.from(new Set(combinedSref)).slice(0, 5);
+          const combinedSref = [
+            ...(parent.parameters.sref || []),
+            ...(nextParams.sref || [])
+          ]
+          nextParams.sref = Array.from(new Set(combinedSref)).slice(0, 5)
         }
         if (parent.parameters?.cref) {
-          const combinedCref = [...(parent.parameters.cref || []), ...(nextParams.cref || [])];
-          nextParams.cref = Array.from(new Set(combinedCref)).slice(0, 5);
+          const combinedCref = [
+            ...(parent.parameters.cref || []),
+            ...(nextParams.cref || [])
+          ]
+          nextParams.cref = Array.from(new Set(combinedCref)).slice(0, 5)
         }
         if (parent.parameters?.imagePrompts) {
-          const combinedIP = [...(parent.parameters.imagePrompts || []), ...(nextParams.imagePrompts || [])];
-          nextParams.imagePrompts = Array.from(new Set(combinedIP)).slice(0, 5);
+          const combinedIP = [
+            ...(parent.parameters.imagePrompts || []),
+            ...(nextParams.imagePrompts || [])
+          ]
+          nextParams.imagePrompts = Array.from(new Set(combinedIP)).slice(0, 5)
         }
         if (parent.parameters?.p) {
-          const combinedP = [...(parent.parameters.p || []), ...(nextParams.p || [])];
-          nextParams.p = Array.from(new Set(combinedP)).slice(0, 5);
+          const combinedP = [
+            ...(parent.parameters.p || []),
+            ...(nextParams.p || [])
+          ]
+          nextParams.p = Array.from(new Set(combinedP)).slice(0, 5)
         }
-      });
+      })
     }
 
-    setEditedSegments(nextSegments);
-    setEditedParams(nextParams);
+    setEditedSegments(nextSegments)
+    setEditedParams(nextParams)
 
     // Initialize slotValues based on nextSegments
-    const initialSlotValues: Record<string, string> = {};
-    nextSegments.forEach(seg => {
+    const initialSlotValues: Record<string, string> = {}
+    nextSegments.forEach((seg) => {
       if (seg.type === "slot") {
-        initialSlotValues[seg.label] = seg.default || "";
+        initialSlotValues[seg.label] = seg.default || ""
       }
-    });
-    setSlotValues(initialSlotValues);
-  }, [workbenchCardsDependency]);
+    })
+    setSlotValues(initialSlotValues)
+  }, [workbenchCardsDependency])
 
   const handleSlotValueChange = (label: string, value: string) => {
-    setSlotValues(prev => ({
+    setSlotValues((prev) => ({
       ...prev,
       [label]: value
-    }));
-  };
+    }))
+  }
 
   const handleSendToWorkbench = async (value: string, label: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) return;
+    const trimmed = value.trim()
+    if (!trimmed) return
 
     try {
       const newCard = {
@@ -215,108 +252,135 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
         frameId: "default",
         genealogy: {
           generation: 1,
-          parentIds: [],
+          parentIds: []
         },
         isVariable: true,
-        associatedJobIds: [],
-      };
+        associatedJobIds: []
+      }
 
-      await db.addCard(newCard);
-      addLog?.(`Sent "${trimmed}" to Workbench under tag "${label}"`);
+      await db.addCard(newCard)
+      addLog?.(`Sent "${trimmed}" to Workbench under tag "${label}"`)
     } catch (err) {
-      console.error("Failed to send card to Workbench:", err);
+      console.error("Failed to send card to Workbench:", err)
     }
-  };
+  }
 
   const handleInjectPrompt = async () => {
-    if (workbenchCards.length === 0) return;
-    setIsInjecting(true);
-    setAlertType(null);
+    if (workbenchCards.length === 0) return
+    setIsInjecting(true)
+    setAlertType(null)
 
     // Replace slot segments with their filled variable values
-    const resolvedSegments = editedSegments.map(seg => {
+    const resolvedSegments = editedSegments.map((seg) => {
       if (seg.type === "slot") {
         return {
           type: "text" as const,
           value: slotValues[seg.label] || seg.default || seg.label
-        };
+        }
       }
-      return seg;
-    });
+      return seg
+    })
 
-    const fullPrompt = buildPromptString(resolvedSegments, editedParams);
+    const fullPrompt = buildPromptString(resolvedSegments, editedParams)
 
     try {
-      const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-      const activeTab = tabs[0];
+      const tabs = await chrome.tabs.query({
+        active: true,
+        currentWindow: true
+      })
+      const activeTab = tabs[0]
 
       if (!activeTab?.id) {
-        throw new Error("No active tab found");
+        throw new Error("No active tab found")
       }
 
       const response = await chrome.tabs.sendMessage(activeTab.id, {
         type: "INJECT_PROMPT",
-        prompt: fullPrompt,
-      });
+        prompt: fullPrompt
+      })
 
       if (response && response.status === "error") {
-        if (response.message && response.message.includes("Could not find chat input")) {
-          setAlertType("no_input");
+        if (
+          response.message &&
+          response.message.includes("Could not find chat input")
+        ) {
+          setAlertType("no_input")
         } else {
-          setAlertType("disconnected");
+          setAlertType("disconnected")
         }
       } else {
-        addLog?.(`Prompt injected successfully!`);
+        addLog?.(`Prompt injected successfully!`)
 
         // Increment usage count for all cards in the Workbench
         workbenchCards.forEach((card) => {
-          db.updateCard(card.id, { usageCount: (card.usageCount || 0) + 1 })
-            .catch(err => console.error("Failed to update usage count on workbench inject:", err));
-        });
+          db.updateCard(card.id, {
+            usageCount: (card.usageCount || 0) + 1
+          }).catch((err) =>
+            console.error(
+              "Failed to update usage count on workbench inject:",
+              err
+            )
+          )
+        })
 
         // Save slot values to history on success
-        const existing = localStorage.getItem("style_atelier_slot_history");
-        const history: Record<string, string[]> = existing ? JSON.parse(existing) : {};
+        const existing = localStorage.getItem("style_atelier_slot_history")
+        const history: Record<string, string[]> = existing
+          ? JSON.parse(existing)
+          : {}
 
         Object.entries(slotValues).forEach(([lbl, val]) => {
-          const trimmedVal = val.trim();
-          if (!trimmedVal) return;
+          const trimmedVal = val.trim()
+          if (!trimmedVal) return
           if (!history[lbl]) {
-            history[lbl] = [];
+            history[lbl] = []
           }
-          history[lbl] = [trimmedVal, ...history[lbl].filter(v => v !== trimmedVal)].slice(0, 10);
-        });
+          history[lbl] = [
+            trimmedVal,
+            ...history[lbl].filter((v) => v !== trimmedVal)
+          ].slice(0, 10)
+        })
 
-        localStorage.setItem("style_atelier_slot_history", JSON.stringify(history));
-        loadSlotHistory();
+        localStorage.setItem(
+          "style_atelier_slot_history",
+          JSON.stringify(history)
+        )
+        loadSlotHistory()
       }
     } catch (err) {
-      console.error("Injection failed:", err);
-      setAlertType("disconnected");
+      console.error("Injection failed:", err)
+      setAlertType("disconnected")
     } finally {
-      setIsInjecting(false);
+      setIsInjecting(false)
     }
-  };
+  }
 
   const handleMintVariation = () => {
-    if (!onStartVariationMinting) return;
+    if (!onStartVariationMinting) return
 
     // Calculate max generation among parents
-    const maxParentGen = Math.max(...workbenchCards.map(c => c.genealogy?.generation || 1), 0);
-    const parentIds = workbenchCards.map(c => c.id);
-    const parentNames = workbenchCards.map(c => c.name).join(", ");
+    const maxParentGen = Math.max(
+      ...workbenchCards.map((c) => c.genealogy?.generation || 1),
+      0
+    )
+    const parentIds = workbenchCards.map((c) => c.id)
+    const parentNames = workbenchCards.map((c) => c.name).join(", ")
 
     const genealogy = {
       generation: maxParentGen + 1,
       parentIds: parentIds,
       originCreatorId: "user",
-      mutationNote: `Blended from: ${parentNames}`,
-    };
+      mutationNote: `Blended from: ${parentNames}`
+    }
 
     // Gather images from parents
-    const parentImages = workbenchCards.flatMap(c => c.images || []).filter(Boolean);
-    const parentThumbnails = workbenchCards.flatMap(c => c.selectedThumbnails || []).filter(Boolean);
-    const thumbnailData = workbenchCards[0]?.thumbnailData || "assets/icon.png";
+    const parentImages = workbenchCards
+      .flatMap((c) => c.images || [])
+      .filter(Boolean)
+    const parentThumbnails = workbenchCards
+      .flatMap((c) => c.selectedThumbnails || [])
+      .filter(Boolean)
+    const thumbnailData = workbenchCards[0]?.thumbnailData || "assets/icon.png"
 
     onStartVariationMinting({
       promptSegments: editedSegments,
@@ -324,12 +388,16 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
       genealogy,
       thumbnailData,
       images: parentImages.length > 0 ? parentImages : undefined,
-      selectedThumbnails: parentThumbnails.length > 0 ? parentThumbnails : undefined,
-    });
-  };
+      selectedThumbnails:
+        parentThumbnails.length > 0 ? parentThumbnails : undefined
+    })
+  }
 
   // Extract slots
-  const slots = editedSegments.filter((seg): seg is { type: "slot"; label: string; default: string } => seg.type === "slot");
+  const slots = editedSegments.filter(
+    (seg): seg is { type: "slot"; label: string; default: string } =>
+      seg.type === "slot"
+  )
 
   return (
     <div className="flex flex-col h-full bg-white text-slate-900 p-4 space-y-4">
@@ -340,8 +408,12 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
         </h2>
         <div className="flex gap-2">
           {workbenchCards.length > 0 && (
-            <Button variant="ghost" size="sm" onClick={clearWorkbench} className="text-slate-400 hover:text-slate-600">
-              Clear All
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearWorkbench}
+              className="text-slate-400 hover:text-slate-600">
+              {t.clearAll}
             </Button>
           )}
         </div>
@@ -349,19 +421,26 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
 
       <div className="grid grid-cols-2 gap-4 bg-slate-50 p-4 rounded-xl border-2 border-dashed border-slate-200 min-h-[160px]">
         {workbenchCards.map((card) => (
-          <div key={card.id} className="relative group animate-in zoom-in-95 duration-200">
-            <CardThumbnail imageUrl={card.thumbnailData} thumbnailImages={card.selectedThumbnails} alt={card.name} tier={card.tier} className="w-full aspect-square" />
+          <div
+            key={card.id}
+            className="relative group animate-in zoom-in-95 duration-200">
+            <CardThumbnail
+              imageUrl={card.thumbnailData}
+              thumbnailImages={card.selectedThumbnails}
+              alt={card.name}
+              tier={card.tier}
+              className="w-full aspect-square"
+            />
             <button
               onClick={() => toggleCardSelection(card.id)}
-              className="absolute -top-2 -right-2 bg-red-500 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity z-10"
-            >
+              className="absolute -top-2 -right-2 bg-red-500 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity z-10">
               <X className="w-3 h-3 text-white" />
             </button>
           </div>
         ))}
         {workbenchCards.length < 2 && (
           <div className="border-2 border-dashed border-slate-700 rounded-lg flex items-center justify-center aspect-square text-slate-500 text-xs text-center p-2">
-            Add style cards to Workbench from Library
+            {t.addPromptDesc}
           </div>
         )}
       </div>
@@ -372,9 +451,11 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
             <div className="bg-slate-50 border border-slate-200 p-4 rounded-lg space-y-3">
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-bold text-slate-700">
-                  {isEvolutionMode ? "Evolution" : "Variation Recipe"}
+                  {isEvolutionMode ? t.evolution : t.variationRecipe}
                 </h3>
-                {isEvolutionMode && targetCard && <RarityBadge tier={targetCard.tier} />}
+                {isEvolutionMode && targetCard && (
+                  <RarityBadge tier={targetCard.tier} />
+                )}
               </div>
 
               <div className="bg-white">
@@ -390,7 +471,13 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
                       <PromptBubble
                         key={index}
                         segment={segment}
-                        tier={segment.type === "text" ? undefined : (isEvolutionMode ? targetCard?.tier : "Common")}
+                        tier={
+                          segment.type === "text"
+                            ? undefined
+                            : isEvolutionMode
+                              ? targetCard?.tier
+                              : "Common"
+                        }
                       />
                     ))}
                   </div>
@@ -410,44 +497,78 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
               )}
 
               {expertFeatures.cardEditing ? (
-                <ParameterEditor parameters={editedParams} onChange={setEditedParams} />
+                <ParameterEditor
+                  parameters={editedParams}
+                  onChange={setEditedParams}
+                />
               ) : (
                 <div className="space-y-2 bg-slate-50/50 p-3 rounded-lg border border-slate-100 text-xs">
                   {editedParams.ar && (
-                    <div><span className="font-bold text-slate-500">Aspect Ratio:</span> {editedParams.ar}</div>
+                    <div>
+                      <span className="font-bold text-slate-500">
+                        Aspect Ratio:
+                      </span>{" "}
+                      {editedParams.ar}
+                    </div>
                   )}
                   {editedParams.p && editedParams.p.length > 0 && (
-                    <div><span className="font-bold text-slate-500">Personalization (--p):</span> {editedParams.p.join(", ")}</div>
+                    <div>
+                      <span className="font-bold text-slate-500">
+                        Personalization (--p):
+                      </span>{" "}
+                      {editedParams.p.join(", ")}
+                    </div>
                   )}
-                  {editedParams.imagePrompts && editedParams.imagePrompts.length > 0 && (
-                    <div><span className="font-bold text-slate-500">Image Prompts:</span> {editedParams.imagePrompts.join(", ")}</div>
-                  )}
+                  {editedParams.imagePrompts &&
+                    editedParams.imagePrompts.length > 0 && (
+                      <div>
+                        <span className="font-bold text-slate-500">
+                          Image Prompts:
+                        </span>{" "}
+                        {editedParams.imagePrompts.join(", ")}
+                      </div>
+                    )}
                   {editedParams.sref && editedParams.sref.length > 0 && (
-                    <div><span className="font-bold text-slate-500">Style Reference (--sref):</span> {editedParams.sref.join(", ")}</div>
+                    <div>
+                      <span className="font-bold text-slate-500">
+                        Style Reference (--sref):
+                      </span>{" "}
+                      {editedParams.sref.join(", ")}
+                    </div>
                   )}
                   {editedParams.cref && editedParams.cref.length > 0 && (
-                    <div><span className="font-bold text-slate-500">Character Reference (--cref):</span> {editedParams.cref.join(", ")}</div>
+                    <div>
+                      <span className="font-bold text-slate-500">
+                        Character Reference (--cref):
+                      </span>{" "}
+                      {editedParams.cref.join(", ")}
+                    </div>
                   )}
-                  {!hasParams && <div className="text-slate-400 italic">No parameters defined.</div>}
+                  {!hasParams && (
+                    <div className="text-slate-400 italic">
+                      No parameters defined.
+                    </div>
+                  )}
                 </div>
               )}
 
               {isEvolutionMode && targetCard && expertFeatures.stack && (
                 <div className="pt-2 border-t border-slate-100">
                   <div className="flex justify-between items-center text-xs mb-2">
-                    <span className="text-slate-500">Usage Progress</span>
-                    <span className="font-mono font-bold text-blue-600">{targetCard.usageCount} uses</span>
+                    <span className="text-slate-500">{t.usageProgress}</span>
+                    <span className="font-mono font-bold text-blue-600">
+                      {targetCard.usageCount} {t.uses}
+                    </span>
                   </div>
                   {canEvolveTarget ? (
                     <Button
                       className="w-full bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-md"
-                      onClick={() => evolveCard(targetCard.id)}
-                    >
-                      <Sparkles className="w-4 h-4 mr-2" /> Evolve to Next Tier
+                      onClick={() => evolveCard(targetCard.id)}>
+                      <Sparkles className="w-4 h-4 mr-2" /> {t.evolveBtn}
                     </Button>
                   ) : (
                     <p className="text-[10px] text-slate-400 italic text-center">
-                      Need more uses to evolve this card
+                      {t.evolveNeedMore}
                     </p>
                   )}
                 </div>
@@ -456,19 +577,17 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
               {isMixingMode && expertFeatures.stack && (
                 <Button
                   className="w-full bg-gradient-to-r from-teal-500 to-emerald-500 text-white shadow-md mb-2"
-                  onClick={handleMintVariation}
-                >
-                  <Sparkles className="w-4 h-4 mr-2" /> Mint Blended Variation
+                  onClick={handleMintVariation}>
+                  <Sparkles className="w-4 h-4 mr-2" /> {t.mintBlended}
                 </Button>
               )}
 
               <Button
                 className="w-full bg-blue-600 hover:bg-blue-700 text-white shadow-sm shadow-blue-200"
                 onClick={handleInjectPrompt}
-                disabled={isInjecting}
-              >
+                disabled={isInjecting}>
                 <Send className="w-4 h-4 mr-2" />
-                {isInjecting ? "Injecting..." : "Try on Midjourney"}
+                {isInjecting ? t.injecting : t.tryOnMidjourney}
               </Button>
             </div>
           </div>
@@ -479,21 +598,27 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
             <div className="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mb-4 text-slate-400 animate-pulse">
               <Layers className="w-6 h-6 text-blue-500" />
             </div>
-            <h3 className="text-sm font-bold text-slate-800 mb-1">Workbench は空です</h3>
+            <h3 className="text-sm font-bold text-slate-800 mb-1">
+              {t.emptyTitle}
+            </h3>
             <p className="text-xs text-slate-500 max-w-[280px] leading-relaxed mb-6 text-center">
-              Libraryタブからスタイルカードをピン留めして、スタイルの調合やカードの進化を開始しましょう。
+              {t.emptyDesc}
             </p>
 
             <div className="w-full max-w-xs space-y-4 text-left border-t border-slate-200/60 pt-6">
-              <h4 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">使い方ガイド</h4>
-              
+              <h4 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                {t.guideTitle}
+              </h4>
+
               <div className="flex gap-3">
                 <div className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-50 border border-blue-200 text-blue-600 flex items-center justify-center text-[10px] font-bold">
                   1
                 </div>
                 <div>
-                  <h5 className="text-xs font-bold text-slate-700">スタイルをピン留め</h5>
-                  <p className="text-[10px] text-slate-500">Libraryからお気に入りのスタイルをWorkbenchへ送ります。</p>
+                  <h5 className="text-xs font-bold text-slate-700">
+                    {t.step1Title}
+                  </h5>
+                  <p className="text-[10px] text-slate-500">{t.step1Desc}</p>
                 </div>
               </div>
 
@@ -502,8 +627,10 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
                   2
                 </div>
                 <div>
-                  <h5 className="text-xs font-bold text-slate-700">プロンプトを調合 / カードを進化</h5>
-                  <p className="text-[10px] text-slate-500">2枚以上でブレンド、1枚ならプロンプトの調整や、使用回数に応じた進化が可能です。</p>
+                  <h5 className="text-xs font-bold text-slate-700">
+                    {t.step2Title}
+                  </h5>
+                  <p className="text-[10px] text-slate-500">{t.step2Desc}</p>
                 </div>
               </div>
 
@@ -512,15 +639,16 @@ export const Workbench: React.FC<WorkbenchProps> = ({ onStartVariationMinting, a
                   3
                 </div>
                 <div>
-                  <h5 className="text-xs font-bold text-slate-700">Midjourneyで生成</h5>
-                  <p className="text-[10px] text-slate-500">「Try on Midjourney」ボタンでプロンプトをチャットへ直接送信します。</p>
+                  <h5 className="text-xs font-bold text-slate-700">
+                    {t.step3Title}
+                  </h5>
+                  <p className="text-[10px] text-slate-500">{t.step3Desc}</p>
                 </div>
               </div>
             </div>
           </div>
         )}
       </div>
-
     </div>
-  );
-};
+  )
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -246,6 +246,46 @@ export const i18nDict = {
       next: "Next",
       autoAdvanceHint: "Perform the action or click 'Next' to proceed"
     },
+    historyTab: {
+      emptyTitle: "No History",
+      emptyDesc:
+        "Drag and drop any generated image from Midjourney directly into the History tab of the Side Panel to import it.",
+      openMidjourney: "Open Midjourney",
+      loading: "Loading..."
+    },
+    libraryTab: {
+      emptyTitle: "No Style Cards",
+      emptyDesc:
+        "Drag and drop images from the History tab of this panel to create your own style cards!",
+      notFoundTitle: "No Cards Found",
+      notFoundDesc: "Change or clear your search terms or filters.",
+      clearFilters: "Clear Filters"
+    },
+    workbench: {
+      clearAll: "Clear All",
+      addPromptDesc: "Add style cards to Workbench from Library",
+      evolution: "Evolution",
+      variationRecipe: "Variation Recipe",
+      usageProgress: "Usage Progress",
+      uses: "uses",
+      evolveBtn: "Evolve to Next Tier",
+      evolveNeedMore: "Need more uses to evolve this card",
+      mintBlended: "Mint Blended Variation",
+      tryOnMidjourney: "Try on Midjourney",
+      injecting: "Injecting...",
+      emptyTitle: "Workbench is empty",
+      emptyDesc:
+        "Pin style cards from the Library tab to start blending styles or evolving cards.",
+      guideTitle: "How to Use Guide",
+      step1Title: "Pin Styles",
+      step1Desc: "Send your favorite styles from Library to the Workbench.",
+      step2Title: "Blend Prompts / Evolve Cards",
+      step2Desc:
+        "Blend with 2 or more cards, or adjust prompt and evolve based on usage with a single card.",
+      step3Title: "Generate in Midjourney",
+      step3Desc:
+        "Send prompt directly to chat using the 'Try on Midjourney' button."
+    },
     tutorial: {
       steps: [
         {
@@ -539,6 +579,47 @@ export const i18nDict = {
       done: "完了！",
       next: "次へ",
       autoAdvanceHint: "操作を行うか、「次へ」を押すと進みます"
+    },
+    historyTab: {
+      emptyTitle: "履歴がありません",
+      emptyDesc:
+        "Midjourneyのプロンプト入力エリアから画像をドラッグ＆ドロップするか、MidjourneyのWebサイトからスタイルを連携してください。",
+      openMidjourney: "Midjourneyを開く",
+      loading: "読み込み中..."
+    },
+    libraryTab: {
+      emptyTitle: "スタイルカードがありません",
+      emptyDesc:
+        "Historyタブから画像をドラッグ＆ドロップして、あなただけの特別なスタイルカードを作成しましょう！",
+      notFoundTitle: "カードが見つかりません",
+      notFoundDesc:
+        "検索キーワードやフィルターの条件を変更するか、クリアしてください。",
+      clearFilters: "フィルターをクリア"
+    },
+    workbench: {
+      clearAll: "すべてクリア",
+      addPromptDesc: "LibraryからスタイルカードをWorkbenchに追加してください",
+      evolution: "進化",
+      variationRecipe: "調合（レシピ）",
+      usageProgress: "使用状況",
+      uses: "回使用",
+      evolveBtn: "次のランクへ進化",
+      evolveNeedMore: "カードを進化させるにはさらに使用回数が必要です",
+      mintBlended: "調合したカードを作成する",
+      tryOnMidjourney: "Try on Midjourney",
+      injecting: "Injecting...",
+      emptyTitle: "Workbench は空です",
+      emptyDesc:
+        "Libraryタブからスタイルカードをピン留めして、スタイルの調合やカードの進化を開始しましょう。",
+      guideTitle: "使い方ガイド",
+      step1Title: "スタイルをピン留め",
+      step1Desc: "Libraryからお気に入りのスタイルをWorkbenchへ送ります。",
+      step2Title: "プロンプトを調合 / カードを進化",
+      step2Desc:
+        "2枚以上でブレンド、1枚ならプロンプトの調整や、使用回数に応じた進化が可能です。",
+      step3Title: "Midjourneyで生成",
+      step3Desc:
+        "「Try on Midjourney」ボタンでプロンプトをチャットへ直接送信します。"
     },
     tutorial: {
       steps: [

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -538,7 +538,7 @@ test.describe("Style Atelier Sandbox E2E Tests - Settings", () => {
     console.log("Expert features toggles E2E test passed successfully!")
   })
 
-  test("should allow changing display language and verify localization in UI", async ({
+  test("should allow changing display language and verify localization in UI and Tabs", async ({
     page
   }) => {
     const screenshotsDir = path.join(__dirname, "../../tests/screenshots")
@@ -552,6 +552,18 @@ test.describe("Style Atelier Sandbox E2E Tests - Settings", () => {
     if (await skipButton.isVisible({ timeout: 5000 }).catch(() => false)) {
       await skipButton.click()
     }
+
+    // Clear database to ensure empty states are shown
+    console.log("Clearing database to ensure empty states...")
+    await spFrame.locator("body").evaluate(async () => {
+      const database = (window as any).db
+      if (database) {
+        await database.styleCards.clear()
+        await database.categories.clear()
+        await database.userSettings.clear()
+        await database.historyItems.clear()
+      }
+    })
 
     // 2. Open Settings Tab
     const settingsNavBtn = spFrame.locator("#settings-nav-btn")
@@ -572,6 +584,34 @@ test.describe("Style Atelier Sandbox E2E Tests - Settings", () => {
     const settingsTitleEn = spFrame.locator("h2:has-text('Settings')")
     await expect(settingsTitleEn).toBeVisible({ timeout: 5000 })
 
+    // Verify Tab English translations:
+    // A. History Tab empty title
+    const historyNavBtn = spFrame.locator("button[title='History']")
+    await historyNavBtn.click()
+    await page.waitForTimeout(300)
+    const historyEmptyEn = spFrame.locator("h3:has-text('No History')")
+    await expect(historyEmptyEn).toBeVisible()
+
+    // B. Library Tab empty title
+    const libraryNavBtn = spFrame.locator("button[title='Library']")
+    await libraryNavBtn.click()
+    await page.waitForTimeout(300)
+    const libraryEmptyEn = spFrame.locator("h3:has-text('No Style Cards')")
+    await expect(libraryEmptyEn).toBeVisible()
+
+    // C. Workbench Tab empty title
+    const workbenchNavBtn = spFrame.locator("button[title='Workbench']")
+    await workbenchNavBtn.click()
+    await page.waitForTimeout(300)
+    const workbenchEmptyEn = spFrame.locator(
+      "h3:has-text('Workbench is Empty')"
+    )
+    await expect(workbenchEmptyEn).toBeVisible()
+
+    // Go back to Settings
+    await settingsNavBtn.click()
+    await page.waitForTimeout(300)
+
     // Capture English Settings screenshot
     await page.screenshot({
       path: path.join(screenshotsDir, "settings-lang-en.png")
@@ -585,6 +625,33 @@ test.describe("Style Atelier Sandbox E2E Tests - Settings", () => {
     // Verify UI has changed to Japanese (Settings title should be "設定")
     const settingsTitleJa = spFrame.locator("h2:has-text('設定')")
     await expect(settingsTitleJa).toBeVisible({ timeout: 5000 })
+
+    // Verify Tab Japanese translations:
+    // A. History Tab empty title
+    await historyNavBtn.click()
+    await page.waitForTimeout(300)
+    const historyEmptyJa = spFrame.locator("h3:has-text('履歴がありません')")
+    await expect(historyEmptyJa).toBeVisible()
+
+    // B. Library Tab empty title
+    await libraryNavBtn.click()
+    await page.waitForTimeout(300)
+    const libraryEmptyJa = spFrame.locator(
+      "h3:has-text('スタイルカードがありません')"
+    )
+    await expect(libraryEmptyJa).toBeVisible()
+
+    // C. Workbench Tab empty title
+    await workbenchNavBtn.click()
+    await page.waitForTimeout(300)
+    const workbenchEmptyJa = spFrame.locator(
+      "h3:has-text('Workbench は空です')"
+    )
+    await expect(workbenchEmptyJa).toBeVisible()
+
+    // Go back to Settings
+    await settingsNavBtn.click()
+    await page.waitForTimeout(300)
 
     // Capture Japanese Settings screenshot
     await page.screenshot({


### PR DESCRIPTION
Resolves #294

### Changes
- Extracted all hardcoded UI strings in HistoryTab, LibraryTab, and Workbench and created translations for them in i18nDict in both English and Japanese.
- Applied useLanguage inside these tabs to render content based on current active language.
- Updated E2E settings test to verify that language switcher correctly updates all tabs.

### Screenshots
- **English Settings & Tab verification**:
  ![settings-lang-en.png](https://github.com/user-attachments/assets/ffb56a29-77a1-4e72-9cf0-0cb868460a33)
- **Japanese Settings & Tab verification**:
  ![settings-lang-ja.png](https://github.com/user-attachments/assets/9071c2a0-d9cd-4dbc-b950-8e2413cc11fa)