### PR TITLE
Refactor React Query boundaries and add integration tests (#415)

### DIFF
--- a/src/components/organisms/CardDetailView.test.tsx
+++ b/src/components/organisms/CardDetailView.test.tsx
@@ -21,7 +21,7 @@ vi.mock("../../hooks/useHand", () => ({
 }))
 
 vi.mock("../../hooks/useCategories", () => ({
-  useCategories: vi.fn().mockReturnValue({ data: [] })
+  useCategories: vi.fn().mockReturnValue([])
 }))
 
 vi.mock("../../hooks/useStyleCards", () => ({

--- a/src/components/organisms/CardDetailView.test.tsx
+++ b/src/components/organisms/CardDetailView.test.tsx
@@ -25,8 +25,7 @@ vi.mock("../../hooks/useCategories", () => ({
 }))
 
 vi.mock("../../hooks/useStyleCards", () => ({
-  useStyleCards: vi.fn().mockReturnValue({ data: [] }),
-  useUpdateStyleCard: vi.fn().mockReturnValue({ mutateAsync: vi.fn() })
+  useStyleCards: vi.fn().mockReturnValue([])
 }))
 
 vi.mock("../../lib/export-utils", () => ({

--- a/src/components/organisms/CardDetailView.tsx
+++ b/src/components/organisms/CardDetailView.tsx
@@ -62,7 +62,7 @@ export function CardDetailView({
   const { expertFeatures } = useSettings()
   const { t } = useLanguage()
 
-  const { data: categoriesList = [] } = useCategories()
+  const categoriesList = useCategories()
 
   const {
     name,

--- a/src/components/organisms/MintingView.test.tsx
+++ b/src/components/organisms/MintingView.test.tsx
@@ -18,7 +18,7 @@ vi.mock("../../hooks/useHand", () => ({
 }))
 
 vi.mock("../../hooks/useCategories", () => ({
-  useCategories: vi.fn().mockReturnValue({ data: [] })
+  useCategories: vi.fn().mockReturnValue([])
 }))
 
 const mockMintingItem: HistoryItem = {

--- a/src/components/organisms/MintingView.tsx
+++ b/src/components/organisms/MintingView.tsx
@@ -74,7 +74,7 @@ export function MintingView({
   const { expertFeatures } = useSettings()
   const { t } = useLanguage()
 
-  const { data: categoriesList = [] } = useCategories()
+  const categoriesList = useCategories()
 
   const toggleKeyword = (keyword: string) => {
     if (selectedKeywords.includes(keyword)) {

--- a/src/components/organisms/ParameterEditor.test.tsx
+++ b/src/components/organisms/ParameterEditor.test.tsx
@@ -8,9 +8,7 @@ import { ParameterEditor } from "./ParameterEditor"
 let mockStyleCards: any[] = []
 
 vi.mock("../../hooks/useStyleCards", () => ({
-  useStyleCards: () => ({
-    data: mockStyleCards
-  })
+  useStyleCards: () => mockStyleCards
 }))
 
 describe("ParameterEditor", () => {

--- a/src/components/organisms/ParameterEditor.tsx
+++ b/src/components/organisms/ParameterEditor.tsx
@@ -58,7 +58,7 @@ export const ParameterEditor: React.FC<ParameterEditorProps> = ({
     }
   }
 
-  const { data: allCards = [] } = useStyleCards()
+  const allCards = useStyleCards()
 
   const allSrefs = useMemo(() => {
     const srefs = new Set<string>()

--- a/src/components/organisms/SimpleMintingView.tsx
+++ b/src/components/organisms/SimpleMintingView.tsx
@@ -41,7 +41,7 @@ export function SimpleMintingView({
   selectedCategory = "",
   setSelectedCategory = () => {}
 }: SimpleMintingViewProps) {
-  const { data: categoriesList = [] } = useCategories()
+  const categoriesList = useCategories()
   const { t } = useLanguage()
 
   // Ensure a category is always selected if categories exist

--- a/src/components/organisms/SimpleWorkbenchModal.test.tsx
+++ b/src/components/organisms/SimpleWorkbenchModal.test.tsx
@@ -2,15 +2,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { useUpdateStyleCard } from "../../hooks/useStyleCards"
 import { db } from "../../lib/db"
+import { updateStyleCard } from "../../lib/style-card-store"
 import { SimpleWorkbenchModal } from "./SimpleWorkbenchModal"
 
-const mockMutateAsync = vi.fn().mockResolvedValue(1)
-vi.mock("../../hooks/useStyleCards", () => ({
-  useUpdateStyleCard: () => ({
-    mutateAsync: mockMutateAsync
-  })
+vi.mock("../../lib/style-card-store", () => ({
+  updateStyleCard: vi.fn().mockResolvedValue(1)
 }))
 
 // Mock PromptBubbleEditor and ParameterEditor to simplify layout testing
@@ -57,7 +54,7 @@ describe("SimpleWorkbenchModal", () => {
       { id: 1, status: "complete" }
     ] as any)
     vi.mocked(chrome.tabs.sendMessage).mockResolvedValue({ status: "success" })
-    mockMutateAsync.mockClear()
+    vi.mocked(updateStyleCard).mockClear()
   })
 
   it("renders card name, details and inputs correctly", () => {
@@ -119,9 +116,8 @@ describe("SimpleWorkbenchModal", () => {
         type: "INJECT_PROMPT",
         prompt: "neon glow --ar 1:1"
       })
-      expect(mockMutateAsync).toHaveBeenCalledWith({
-        id: "card-123",
-        changes: { usageCount: 1 }
+      expect(updateStyleCard).toHaveBeenCalledWith("card-123", {
+        usageCount: 1
       })
       expect(mockAddLog).toHaveBeenCalledWith("Prompt injected successfully!")
     })

--- a/src/components/organisms/SimpleWorkbenchModal.tsx
+++ b/src/components/organisms/SimpleWorkbenchModal.tsx
@@ -2,9 +2,9 @@ import { Send, X } from "lucide-react"
 import React, { useEffect, useState } from "react"
 
 import { useLanguage } from "../../contexts/LanguageContext"
-import { useUpdateStyleCard } from "../../hooks/useStyleCards"
 import type { PromptSegment, StyleCard } from "../../lib/db-schema"
 import { buildPromptString } from "../../lib/prompt-utils"
+import { updateStyleCard } from "../../lib/style-card-store"
 import { Button } from "../atoms/Button"
 import { CardThumbnail } from "../molecules/CardThumbnail"
 import type { AlertType } from "../molecules/ConnectionAlert"
@@ -27,7 +27,6 @@ export function SimpleWorkbenchModal({
   const [editedSegments, setEditedSegments] = useState<PromptSegment[]>([])
   const [editedParams, setEditedParams] = useState<any>({})
   const [isInjecting, setIsInjecting] = useState(false)
-  const updateCardMutation = useUpdateStyleCard()
 
   const { t: i18n } = useLanguage()
   const t = i18n.simpleWorkbench
@@ -138,9 +137,8 @@ export function SimpleWorkbenchModal({
         addLog?.(t.injectSuccess)
 
         // Increment usage count for the card
-        await updateCardMutation.mutateAsync({
-          id: card.id,
-          changes: { usageCount: (card.usageCount || 0) + 1 }
+        await updateStyleCard(card.id, {
+          usageCount: (card.usageCount || 0) + 1
         })
       }
     } catch (err) {

--- a/src/components/organisms/Workbench.test.tsx
+++ b/src/components/organisms/Workbench.test.tsx
@@ -37,7 +37,7 @@ vi.mock("../../hooks/useStyleCards", () => ({
 }))
 
 vi.mock("../../hooks/useCategories", () => ({
-  useCategories: vi.fn().mockReturnValue({ data: [] })
+  useCategories: vi.fn().mockReturnValue([])
 }))
 
 describe("Workbench", () => {

--- a/src/components/organisms/Workbench.test.tsx
+++ b/src/components/organisms/Workbench.test.tsx
@@ -32,8 +32,7 @@ vi.mock("../../hooks/useEvolution", () => ({
 }))
 
 vi.mock("../../hooks/useStyleCards", () => ({
-  useStyleCards: vi.fn().mockReturnValue({ data: [] }),
-  useUpdateStyleCard: vi.fn().mockReturnValue({ mutateAsync: vi.fn() })
+  useStyleCards: vi.fn().mockReturnValue([])
 }))
 
 vi.mock("../../hooks/useCategories", () => ({

--- a/src/hooks/useCategories.integration.test.ts
+++ b/src/hooks/useCategories.integration.test.ts
@@ -1,0 +1,45 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { db } from "../lib/db"
+import { useCategories } from "./useCategories"
+
+// Unmock the database to test real IndexedDB reactive behaviour with fake-indexeddb
+vi.unmock("../lib/db")
+vi.unmock("./src/lib/db")
+
+describe("useCategories integration test", () => {
+  beforeEach(async () => {
+    await db.categories.clear()
+  })
+
+  it("should reactively update when categories are added or deleted", async () => {
+    const { result } = renderHook(() => useCategories())
+
+    // 1. Initial state
+    expect(result.current).toEqual([])
+
+    // 2. Add category
+    let categoryId: string = ""
+    await act(async () => {
+      categoryId = await db.addCategory({
+        id: "cyberpunk",
+        name: "Cyberpunk"
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.length).toBe(1)
+      expect(result.current[0].name).toBe("Cyberpunk")
+    })
+
+    // 3. Delete category
+    await act(async () => {
+      await db.deleteCategory(categoryId)
+    })
+
+    await waitFor(() => {
+      expect(result.current).toEqual([])
+    })
+  })
+})

--- a/src/hooks/useCategories.test.ts
+++ b/src/hooks/useCategories.test.ts
@@ -1,84 +1,32 @@
-import { renderHook, waitFor } from "@testing-library/react"
-import React from "react"
+import { renderHook } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { db } from "../lib/db"
-import * as store from "../lib/style-card-store"
-import { QueryTestProvider } from "../test/react-query-helper"
-import {
-  useAddCategory,
-  useCategories,
-  useDeleteCategory,
-  useUpdateCategory
-} from "./useCategories"
+import { useCategories } from "./useCategories"
 
-vi.mock("../lib/style-card-store", () => ({
-  getAllCategories: vi.fn()
+// Mock dexie-react-hooks
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: (fn: any) => fn()
 }))
 
 vi.mock("../lib/db", () => ({
   db: {
-    addCategory: vi.fn(),
-    updateCategory: vi.fn(),
-    deleteCategory: vi.fn()
+    getAllCategories: vi.fn()
   }
 }))
 
-describe("useCategories hooks", () => {
-  const wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryTestProvider, null, children)
-
+describe("useCategories hook", () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it("useCategories fetches all categories", async () => {
+  it("useCategories fetches all categories from IndexedDB", () => {
     const mockCategories = [{ id: "1", name: "Category 1" }]
-    vi.mocked(store.getAllCategories).mockResolvedValue(mockCategories as any)
+    vi.mocked(db.getAllCategories).mockReturnValue(mockCategories as any)
 
-    const { result } = renderHook(() => useCategories(), { wrapper })
+    const { result } = renderHook(() => useCategories())
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data).toEqual(mockCategories)
-    expect(store.getAllCategories).toHaveBeenCalled()
-  })
-
-  it("useAddCategory calls db.addCategory and invalidates query", async () => {
-    vi.mocked(db.addCategory).mockResolvedValue("new-cat-id")
-
-    const { result } = renderHook(() => useAddCategory(), { wrapper })
-
-    result.current.mutate({ id: "new", name: "New" } as any)
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(vi.mocked(db.addCategory).mock.calls[0][0]).toEqual({
-      id: "new",
-      name: "New"
-    })
-  })
-
-  it("useUpdateCategory calls db.updateCategory", async () => {
-    vi.mocked(db.updateCategory).mockResolvedValue(1)
-
-    const { result } = renderHook(() => useUpdateCategory(), { wrapper })
-
-    result.current.mutate({ id: "1", changes: { name: "updated" } })
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(vi.mocked(db.updateCategory).mock.calls[0][0]).toBe("1")
-    expect(vi.mocked(db.updateCategory).mock.calls[0][1]).toEqual({
-      name: "updated"
-    })
-  })
-
-  it("useDeleteCategory calls db.deleteCategory", async () => {
-    vi.mocked(db.deleteCategory).mockResolvedValue(undefined)
-
-    const { result } = renderHook(() => useDeleteCategory(), { wrapper })
-
-    result.current.mutate("1")
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(vi.mocked(db.deleteCategory).mock.calls[0][0]).toBe("1")
+    expect(result.current).toEqual(mockCategories)
+    expect(db.getAllCategories).toHaveBeenCalled()
   })
 })

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,51 +1,7 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useLiveQuery } from "dexie-react-hooks"
 
 import { db } from "../lib/db"
-import type { CustomCategory } from "../lib/db-schema"
-import { getAllCategories } from "../lib/style-card-store"
-
-export const CATEGORIES_QUERY_KEY = ["categories"]
 
 export function useCategories() {
-  return useQuery({
-    queryKey: CATEGORIES_QUERY_KEY,
-    queryFn: getAllCategories,
-    staleTime: 1000 * 60 * 5 // 5 minutes
-  })
-}
-
-export function useAddCategory() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: (category: CustomCategory) => db.addCategory(category),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: CATEGORIES_QUERY_KEY })
-    }
-  })
-}
-
-export function useUpdateCategory() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: ({
-      id,
-      changes
-    }: {
-      id: string
-      changes: Partial<CustomCategory>
-    }) => db.updateCategory(id, changes),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: CATEGORIES_QUERY_KEY })
-    }
-  })
-}
-
-export function useDeleteCategory() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: (id: string) => db.deleteCategory(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: CATEGORIES_QUERY_KEY })
-    }
-  })
+  return useLiveQuery(() => db.getAllCategories()) ?? []
 }

--- a/src/hooks/useStyleCards.integration.test.ts
+++ b/src/hooks/useStyleCards.integration.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { db } from "../lib/db"
+import {
+  addStyleCard,
+  deleteStyleCard,
+  updateStyleCard
+} from "../lib/style-card-store"
+import { useStyleCards } from "./useStyleCards"
+
+// Unmock the database to test real IndexedDB reactive behaviour with fake-indexeddb
+vi.unmock("../lib/db")
+vi.unmock("./src/lib/db")
+
+describe("useStyleCards integration test", () => {
+  beforeEach(async () => {
+    await db.styleCards.clear()
+  })
+
+  it("should reactively update when cards are added, updated, or deleted", async () => {
+    const { result } = renderHook(() => useStyleCards())
+
+    // 1. Initial state
+    expect(result.current).toEqual([])
+
+    // 2. Add card with explicit id
+    const cardId = "card-test-123"
+    await act(async () => {
+      await addStyleCard({
+        id: cardId,
+        name: "Neo Tokyo",
+        tier: "Rare",
+        parameters: { ar: "16:9" }
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.length).toBe(1)
+      expect(result.current[0].name).toBe("Neo Tokyo")
+    })
+
+    // 3. Update card
+    await act(async () => {
+      await updateStyleCard(cardId, { name: "Neo Tokyo V2" })
+    })
+
+    await waitFor(() => {
+      expect(result.current.length).toBe(1)
+      expect(result.current[0].name).toBe("Neo Tokyo V2")
+    })
+
+    // 4. Delete card
+    await act(async () => {
+      await deleteStyleCard(cardId)
+    })
+
+    await waitFor(() => {
+      expect(result.current).toEqual([])
+    })
+  })
+})

--- a/src/hooks/useStyleCards.test.ts
+++ b/src/hooks/useStyleCards.test.ts
@@ -1,90 +1,40 @@
-import { renderHook, waitFor } from "@testing-library/react"
-import React from "react"
+import { renderHook } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import * as store from "../lib/style-card-store"
-import { QueryTestProvider } from "../test/react-query-helper"
-import {
-  useAddStyleCard,
-  useDeleteStyleCard,
-  usePinnedStyleCards,
-  useStyleCards,
-  useUpdateStyleCard
-} from "./useStyleCards"
+import { usePinnedStyleCards, useStyleCards } from "./useStyleCards"
+
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: vi.fn((fn) => fn())
+}))
 
 vi.mock("../lib/style-card-store", () => ({
   getAllStyleCards: vi.fn(),
-  getPinnedStyleCards: vi.fn(),
-  addStyleCard: vi.fn(),
-  updateStyleCard: vi.fn(),
-  deleteStyleCard: vi.fn()
+  getPinnedStyleCards: vi.fn()
 }))
 
 describe("useStyleCards hooks", () => {
-  const wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryTestProvider, null, children)
-
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it("useStyleCards fetches all cards", async () => {
+  it("useStyleCards fetches all cards", () => {
     const mockCards = [{ id: "1", name: "Card 1" }]
-    vi.mocked(store.getAllStyleCards).mockResolvedValue(mockCards as any)
+    vi.mocked(store.getAllStyleCards).mockReturnValue(mockCards as any)
 
-    const { result } = renderHook(() => useStyleCards(), { wrapper })
+    const { result } = renderHook(() => useStyleCards())
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data).toEqual(mockCards)
+    expect(result.current).toEqual(mockCards)
     expect(store.getAllStyleCards).toHaveBeenCalled()
   })
 
-  it("usePinnedStyleCards fetches pinned cards", async () => {
+  it("usePinnedStyleCards fetches pinned cards", () => {
     const mockCards = [{ id: "1", name: "Card 1", isPinned: true }]
-    vi.mocked(store.getPinnedStyleCards).mockResolvedValue(mockCards as any)
+    vi.mocked(store.getPinnedStyleCards).mockReturnValue(mockCards as any)
 
-    const { result } = renderHook(() => usePinnedStyleCards(), { wrapper })
+    const { result } = renderHook(() => usePinnedStyleCards())
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data).toEqual(mockCards)
+    expect(result.current).toEqual(mockCards)
     expect(store.getPinnedStyleCards).toHaveBeenCalled()
-  })
-
-  it("useAddStyleCard calls addStyleCard and invalidates query", async () => {
-    vi.mocked(store.addStyleCard).mockResolvedValue("new-id")
-
-    const { result } = renderHook(() => useAddStyleCard(), { wrapper })
-
-    result.current.mutate({ id: "new" } as any)
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(vi.mocked(store.addStyleCard).mock.calls[0][0]).toEqual({
-      id: "new"
-    })
-  })
-
-  it("useUpdateStyleCard calls updateStyleCard", async () => {
-    vi.mocked(store.updateStyleCard).mockResolvedValue(1)
-
-    const { result } = renderHook(() => useUpdateStyleCard(), { wrapper })
-
-    result.current.mutate({ id: "1", changes: { name: "updated" } })
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(vi.mocked(store.updateStyleCard).mock.calls[0][0]).toBe("1")
-    expect(vi.mocked(store.updateStyleCard).mock.calls[0][1]).toEqual({
-      name: "updated"
-    })
-  })
-
-  it("useDeleteStyleCard calls deleteStyleCard", async () => {
-    vi.mocked(store.deleteStyleCard).mockResolvedValue(undefined)
-
-    const { result } = renderHook(() => useDeleteStyleCard(), { wrapper })
-
-    result.current.mutate("1")
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(vi.mocked(store.deleteStyleCard).mock.calls[0][0]).toBe("1")
   })
 })

--- a/src/hooks/useStyleCards.ts
+++ b/src/hooks/useStyleCards.ts
@@ -1,68 +1,11 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useLiveQuery } from "dexie-react-hooks"
 
-import type { StyleCard } from "../lib/db-schema"
-import {
-  addStyleCard,
-  deleteStyleCard,
-  getAllStyleCards,
-  getPinnedStyleCards,
-  updateStyleCard
-} from "../lib/style-card-store"
-
-export const STYLE_CARDS_QUERY_KEY = ["styleCards"]
-export const PINNED_CARDS_QUERY_KEY = ["pinnedCards"]
+import { getAllStyleCards, getPinnedStyleCards } from "../lib/style-card-store"
 
 export function useStyleCards() {
-  return useQuery({
-    queryKey: STYLE_CARDS_QUERY_KEY,
-    queryFn: getAllStyleCards,
-    staleTime: 1000 * 60 * 5 // 5 minutes
-  })
+  return useLiveQuery(getAllStyleCards) ?? []
 }
 
 export function usePinnedStyleCards() {
-  return useQuery({
-    queryKey: PINNED_CARDS_QUERY_KEY,
-    queryFn: getPinnedStyleCards,
-    staleTime: 1000 * 60 * 5 // 5 minutes
-  })
-}
-
-export function useAddStyleCard() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: addStyleCard,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: STYLE_CARDS_QUERY_KEY })
-      queryClient.invalidateQueries({ queryKey: PINNED_CARDS_QUERY_KEY })
-    }
-  })
-}
-
-export function useUpdateStyleCard() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: ({
-      id,
-      changes
-    }: {
-      id: string
-      changes: Partial<StyleCard>
-    }) => updateStyleCard(id, changes),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: STYLE_CARDS_QUERY_KEY })
-      queryClient.invalidateQueries({ queryKey: PINNED_CARDS_QUERY_KEY })
-    }
-  })
-}
-
-export function useDeleteStyleCard() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: deleteStyleCard,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: STYLE_CARDS_QUERY_KEY })
-      queryClient.invalidateQueries({ queryKey: PINNED_CARDS_QUERY_KEY })
-    }
-  })
+  return useLiveQuery(getPinnedStyleCards) ?? []
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -17,11 +17,11 @@ export class StyleAtelierDatabase extends StyleAtelierDatabaseBase {
     return card
   }
 
-  async getAllCards(): Promise<StyleCard[]> {
+  getAllCards(): Promise<StyleCard[]> {
     return this.styleCards.filter((card) => !card.isDeleted).toArray()
   }
 
-  async getPinnedCards(): Promise<StyleCard[]> {
+  getPinnedCards(): Promise<StyleCard[]> {
     return this.styleCards
       .filter((card) => !card.isDeleted && !!card.isPinned)
       .toArray()
@@ -57,7 +57,7 @@ export class StyleAtelierDatabase extends StyleAtelierDatabaseBase {
 
   // --- Category Operations ---
 
-  async getAllCategories(): Promise<CustomCategory[]> {
+  getAllCategories(): Promise<CustomCategory[]> {
     return this.categories.filter((cat) => !cat.isDeleted).toArray()
   }
 

--- a/src/lib/style-card-store.ts
+++ b/src/lib/style-card-store.ts
@@ -14,22 +14,22 @@ export async function getStyleCardById(
 /**
  * Retrieves all non-deleted StyleCards.
  */
-export async function getAllStyleCards(): Promise<StyleCard[]> {
-  return await db.getAllCards()
+export function getAllStyleCards(): Promise<StyleCard[]> {
+  return db.getAllCards()
 }
 
 /**
  * Retrieves pinned StyleCards.
  */
-export async function getPinnedStyleCards(): Promise<StyleCard[]> {
-  return await db.getPinnedCards()
+export function getPinnedStyleCards(): Promise<StyleCard[]> {
+  return db.getPinnedCards()
 }
 
 /**
  * Retrieves all categories.
  */
-export async function getAllCategories(): Promise<CustomCategory[]> {
-  return await db.getAllCategories()
+export function getAllCategories(): Promise<CustomCategory[]> {
+  return db.getAllCategories()
 }
 
 /**


### PR DESCRIPTION
Closes #415. Migrated hooks to useLiveQuery, cleaned up React Query test artifacts, and added integration tests for useStyleCards and useCategories to verify Local-First IndexedDB reactivity.