### PR TITLE
fix(ux): hide guide button in easy mode to resolve dead links (#353)

### DIFF
--- a/src/components/templates/SidePanelLayout.test.tsx
+++ b/src/components/templates/SidePanelLayout.test.tsx
@@ -1,6 +1,7 @@
-import React from "react"
-import { describe, it, expect, vi, afterEach } from "vitest"
 import { render, screen } from "@testing-library/react"
+import React from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
 import { SidePanelLayout } from "./SidePanelLayout"
 
 describe("SidePanelLayout", () => {
@@ -21,8 +22,7 @@ describe("SidePanelLayout", () => {
         onClearLogs={vi.fn()}
         onResetDb={vi.fn()}
         droppedItem={null}
-        onOpenGuide={vi.fn()}
-      >
+        onOpenGuide={vi.fn()}>
         <div>Test Child Content</div>
       </SidePanelLayout>
     )
@@ -42,13 +42,50 @@ describe("SidePanelLayout", () => {
         onClearLogs={vi.fn()}
         onResetDb={vi.fn()}
         droppedItem={null}
-        onOpenGuide={vi.fn()}
-      >
+        onOpenGuide={vi.fn()}>
         <div>Test Child Content</div>
       </SidePanelLayout>
     )
 
     expect(screen.queryByText("Debug Logs")).not.toBeInTheDocument()
     expect(screen.queryByText("> test-log-item")).not.toBeInTheDocument()
+  })
+
+  it("should render the Guide button when isEasyMode is false or undefined", () => {
+    render(
+      <SidePanelLayout
+        activeTab="history"
+        onTabChange={vi.fn()}
+        isDragging={false}
+        logs={[]}
+        onClearLogs={vi.fn()}
+        onResetDb={vi.fn()}
+        droppedItem={null}
+        onOpenGuide={vi.fn()}
+        isEasyMode={false}>
+        <div>Test Child Content</div>
+      </SidePanelLayout>
+    )
+
+    expect(screen.getByTitle("Show Guide")).toBeInTheDocument()
+  })
+
+  it("should not render the Guide button when isEasyMode is true", () => {
+    render(
+      <SidePanelLayout
+        activeTab="history"
+        onTabChange={vi.fn()}
+        isDragging={false}
+        logs={[]}
+        onClearLogs={vi.fn()}
+        onResetDb={vi.fn()}
+        droppedItem={null}
+        onOpenGuide={vi.fn()}
+        isEasyMode={true}>
+        <div>Test Child Content</div>
+      </SidePanelLayout>
+    )
+
+    expect(screen.queryByTitle("Show Guide")).not.toBeInTheDocument()
   })
 })

--- a/src/components/templates/SidePanelLayout.tsx
+++ b/src/components/templates/SidePanelLayout.tsx
@@ -114,13 +114,15 @@ export function SidePanelLayout({
                 <Settings className="w-4 h-4 text-slate-500" />
                 <span className="sr-only">Settings</span>
               </button>
-              <button
-                onClick={onOpenGuide}
-                className="text-xs text-slate-500 hover:text-slate-700 flex items-center gap-1 py-1 px-2 hover:bg-slate-100 rounded-lg transition-all font-semibold"
-                title="Show Guide">
-                <HelpCircle className="w-4 h-4 text-blue-500" />
-                <span className="hidden sm:inline">Guide</span>
-              </button>
+              {!isEasyMode && (
+                <button
+                  onClick={onOpenGuide}
+                  className="text-xs text-slate-500 hover:text-slate-700 flex items-center gap-1 py-1 px-2 hover:bg-slate-100 rounded-lg transition-all font-semibold"
+                  title="Show Guide">
+                  <HelpCircle className="w-4 h-4 text-blue-500" />
+                  <span className="hidden sm:inline">Guide</span>
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/tests/e2e/easy-mode.spec.ts
+++ b/tests/e2e/easy-mode.spec.ts
@@ -30,6 +30,10 @@ test.describe("Style Atelier Sandbox E2E Tests - Easy Mode Workbench Modal @J-WB
       await skipButton.click()
     }
 
+    // Verify Guide button is visible in default Expert Mode
+    const guideBtn = spFrame.locator("button[title='Show Guide']")
+    await expect(guideBtn).toBeVisible({ timeout: 10000 })
+
     // 2. Toggle Easy Mode ON
     const settingsNavBtn = spFrame.locator("#settings-nav-btn")
     await expect(settingsNavBtn).toBeVisible({ timeout: 10000 })
@@ -39,6 +43,14 @@ test.describe("Style Atelier Sandbox E2E Tests - Easy Mode Workbench Modal @J-WB
     await expect(easyModeToggle).toBeVisible({ timeout: 10000 })
     await easyModeToggle.click()
     await page.waitForTimeout(500)
+
+    // Verify Guide button is hidden in Easy Mode
+    await expect(guideBtn).not.toBeVisible({ timeout: 10000 })
+
+    // Save screenshot of Easy Mode layout showing the guide button is hidden
+    await page.screenshot({
+      path: path.join(screenshotsDir, "easy-mode-guide-hidden.png")
+    })
 
     // 3. Inject a mock card in Easy Mode
     await spFrame.locator("body").evaluate(async () => {


### PR DESCRIPTION
Resolves #353

### Changes
- Wrapped the "Guide" button in `src/components/templates/SidePanelLayout.tsx` with `!isEasyMode` check to prevent it from rendering in Easy Mode.
- Added unit tests in `src/components/templates/SidePanelLayout.test.tsx` verifying the "Guide" button visibility in both mode states.
- Updated Playwright E2E tests in `tests/e2e/easy-mode.spec.ts` to assert that the "Guide" button is visible in Expert Mode and hidden in Easy Mode, and to save a screenshot of the hidden state.

### Verification (Screenshots & Tests)
- All unit tests and E2E tests pass.
- Verified Easy Mode layout showing that the Guide button is hidden:

![easy-mode-guide-hidden.png](https://github.com/user-attachments/assets/f6c3e1de-42e9-465b-882d-8e1486b61dbd)
