### PR TITLE
[UX/Responsive] Fix TipsBar truncation in narrow viewports (#354)

### DIFF
--- a/src/components/organisms/TipsBar.test.tsx
+++ b/src/components/organisms/TipsBar.test.tsx
@@ -90,4 +90,15 @@ describe("TipsBar", () => {
     expect(tipsBarDiv?.className).toContain("bottom-0")
     expect(tipsBarDiv?.className).not.toContain("bottom-[92px]")
   })
+
+  it("renders tips bar text with formatting classes but no title attribute", () => {
+    const { container } = renderTipsBar()
+
+    const tipText = container.querySelector("#tips-bar-text")
+    expect(tipText).not.toBeNull()
+    expect(tipText?.className).toContain("whitespace-normal")
+    expect(tipText?.className).toContain("break-words")
+    expect(tipText?.className).not.toContain("truncate")
+    expect(tipText?.getAttribute("title")).toBeNull()
+  })
 })

--- a/src/components/organisms/TipsBar.tsx
+++ b/src/components/organisms/TipsBar.tsx
@@ -32,12 +32,12 @@ export function TipsBar() {
       id="tips-bar"
       className={`fixed ${
         hasPinned ? "bottom-[92px]" : "bottom-0"
-      } left-0 right-0 z-40 bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 border-t border-slate-700/50 shadow-lg text-slate-300 transition-all duration-300 ease-in-out`}>
+      } left-0 right-0 z-40 bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 border-t border-slate-700/50 shadow-lg text-slate-300 transition-all duration-300 ease-in-out pointer-events-none`}>
       <div className="max-w-md mx-auto py-1.5 px-3 flex items-center justify-between text-[10px] sm:text-xs">
         <div className="flex items-center gap-1.5 flex-1 min-w-0">
           <Sparkles className="w-3.5 h-3.5 text-yellow-400 animate-pulse shrink-0" />
           <span
-            className="truncate leading-normal select-none font-medium animate-in fade-in slide-in-from-right-2 duration-300"
+            className="whitespace-normal break-words leading-normal select-none font-medium animate-in fade-in slide-in-from-right-2 duration-300"
             key={currentTipIndex}
             id="tips-bar-text">
             {tips[currentTipIndex]}
@@ -46,7 +46,7 @@ export function TipsBar() {
         <button
           type="button"
           onClick={() => setCurrentTipIndex((prev) => (prev + 1) % tips.length)}
-          className="text-[9px] font-bold text-slate-400 hover:text-slate-200 ml-2 shrink-0 transition-colors bg-slate-800 hover:bg-slate-700 px-1.5 py-0.5 rounded border border-slate-700 cursor-pointer"
+          className="text-[9px] font-bold text-slate-400 hover:text-slate-200 ml-2 shrink-0 transition-colors bg-slate-800 hover:bg-slate-700 px-1.5 py-0.5 rounded border border-slate-700 cursor-pointer pointer-events-auto"
           id="next-tip-btn">
           Next &rarr;
         </button>

--- a/tests/e2e/tips-bar.spec.ts
+++ b/tests/e2e/tips-bar.spec.ts
@@ -78,5 +78,29 @@ test.describe("Style Atelier Sandbox E2E Tests - Tips Bar @J-SYS-03", () => {
 
     // Verify Tips Bar is back
     await expect(tipsBar).toBeVisible()
+
+    // 6. Resize viewport to narrow width (e.g., 320px) to verify responsive wrap
+    console.log("Resizing viewport to narrow width (320px)...")
+    await page.setViewportSize({ width: 320, height: 600 })
+    await page.waitForTimeout(500)
+
+    // Verify Tips Bar is still visible
+    await expect(tipsBar).toBeVisible()
+    await expect(tipText).toBeVisible()
+
+    // Verify it is not truncated (scrollWidth <= clientWidth due to whitespace-normal)
+    const isTruncated = await tipText.evaluate(
+      (el) => el.scrollWidth > el.clientWidth
+    )
+    expect(isTruncated).toBe(false)
+
+    // Capture screenshot of narrow viewport showing wrapped text
+    await page.screenshot({
+      path: path.join(screenshotsDir, "tips-bar-narrow.png")
+    })
+    console.log("Narrow Tips Bar screenshot saved.")
+
+    // Restore viewport size
+    await page.setViewportSize({ width: 1920, height: 1080 })
   })
 })


### PR DESCRIPTION
This PR fixes the issue where the TipsBar text gets truncated in narrow viewports by removing the 'truncate' class and introducing 'whitespace-normal break-words'. Also resolves pointer events overlay issues on narrow devices by setting 'pointer-events-none' on the TipsBar container and 'pointer-events-auto' on the interactive Next button. Resolves #354.