### PR TITLE
fix(test): resolve issue #377 (E2E journey tags mismatch)

### DIFF
--- a/memory-bank/e2e-traceability-matrix.md
+++ b/memory-bank/e2e-traceability-matrix.md
@@ -2,29 +2,29 @@
 
 このドキュメントはユーザージャーニーとPlaywright E2Eテストの対応状況をマッピングしたものです。
 
-| ジャーニーID          | ジャーニー名                 | E2E カバレッジ                                   |
-| --------------------- | ---------------------------- | ------------------------------------------------ |
-| **@J-MINT-EXPERT-01** | エキスパートミント           | ✔️ `tests\e2e\mint-expert.spec.ts`               |
-| **@J-MINT-EASY-01**   | かんたんミント               | ❌ 未カバー (Missing)                            |
-| **@J-ORG-EXPERT-01**  | カード管理（エキスパート）   | ✔️ `tests\e2e\card-management.spec.ts`           |
-| **@J-ORG-EXPERT-02**  | カテゴリ管理                 | ✔️ `tests\e2e\categories.spec.ts`                |
-| **@J-ORG-EASY-01**    | かんたんライブラリ           | ❌ 未カバー (Missing)                            |
-| **@J-WB-EXPERT-01**   | ワークベンチ（エキスパート） | ✔️ `tests\e2e\workbench.spec.ts`                 |
-| **@J-WB-EXPERT-02**   | ドラッグ＆ドロップ操作       | ✔️ `tests\e2e\drag-and-drop.spec.ts`             |
-| **@J-WB-EXPERT-03**   | プロンプトインジェクション   | ✔️ `tests\e2e\prompt-injection.spec.ts`          |
-| **@J-WB-EASY-01**     | かんたんワークベンチ         | ✔️ `tests\e2e\easy-mode.spec.ts`                 |
-| **@J-IO-QR-OUT**      | QRエクスポート               | ❌ 未カバー (Missing)                            |
-| **@J-IO-QR-IN**       | QRインポート                 | ❌ 未カバー (Missing)                            |
-| **@J-IO-BACKUP**      | データバックアップ           | ❌ 未カバー (Missing)                            |
-| **@J-IO-RESTORE**     | データリストア               | ❌ 未カバー (Missing)                            |
-| **@J-SYS-01**         | 履歴表示                     | ✔️ `tests\e2e\history-scroll.spec.ts`            |
-| **@J-SYS-02**         | エキスパートヘルプ           | ✔️ `tests\e2e\expert-help.spec.ts`               |
-| **@J-SYS-03**         | Tipsバー                     | ✔️ `tests\e2e\tips-bar.spec.ts`                  |
-| **@J-SYS-04**         | 言語切り替え                 | ✔️ `tests\e2e\i18n-missing-translations.spec.ts` |
-| **@J-SET-01**         | アプリ設定                   | ✔️ `tests\e2e\settings.spec.ts`                  |
+| ジャーニーID          | ジャーニー名                 | E2E カバレッジ                                                                                    |
+| --------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------- |
+| **@J-MINT-EXPERT-01** | エキスパートミント           | ✔️ `tests\e2e\mint-expert.spec.ts`                                                                |
+| **@J-MINT-EASY-01**   | かんたんミント               | ✔️ `tests\e2e\easy-mode.spec.ts`                                                                  |
+| **@J-ORG-EXPERT-01**  | カード管理（エキスパート）   | ✔️ `tests\e2e\card-management.spec.ts`                                                            |
+| **@J-ORG-EXPERT-02**  | カテゴリ管理                 | ✔️ `tests\e2e\categories.spec.ts`                                                                 |
+| **@J-ORG-EASY-01**    | かんたんライブラリ           | ✔️ `tests\e2e\easy-mode.spec.ts`                                                                  |
+| **@J-WB-EXPERT-01**   | ワークベンチ（エキスパート） | ✔️ `tests\e2e\workbench.spec.ts`                                                                  |
+| **@J-WB-EXPERT-02**   | ドラッグ＆ドロップ操作       | ✔️ `tests\e2e\drag-and-drop.spec.ts`                                                              |
+| **@J-WB-EXPERT-03**   | プロンプトインジェクション   | ✔️ `tests\e2e\prompt-injection.spec.ts`                                                           |
+| **@J-WB-EASY-01**     | かんたんワークベンチ         | ✔️ `tests\e2e\easy-mode.spec.ts`                                                                  |
+| **@J-IO-QR-OUT**      | QRエクスポート               | ✔️ `tests\e2e\data-io.spec.ts`                                                                    |
+| **@J-IO-QR-IN**       | QRインポート                 | ✔️ `tests\e2e\data-io.spec.ts`                                                                    |
+| **@J-IO-BACKUP**      | データバックアップ           | ✔️ `tests\e2e\data-io.spec.ts`                                                                    |
+| **@J-IO-RESTORE**     | データリストア               | ✔️ `tests\e2e\data-io.spec.ts`                                                                    |
+| **@J-SYS-01**         | 履歴表示                     | ✔️ `tests\e2e\history-scroll.spec.ts`                                                             |
+| **@J-SYS-02**         | エキスパートヘルプ           | ✔️ `tests\e2e\expert-help.spec.ts`                                                                |
+| **@J-SYS-03**         | Tipsバー                     | ✔️ `tests\e2e\tips-bar.spec.ts`                                                                   |
+| **@J-SYS-04**         | 言語切り替え                 | ✔️ `tests\e2e\i18n-missing-translations.spec.ts`<br>✔️ `tests\e2e\i18n-new-comprehensive.spec.ts` |
+| **@J-SET-01**         | アプリ設定                   | ✔️ `tests\e2e\settings.spec.ts`                                                                   |
 
 ## サマリー
 
 - 全ジャーニー数: 18
-- カバー済み: 12
-- 未カバー: 6
+- カバー済み: 18
+- 未カバー: 0

--- a/tests/e2e/data-io.spec.ts
+++ b/tests/e2e/data-io.spec.ts
@@ -16,7 +16,7 @@ test.describe("Style Atelier Sandbox E2E Tests - Data I/O @J-IO-01", () => {
     })
   })
 
-  test("should allow exporting style card as image (QR output) and importing from it (QR input) @J-IO-QR", async ({
+  test("should allow exporting style card as image (QR output) and importing from it (QR input) @J-IO-QR-OUT @J-IO-QR-IN", async ({
     page
   }) => {
     const screenshotsDir = path.join(__dirname, "../../tests/screenshots")
@@ -164,7 +164,7 @@ test.describe("Style Atelier Sandbox E2E Tests - Data I/O @J-IO-01", () => {
     console.log("QR Import E2E validation passed successfully!")
   })
 
-  test("should allow exporting local database backup and importing from it @J-IO-LOCAL", async ({
+  test("should allow exporting local database backup and importing from it @J-IO-BACKUP @J-IO-RESTORE", async ({
     page
   }) => {
     const screenshotsDir = path.join(__dirname, "../../tests/screenshots")


### PR DESCRIPTION
Resolves #377

This PR updates the E2E test journey tag names in tests/e2e/data-io.spec.ts to match the official journey IDs in userJourneys.json.
Specifically:
- @J-IO-QR -> @J-IO-QR-OUT @J-IO-QR-IN
- @J-IO-LOCAL -> @J-IO-BACKUP @J-IO-RESTORE

We also re-ran the audit script, which successfully updated memory-bank/e2e-traceability-matrix.md. All 18 journeys are now covered (0 missing tests).