### PR TITLE
[UX/Library] LibraryTabにおけるフィルターUIの折りたたみアコーディオン化とリセットバグ修正

### DIFF
--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -52,6 +52,7 @@ tags: []
   - Utilizes `FlexSearch` client-side indexer to enable high-performance, real-time filtering across name, tags, and categories.
   - Implements memory-friendly client-side pagination ("Load More" pattern) in `useLibrary` to limit active DOM node counts in the style grid, preventing rendering-based UI freeze.
   - Implements visual scroll affordance for horizontal color filters using CSS `mask-image` linear-gradients (for smooth edge-fade indications) coupled with dynamic scroll arrow overlays.
+  - Implements a collapsible accordion UI (`LibraryFilterAccordion`) for advanced filters (rarity, category, color, sorting) to maximize screen space while keeping code modularized under 50-line function limits.
 - **Tutorial Spotlight & Position Synchronization**:
   - Tutorial spotlight positioning, window resize/scroll event listeners, click-blocking logic, and database mock insertions are fully encapsulated in the `useSpotlight` custom hook (`src/hooks/useSpotlight.ts`).
   - Decouples DOM calculations and window event handlers from the `InteractiveTutorial` overlay component (`src/components/organisms/InteractiveTutorial.tsx`), maintaining clean separation of concerns and keeping component file size well within constraints (under 300 lines).

--- a/src/components/molecules/ColorPaletteFilter.tsx
+++ b/src/components/molecules/ColorPaletteFilter.tsx
@@ -1,0 +1,176 @@
+import React, { useCallback, useEffect, useRef, useState } from "react"
+
+interface ColorOption {
+  value: string
+  label: string
+  bg: string
+}
+
+interface ColorPaletteFilterProps {
+  colorFilter: string
+  setColorFilter: (color: string) => void
+  colorOptions: ColorOption[]
+  colorLabel?: string
+  styleCardsCount: number
+}
+
+interface ColorButtonProps {
+  colorOpt: ColorOption
+  isSelected: boolean
+  onClick: () => void
+}
+
+export function ColorButton({
+  colorOpt,
+  isSelected,
+  onClick
+}: ColorButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-3.5 h-3.5 rounded-full flex-shrink-0 transition-all border relative ${
+        isSelected
+          ? "scale-110 ring-1.5 ring-blue-500 ring-offset-0.5"
+          : "hover:scale-105"
+      }`}
+      style={{
+        background: colorOpt.bg,
+        borderColor: colorOpt.value === "White" ? "#cbd5e1" : "transparent"
+      }}
+      title={colorOpt.label}>
+      {isSelected && (
+        <span
+          className={`absolute inset-0 flex items-center justify-center text-[7px] font-black ${
+            colorOpt.value === "White" || colorOpt.value === "Yellow"
+              ? "text-slate-800"
+              : "text-white"
+          }`}>
+          ✓
+        </span>
+      )}
+    </button>
+  )
+}
+
+interface ScrollButtonProps {
+  direction: "left" | "right"
+  onClick: () => void
+}
+
+export function ScrollButton({ direction, onClick }: ScrollButtonProps) {
+  const isLeft = direction === "left"
+  return (
+    <button
+      onClick={onClick}
+      className={`absolute ${
+        isLeft ? "left-0" : "right-0"
+      } z-10 w-4 h-4 bg-white/95 text-slate-700 hover:text-slate-900 rounded-full flex items-center justify-center border border-slate-200 shadow hover:bg-slate-50 transition-colors text-[9px] font-bold`}
+      aria-label={`Scroll ${direction}`}>
+      {isLeft ? "‹" : "›"}
+    </button>
+  )
+}
+
+function useHorizontalScroll(dependencies: any[]) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [showLeftArrow, setShowLeftArrow] = useState(false)
+  const [showRightArrow, setShowRightArrow] = useState(false)
+
+  const checkScroll = useCallback(() => {
+    const el = scrollRef.current
+    if (el) {
+      const { scrollLeft, scrollWidth, clientWidth } = el
+      setShowLeftArrow(scrollLeft > 1)
+      setShowRightArrow(scrollLeft < scrollWidth - clientWidth - 1)
+    }
+  }, [])
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) {
+      checkScroll()
+      el.addEventListener("scroll", checkScroll)
+      window.addEventListener("resize", checkScroll)
+
+      const timer = setTimeout(checkScroll, 100)
+
+      let resizeObserver: ResizeObserver | null = null
+      if (typeof ResizeObserver !== "undefined") {
+        resizeObserver = new ResizeObserver(() => {
+          checkScroll()
+        })
+        resizeObserver.observe(el)
+      }
+
+      return () => {
+        el.removeEventListener("scroll", checkScroll)
+        window.removeEventListener("resize", checkScroll)
+        clearTimeout(timer)
+        if (resizeObserver) {
+          resizeObserver.disconnect()
+        }
+      }
+    }
+  }, [checkScroll, ...dependencies])
+
+  const scrollBy = (amount: number) => {
+    const el = scrollRef.current
+    if (el) {
+      el.scrollBy({ left: amount, behavior: "smooth" })
+    }
+  }
+
+  return { scrollRef, showLeftArrow, showRightArrow, scrollBy }
+}
+
+export function ColorPaletteFilter({
+  colorFilter,
+  setColorFilter,
+  colorOptions,
+  colorLabel = "Color:",
+  styleCardsCount
+}: ColorPaletteFilterProps) {
+  const { scrollRef, showLeftArrow, showRightArrow, scrollBy } =
+    useHorizontalScroll([styleCardsCount])
+
+  return (
+    <div className="flex gap-1 items-center mt-0.5 select-none w-full">
+      <span className="text-[9px] text-slate-400 font-bold mr-1 flex-shrink-0">
+        {colorLabel}
+      </span>
+      <div className="relative flex-1 flex items-center min-w-0">
+        {showLeftArrow && (
+          <ScrollButton direction="left" onClick={() => scrollBy(-100)} />
+        )}
+        <div
+          ref={scrollRef}
+          data-testid="color-scroll-container"
+          className="flex gap-1 items-center overflow-x-auto pb-1 scrollbar-none w-full"
+          style={{
+            maskImage: `linear-gradient(to right, ${
+              showLeftArrow ? "transparent" : "white"
+            } 0%, white 12px, white calc(100% - 12px), ${
+              showRightArrow ? "transparent" : "white"
+            } 100%)`,
+            WebkitMaskImage: `linear-gradient(to right, ${
+              showLeftArrow ? "transparent" : "white"
+            } 0%, white 12px, white calc(100% - 12px), ${
+              showRightArrow ? "transparent" : "white"
+            } 100%)`
+          }}>
+          {colorOptions.map((colorOpt) => (
+            <ColorButton
+              key={colorOpt.value}
+              colorOpt={colorOpt}
+              isSelected={colorFilter === colorOpt.value}
+              onClick={() => setColorFilter(colorOpt.value)}
+            />
+          ))}
+        </div>
+        {showRightArrow && (
+          <ScrollButton direction="right" onClick={() => scrollBy(100)} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/organisms/LibraryFilterAccordion.tsx
+++ b/src/components/organisms/LibraryFilterAccordion.tsx
@@ -1,0 +1,224 @@
+import { Tag } from "lucide-react"
+import React from "react"
+
+import { ColorPaletteFilter } from "../molecules/ColorPaletteFilter"
+
+interface LibraryFilterAccordionProps {
+  isFiltersExpanded: boolean
+  expertFeatures: {
+    rarity?: boolean
+    categories?: boolean
+  }
+  rarityFilter: string
+  setRarityFilter: (rarity: any) => void
+  sortBy: string
+  setSortBy: (sort: any) => void
+  colorFilter: string
+  setColorFilter: (color: any) => void
+  colorOptions: Array<{ value: string; label: string; bg: string }>
+  colorLabel?: string
+  styleCardsCount: number
+  categoryFilter: string
+  setCategoryFilter: (category: string) => void
+  categories: Array<{
+    id: string
+    name: string
+    iconUrl?: string
+    iconEmoji?: string
+  }>
+  setIsCategoryModalOpen: (open: boolean) => void
+  allCategoriesLabel?: string
+  manageCategoriesTitle?: string
+  allRaritiesLabel?: string
+  sortByNewestLabel?: string
+  sortByOldestLabel?: string
+  sortByRarityLabel?: string
+  sortByUsageLabel?: string
+  sortByColorLabel?: string
+}
+
+interface RaritySortFiltersProps {
+  expertFeatures: { rarity?: boolean }
+  rarityFilter: string
+  setRarityFilter: (rarity: any) => void
+  sortBy: string
+  setSortBy: (sort: any) => void
+  allRaritiesLabel: string
+  sortByNewestLabel: string
+  sortByOldestLabel: string
+  sortByRarityLabel: string
+  sortByUsageLabel: string
+  sortByColorLabel: string
+}
+
+export function RaritySortFilters({
+  expertFeatures,
+  rarityFilter,
+  setRarityFilter,
+  sortBy,
+  setSortBy,
+  allRaritiesLabel,
+  sortByNewestLabel,
+  sortByOldestLabel,
+  sortByRarityLabel,
+  sortByUsageLabel,
+  sortByColorLabel
+}: RaritySortFiltersProps) {
+  return (
+    <div className="flex gap-2">
+      {expertFeatures.rarity && (
+        <select
+          value={rarityFilter}
+          onChange={(e) => setRarityFilter(e.target.value as any)}
+          className="flex-1 px-1 py-1 text-[10px] border rounded bg-white">
+          <option value="All">{allRaritiesLabel}</option>
+          <option value="Common">Common</option>
+          <option value="Rare">Rare</option>
+          <option value="Epic">Epic</option>
+          <option value="Legendary">Legendary</option>
+        </select>
+      )}
+      <select
+        value={sortBy}
+        onChange={(e) => setSortBy(e.target.value as any)}
+        className="flex-1 px-1 py-1 text-[10px] border rounded bg-white">
+        <option value="newest">{sortByNewestLabel}</option>
+        <option value="oldest">{sortByOldestLabel}</option>
+        {expertFeatures.rarity && (
+          <option value="rarity">{sortByRarityLabel}</option>
+        )}
+        <option value="usage">{sortByUsageLabel}</option>
+        <option value="color">{sortByColorLabel}</option>
+      </select>
+    </div>
+  )
+}
+
+interface CategoryFilterButtonProps {
+  cat: { id: string; name: string; iconUrl?: string; iconEmoji?: string }
+  isSelected: boolean
+  onClick: () => void
+}
+
+export function CategoryFilterButton({
+  cat,
+  isSelected,
+  onClick
+}: CategoryFilterButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex items-center gap-1 flex-shrink-0 px-2.5 py-1 rounded-full text-[10px] font-bold transition-all border ${
+        isSelected
+          ? "bg-blue-600 border-blue-600 text-white shadow-sm"
+          : "bg-white border-slate-200 text-slate-600 hover:border-slate-300"
+      }`}>
+      {cat.iconUrl ? (
+        <img
+          src={cat.iconUrl}
+          className="w-3.5 h-3.5 rounded-full object-cover border border-white/20"
+          alt={cat.name}
+        />
+      ) : (
+        <span className="text-[11px] leading-none">
+          {cat.iconEmoji || "🖼️"}
+        </span>
+      )}
+      <span>{cat.name}</span>
+    </button>
+  )
+}
+
+interface CategoryFiltersRowProps {
+  categoryFilter: string
+  setCategoryFilter: (category: string) => void
+  categories: Array<{
+    id: string
+    name: string
+    iconUrl?: string
+    iconEmoji?: string
+  }>
+  setIsCategoryModalOpen: (open: boolean) => void
+  allCategoriesLabel: string
+  manageCategoriesTitle: string
+}
+
+export function CategoryFiltersRow(props: CategoryFiltersRowProps) {
+  return (
+    <div className="flex items-center gap-1.5 overflow-x-auto pb-1 mt-0.5 scrollbar-none">
+      <button
+        onClick={() => props.setCategoryFilter("All")}
+        className={`flex-shrink-0 px-2.5 py-1 rounded-full text-[10px] font-bold transition-all border ${
+          props.categoryFilter === "All"
+            ? "bg-slate-800 border-slate-800 text-white shadow-sm"
+            : "bg-white border-slate-200 text-slate-600 hover:border-slate-300"
+        }`}>
+        {props.allCategoriesLabel}
+      </button>
+      {props.categories.map((cat) => (
+        <CategoryFilterButton
+          key={cat.id}
+          cat={cat}
+          isSelected={props.categoryFilter === cat.id}
+          onClick={() => props.setCategoryFilter(cat.id)}
+        />
+      ))}
+      <button
+        onClick={() => props.setIsCategoryModalOpen(true)}
+        className="flex items-center justify-center w-6 h-6 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-500 hover:text-slate-800 border border-dashed border-slate-300 transition-colors flex-shrink-0"
+        title={props.manageCategoriesTitle}>
+        <Tag className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  )
+}
+
+export function LibraryFilterAccordion(props: LibraryFilterAccordionProps) {
+  const { isFiltersExpanded, expertFeatures } = props
+  return (
+    <div
+      className="transition-all duration-300 ease-in-out overflow-hidden flex flex-col gap-2.5"
+      style={{
+        maxHeight: isFiltersExpanded ? "500px" : "0px",
+        opacity: isFiltersExpanded ? 1 : 0,
+        pointerEvents: isFiltersExpanded ? "auto" : "none",
+        marginTop: isFiltersExpanded ? "4px" : "0px"
+      }}
+      data-testid="filters-accordion">
+      <RaritySortFilters
+        expertFeatures={expertFeatures}
+        rarityFilter={props.rarityFilter}
+        setRarityFilter={props.setRarityFilter}
+        sortBy={props.sortBy}
+        setSortBy={props.setSortBy}
+        allRaritiesLabel={props.allRaritiesLabel || "All Rarities"}
+        sortByNewestLabel={props.sortByNewestLabel || "Newest"}
+        sortByOldestLabel={props.sortByOldestLabel || "Oldest"}
+        sortByRarityLabel={props.sortByRarityLabel || "Rarity"}
+        sortByUsageLabel={props.sortByUsageLabel || "Usage"}
+        sortByColorLabel={props.sortByColorLabel || "Color"}
+      />
+
+      <ColorPaletteFilter
+        colorFilter={props.colorFilter}
+        setColorFilter={props.setColorFilter}
+        colorOptions={props.colorOptions}
+        colorLabel={props.colorLabel}
+        styleCardsCount={props.styleCardsCount}
+      />
+
+      {expertFeatures.categories && (
+        <CategoryFiltersRow
+          categoryFilter={props.categoryFilter}
+          setCategoryFilter={props.setCategoryFilter}
+          categories={props.categories}
+          setIsCategoryModalOpen={props.setIsCategoryModalOpen}
+          allCategoriesLabel={props.allCategoriesLabel || "All"}
+          manageCategoriesTitle={
+            props.manageCategoriesTitle || "Manage Categories"
+          }
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/organisms/LibraryTab.tsx
+++ b/src/components/organisms/LibraryTab.tsx
@@ -1,5 +1,11 @@
-import { BookUp2, ChevronDown, Search, Tag } from "lucide-react"
-import React, { useCallback, useEffect, useRef, useState } from "react"
+import {
+  BookUp2,
+  ChevronDown,
+  Search,
+  SlidersHorizontal,
+  Tag
+} from "lucide-react"
+import React, { useState } from "react"
 
 import { useLanguage } from "../../contexts/LanguageContext"
 import { useSettings } from "../../contexts/SettingsContext"
@@ -12,6 +18,7 @@ import { CardThumbnail } from "../molecules/CardThumbnail"
 import { ConnectionAlert, type AlertType } from "../molecules/ConnectionAlert"
 import { SearchField } from "../molecules/SearchField"
 import { CategoryManagerModal } from "./CategoryManagerModal"
+import { LibraryFilterAccordion } from "./LibraryFilterAccordion"
 import { ShareCardModal } from "./ShareCardModal"
 
 interface LibraryTabProps {
@@ -33,6 +40,7 @@ export function LibraryTab({
 }: LibraryTabProps) {
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false)
   const [sharingCard, setSharingCard] = useState<StyleCard | null>(null)
+  const [isFiltersExpanded, setIsFiltersExpanded] = useState(false)
   const { advanceIfStep } = useTutorial()
 
   const { expertFeatures } = useSettings()
@@ -60,54 +68,12 @@ export function LibraryTab({
     loadMore
   } = useLibrary(addLog, setAlertType, onNavigateToWorkbench)
 
-  const colorScrollRef = useRef<HTMLDivElement>(null)
-  const [showLeftArrow, setShowLeftArrow] = useState(false)
-  const [showRightArrow, setShowRightArrow] = useState(false)
-
-  const checkScroll = useCallback(() => {
-    const el = colorScrollRef.current
-    if (el) {
-      const { scrollLeft, scrollWidth, clientWidth } = el
-      setShowLeftArrow(scrollLeft > 1)
-      setShowRightArrow(scrollLeft < scrollWidth - clientWidth - 1)
-    }
-  }, [])
-
-  useEffect(() => {
-    const el = colorScrollRef.current
-    if (el) {
-      checkScroll()
-      el.addEventListener("scroll", checkScroll)
-      window.addEventListener("resize", checkScroll)
-
-      const timer = setTimeout(checkScroll, 100)
-
-      let resizeObserver: ResizeObserver | null = null
-      if (typeof ResizeObserver !== "undefined") {
-        resizeObserver = new ResizeObserver(() => {
-          checkScroll()
-        })
-        resizeObserver.observe(el)
-      }
-
-      return () => {
-        el.removeEventListener("scroll", checkScroll)
-        window.removeEventListener("resize", checkScroll)
-        clearTimeout(timer)
-        if (resizeObserver) {
-          resizeObserver.disconnect()
-        }
-      }
-    }
-  }, [checkScroll, styleCards])
-
-  const scrollColors = (direction: "left" | "right") => {
-    const el = colorScrollRef.current
-    if (el) {
-      const scrollAmount = direction === "left" ? -100 : 100
-      el.scrollBy({ left: scrollAmount, behavior: "smooth" })
-    }
-  }
+  const activeFiltersCount = [
+    rarityFilter !== "All",
+    categoryFilter !== "All",
+    colorFilter !== "All",
+    sortBy !== "newest"
+  ].filter(Boolean).length
 
   const colorOptions = [
     {
@@ -132,158 +98,72 @@ export function LibraryTab({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2 bg-slate-50 p-2 rounded-lg border border-slate-200">
-        <SearchField
-          placeholder={t.searchPlaceholder || "Search by tag, name or sref..."}
-          options={allSrefs}
-          value={searchTag}
-          onChange={(e) => setSearchTag(e.target.value)}
-          className="text-xs"
-        />
-        <div className="flex gap-2">
-          {expertFeatures.rarity && (
-            <select
-              value={rarityFilter}
-              onChange={(e) => setRarityFilter(e.target.value as any)}
-              className="flex-1 px-1 py-1 text-[10px] border rounded bg-white">
-              <option value="All">{t.allRarities || "All Rarities"}</option>
-              <option value="Common">Common</option>
-              <option value="Rare">Rare</option>
-              <option value="Epic">Epic</option>
-              <option value="Legendary">Legendary</option>
-            </select>
-          )}
-          <select
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as any)}
-            className="flex-1 px-1 py-1 text-[10px] border rounded bg-white">
-            <option value="newest">{t.sortBy?.newest || "Newest"}</option>
-            <option value="oldest">{t.sortBy?.oldest || "Oldest"}</option>
-            {expertFeatures.rarity && (
-              <option value="rarity">{t.sortBy?.rarity || "Rarity"}</option>
-            )}
-            <option value="usage">{t.sortBy?.usage || "Usage"}</option>
-            <option value="color">{t.sortBy?.color || "Color"}</option>
-          </select>
-        </div>
-
-        {/* Color Palette Filter */}
-        <div className="flex gap-1 items-center mt-1.5 select-none w-full">
-          <span className="text-[9px] text-slate-400 font-bold mr-1 flex-shrink-0">
-            {t.colorLabel || "Color:"}
-          </span>
-          <div className="relative flex-1 flex items-center min-w-0">
-            {showLeftArrow && (
-              <button
-                onClick={() => scrollColors("left")}
-                className="absolute left-0 z-10 w-4 h-4 bg-white/95 text-slate-700 hover:text-slate-900 rounded-full flex items-center justify-center border border-slate-200 shadow hover:bg-slate-50 transition-colors text-[9px] font-bold"
-                aria-label="Scroll left">
-                ‹
-              </button>
-            )}
-            <div
-              ref={colorScrollRef}
-              data-testid="color-scroll-container"
-              className="flex gap-1 items-center overflow-x-auto pb-1 scrollbar-none w-full"
-              style={{
-                maskImage: `linear-gradient(to right, ${
-                  showLeftArrow ? "transparent" : "white"
-                } 0%, white 12px, white calc(100% - 12px), ${
-                  showRightArrow ? "transparent" : "white"
-                } 100%)`,
-                WebkitMaskImage: `linear-gradient(to right, ${
-                  showLeftArrow ? "transparent" : "white"
-                } 0%, white 12px, white calc(100% - 12px), ${
-                  showRightArrow ? "transparent" : "white"
-                } 100%)`
-              }}>
-              {colorOptions.map((colorOpt) => {
-                const isSelected = colorFilter === colorOpt.value
-                return (
-                  <button
-                    key={colorOpt.value}
-                    onClick={() => setColorFilter(colorOpt.value as any)}
-                    className={`w-3.5 h-3.5 rounded-full flex-shrink-0 transition-all border relative ${
-                      isSelected
-                        ? "scale-110 ring-1.5 ring-blue-500 ring-offset-0.5"
-                        : "hover:scale-105"
-                    }`}
-                    style={{
-                      background: colorOpt.bg,
-                      borderColor:
-                        colorOpt.value === "White" ? "#cbd5e1" : "transparent"
-                    }}
-                    title={colorOpt.label}>
-                    {isSelected && (
-                      <span
-                        className={`absolute inset-0 flex items-center justify-center text-[7px] font-black ${
-                          colorOpt.value === "White" ||
-                          colorOpt.value === "Yellow"
-                            ? "text-slate-800"
-                            : "text-white"
-                        }`}>
-                        ✓
-                      </span>
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-            {showRightArrow && (
-              <button
-                onClick={() => scrollColors("right")}
-                className="absolute right-0 z-10 w-4 h-4 bg-white/95 text-slate-700 hover:text-slate-900 rounded-full flex items-center justify-center border border-slate-200 shadow hover:bg-slate-50 transition-colors text-[9px] font-bold"
-                aria-label="Scroll right">
-                ›
-              </button>
-            )}
+        <div className="flex gap-2 items-center">
+          <div className="flex-1 min-w-0">
+            <SearchField
+              placeholder={
+                t.searchPlaceholder || "Search by tag, name or sref..."
+              }
+              options={allSrefs}
+              value={searchTag}
+              onChange={(e) => setSearchTag(e.target.value)}
+              className="text-xs"
+            />
           </div>
+          <button
+            onClick={() => setIsFiltersExpanded(!isFiltersExpanded)}
+            className={`flex items-center gap-1 px-2.5 py-1.5 text-xs font-bold rounded-lg border transition-all duration-200 cursor-pointer ${
+              isFiltersExpanded || activeFiltersCount > 0
+                ? "bg-indigo-50 border-indigo-200 text-indigo-700 hover:bg-indigo-100"
+                : "bg-white border-slate-200 text-slate-600 hover:bg-slate-50"
+            }`}
+            title="Toggle filters"
+            id="toggle-filters-btn"
+            data-testid="toggle-filters-btn">
+            <SlidersHorizontal className="w-3.5 h-3.5" />
+            <span className="hidden sm:inline">
+              {t.filtersToggleLabel || "Filters"}
+            </span>
+            {activeFiltersCount > 0 && (
+              <span className="flex items-center justify-center min-w-4 h-4 px-1 text-[9px] font-extrabold text-white bg-indigo-600 rounded-full">
+                {activeFiltersCount}
+              </span>
+            )}
+            <ChevronDown
+              className={`w-3 h-3 transition-transform duration-200 ${
+                isFiltersExpanded ? "rotate-180" : ""
+              }`}
+            />
+          </button>
         </div>
-      </div>
 
-      {/* Category Horizontal Filter Row */}
-      {expertFeatures.categories && (
-        <div className="flex items-center gap-1.5 overflow-x-auto pb-1 scrollbar-none">
-          <button
-            onClick={() => setCategoryFilter("All")}
-            className={`flex-shrink-0 px-2.5 py-1 rounded-full text-[10px] font-bold transition-all border ${
-              categoryFilter === "All"
-                ? "bg-slate-800 border-slate-800 text-white shadow-sm"
-                : "bg-white border-slate-200 text-slate-600 hover:border-slate-300"
-            }`}>
-            {t.allCategories || "All"}
-          </button>
-          {categories.map((cat) => (
-            <button
-              key={cat.id}
-              onClick={() => setCategoryFilter(cat.id)}
-              className={`flex items-center gap-1 flex-shrink-0 px-2.5 py-1 rounded-full text-[10px] font-bold transition-all border ${
-                categoryFilter === cat.id
-                  ? "bg-blue-600 border-blue-600 text-white shadow-sm"
-                  : "bg-white border-slate-200 text-slate-600 hover:border-slate-300"
-              }`}>
-              {cat.iconUrl ? (
-                <img
-                  src={cat.iconUrl}
-                  className="w-3.5 h-3.5 rounded-full object-cover border border-white/20"
-                  alt={cat.name}
-                />
-              ) : (
-                <span className="text-[11px] leading-none">
-                  {cat.iconEmoji || "🖼️"}
-                </span>
-              )}
-              <span>{cat.name}</span>
-            </button>
-          ))}
-          {/* Manage categories button */}
-          <button
-            onClick={() => setIsCategoryModalOpen(true)}
-            className="flex items-center justify-center w-6 h-6 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-500 hover:text-slate-800 border border-dashed border-slate-300 transition-colors flex-shrink-0"
-            title={t.manageCategories || "Manage Categories"}>
-            <Tag className="w-3.5 h-3.5" />
-          </button>
-        </div>
-      )}
+        {/* Collapsible Accordion Container */}
+        <LibraryFilterAccordion
+          isFiltersExpanded={isFiltersExpanded}
+          expertFeatures={expertFeatures}
+          rarityFilter={rarityFilter}
+          setRarityFilter={setRarityFilter}
+          sortBy={sortBy}
+          setSortBy={setSortBy}
+          colorFilter={colorFilter}
+          setColorFilter={setColorFilter}
+          colorOptions={colorOptions}
+          colorLabel={t.colorLabel}
+          styleCardsCount={styleCards?.length || 0}
+          categoryFilter={categoryFilter}
+          setCategoryFilter={setCategoryFilter}
+          categories={categories}
+          setIsCategoryModalOpen={setIsCategoryModalOpen}
+          allCategoriesLabel={t.allCategories}
+          manageCategoriesTitle={t.manageCategories}
+          allRaritiesLabel={t.allRarities}
+          sortByNewestLabel={t.sortBy?.newest}
+          sortByOldestLabel={t.sortBy?.oldest}
+          sortByRarityLabel={t.sortBy?.rarity}
+          sortByUsageLabel={t.sortBy?.usage}
+          sortByColorLabel={t.sortBy?.color}
+        />
+      </div>
 
       {styleCards !== undefined && styleCards.length > 0 ? (
         <>
@@ -393,6 +273,7 @@ export function LibraryTab({
                   setSearchTag("")
                   setRarityFilter("All")
                   setCategoryFilter("All")
+                  setColorFilter("All")
                 }}
                 className="px-3 py-1.5 text-xs font-bold bg-indigo-600 hover:bg-indigo-700 text-white rounded-md transition-colors shadow-sm">
                 {t.clearFilters}

--- a/tests/e2e/categories.spec.ts
+++ b/tests/e2e/categories.spec.ts
@@ -55,6 +55,14 @@ test.describe("Style Atelier Sandbox E2E Tests - Custom Categories @J-ORG-EXPERT
       await libraryTabButton.click()
       await page.waitForTimeout(1000) // Wait for Dexie queries to load style cards and categories
 
+      // Expand filters accordion
+      const filterToggleBtn = spFrame
+        .locator("[data-testid='toggle-filters-btn']")
+        .first()
+      await expect(filterToggleBtn).toBeVisible({ timeout: 10000 })
+      await filterToggleBtn.click()
+      await page.waitForTimeout(500)
+
       // 3. タグボタン（Manage Categories）をクリックしてモーダルを開く
       console.log("4. Opening category modal...")
       const addCategoryBtn = spFrame.locator(
@@ -205,6 +213,14 @@ test.describe("Style Atelier Sandbox E2E Tests - Custom Categories @J-ORG-EXPERT
       await expect(libraryTabButton).toBeVisible({ timeout: 15000 })
       await libraryTabButton.click()
       await page.waitForTimeout(1000)
+
+      // Expand filters accordion
+      const filterToggleBtn = spFrame
+        .locator("[data-testid='toggle-filters-btn']")
+        .first()
+      await expect(filterToggleBtn).toBeVisible({ timeout: 10000 })
+      await filterToggleBtn.click()
+      await page.waitForTimeout(500)
 
       // Open Category Modal
       console.log("4. Opening category modal...")

--- a/tests/e2e/color-filter-scroll.spec.ts
+++ b/tests/e2e/color-filter-scroll.spec.ts
@@ -35,6 +35,14 @@ test.describe("Style Atelier Sandbox E2E Tests - Color Filter Scroll Affordance 
     await libraryTabBtn.click()
     await page.waitForTimeout(500)
 
+    // Expand filters accordion
+    const filterToggleBtn = spFrame
+      .locator("[data-testid='toggle-filters-btn']")
+      .first()
+    await expect(filterToggleBtn).toBeVisible({ timeout: 10000 })
+    await filterToggleBtn.click()
+    await page.waitForTimeout(500)
+
     // 2. Clear database and seed custom test cards with different dominant colors
     await spFrame.locator("body").evaluate(async () => {
       const database = (window as any).db

--- a/tests/e2e/library-search-scroll.spec.ts
+++ b/tests/e2e/library-search-scroll.spec.ts
@@ -140,4 +140,133 @@ test.describe("Style Atelier Sandbox E2E Tests - Library Search & Scroll @J-ORG-
       "All Library Search and Scroll E2E tests completed successfully!"
     )
   })
+
+  test("should support collapsible filters accordion and reset color filter", async ({
+    page
+  }) => {
+    test.setTimeout(60000)
+    const screenshotsDir = path.join(__dirname, "../../tests/screenshots")
+
+    console.log("Navigating to sandbox page...")
+    await page.goto("/tests/sandbox/index.html")
+
+    const spFrame = page.frameLocator("#sidepanel-frame")
+
+    // Skip onboarding
+    const skipButton = spFrame.locator("#welcome-skip-btn")
+    if (await skipButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await skipButton.click()
+    }
+
+    // Switch to Library tab
+    console.log("Switching to Library tab...")
+    const libraryTabButton = spFrame.locator("button:has-text('Library')")
+    await expect(libraryTabButton).toBeVisible()
+    await libraryTabButton.click()
+
+    // Accordion should be collapsed by default
+    const accordion = spFrame.locator("[data-testid='filters-accordion']")
+    await expect(accordion).toBeAttached() // locator is in DOM
+
+    // Check style of accordion (should have maxHeight 0px or opacity 0)
+    const initialStyle = await accordion.getAttribute("style")
+    expect(initialStyle).toContain("max-height: 0px")
+    expect(initialStyle).toContain("opacity: 0")
+
+    // Click toggle button to expand
+    console.log("Expanding filters accordion...")
+    const toggleButton = spFrame.locator("[data-testid='toggle-filters-btn']")
+    await expect(toggleButton).toBeVisible()
+    await toggleButton.click()
+
+    // Wait for transition
+    await page.waitForTimeout(500)
+
+    const expandedStyle = await accordion.getAttribute("style")
+    expect(expandedStyle).toContain("max-height: 500px")
+    expect(expandedStyle).toContain("opacity: 1")
+
+    // Take screenshot of expanded filters
+    await page.screenshot({
+      path: path.join(screenshotsDir, "library-filters-expanded.png")
+    })
+
+    // Click toggle button to collapse again
+    console.log("Collapsing filters accordion...")
+    await toggleButton.click()
+    await page.waitForTimeout(500)
+
+    const collapsedStyle = await accordion.getAttribute("style")
+    expect(collapsedStyle).toContain("max-height: 0px")
+    expect(collapsedStyle).toContain("opacity: 0")
+
+    // Test Clear Filters with Color resetting
+    // 1. Seed a mock card to search and make search result empty
+    console.log("Seeding a single mock card...")
+    await spFrame.locator("body").evaluate(async () => {
+      const database = (window as any).db
+      if (!database) {
+        throw new Error("db is undefined")
+      }
+      await database.styleCards.clear()
+      await database.styleCards.add({
+        id: "mock-card-reset",
+        name: "Reset Test Card",
+        tags: ["blue-theme"],
+        tier: "Common",
+        category: "All",
+        dominantColor: "#3b82f6", // Blue
+        parameters: { sref: ["sref-url-reset"] },
+        promptSegments: [{ type: "text", value: "prompt reset" }],
+        createdAt: Date.now(),
+        isPinned: false,
+        usageCount: 0,
+        isVariable: false,
+        isDeleted: 0,
+        masking: {},
+        thumbnailData:
+          "data:image/svg+xml;utf8,<svg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='%23ccc'/></svg>"
+      })
+    })
+
+    await page.waitForTimeout(1000)
+
+    // Expand accordion to access color filter
+    await toggleButton.click()
+    await page.waitForTimeout(300)
+
+    // Apply Red color filter (it won't match our Blue card)
+    const redColorButton = spFrame.locator("button[title='Red']")
+    await expect(redColorButton).toBeVisible()
+    await redColorButton.evaluate((el) => (el as HTMLButtonElement).click())
+    await page.waitForTimeout(500)
+
+    // Grid should be empty
+    const allCardsInGrid = spFrame.locator(
+      "[data-tutorial='library-card-grid'] > div"
+    )
+    await expect(allCardsInGrid).toHaveCount(0)
+
+    // "Clear Filters" button should be visible
+    const clearFiltersBtn = spFrame.locator("button:has-text('Clear Filters')")
+    await expect(clearFiltersBtn).toBeVisible()
+
+    // Take screenshot before resetting
+    await page.screenshot({
+      path: path.join(screenshotsDir, "library-before-clear-filters.png")
+    })
+
+    // Click Clear Filters
+    console.log("Clicking Clear Filters...")
+    await clearFiltersBtn.click()
+    await page.waitForTimeout(1000)
+
+    // Card should be visible again (means color filter is reset to All)
+    await expect(allCardsInGrid).toHaveCount(1)
+
+    // Take screenshot after resetting
+    await page.screenshot({
+      path: path.join(screenshotsDir, "library-after-clear-filters.png")
+    })
+  })
 })


### PR DESCRIPTION
This PR resolves #472.

### Changes
- Implemented a collapsible accordion UI for detailed filters in `LibraryTab`.
  - Toggle button with icon and dynamic active filter count badge.
  - Smooth height transition and fade animations.
  - Extracted color palette and collapsible filters into modular subcomponents to keep cognitive complexity low and maintain strict 50-line function length limits:
    - `ColorPaletteFilter`
    - `LibraryFilterAccordion`
- Fixed a bug where "Clear Filters" did not correctly reset the color filter selection to "All".
- Added Playwright E2E tests in `tests/e2e/library-search-scroll.spec.ts` verifying accordion toggle states and filter reset behavior, capturing verification screenshots.

### Screenshots (E2E Verification)

| Expanded Filter Accordion |
|---|
| ![library-filters-expanded.png](https://github.com/user-attachments/assets/fd6b9fa9-c1d2-46c6-b34f-63ccb1d395c5) |

| Filter Reset (Before) | Filter Reset (After "Clear Filters") |
|---|---|
| ![library-before-clear-filters.png](https://github.com/user-attachments/assets/02c04674-9dfe-4121-8e29-b90f34b01562) | ![library-after-clear-filters.png](https://github.com/user-attachments/assets/f19aac3e-dbfe-439e-8884-536c89684ea8) |
