### PR TITLE
feat(i18n): install eslint-plugin-i18next and enforce no-literal-string rule for localized components (#455)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,8 @@ import reactHooks from "eslint-plugin-react-hooks";
 import sonarjs from "eslint-plugin-sonarjs";
 import boundaries from "eslint-plugin-boundaries";
 import importPlugin from "eslint-plugin-import";
+import i18next from "eslint-plugin-i18next";
+
 
 export default ts.config(
   {
@@ -21,6 +23,7 @@ export default ts.config(
       sonarjs,
       boundaries,
       import: importPlugin,
+      i18next,
     },
     languageOptions: {
       parserOptions: {
@@ -238,6 +241,48 @@ export default ts.config(
     ],
     rules: {
       "max-lines-per-function": "warn"
+    }
+  },
+  // 4. Enforce i18n literal checks for fully-translated files
+  {
+    files: [
+      "src/components/molecules/DeleteConfirmModal.tsx",
+      "src/components/organisms/HistoryTab.tsx"
+    ],
+    rules: {
+      "i18next/no-literal-string": [
+        "error",
+        {
+          mode: "jsx-only",
+          "jsx-attributes": {
+            exclude: [
+              "className",
+              "styleName",
+              "style",
+              "type",
+              "key",
+              "id",
+              "width",
+              "height",
+              "variant",
+              "size",
+              "target",
+              "rel",
+              "href",
+              "data-testid",
+              "data-tutorial"
+            ]
+          },
+          words: {
+            exclude: [
+              "[0-9!-/:-@[-`{-~]+",
+              "[A-Z_-]+",
+              "^[0-9]+(px|rem|em|%|ms|s|deg)$",
+              "^[\\p{Emoji}\\p{Extended_Pictographic}\\s]+$"
+            ]
+          }
+        }
+      ]
     }
   },
   // Overrides for test files to ease complexity and architecture rules

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -110,4 +110,5 @@ To maintain clean architecture and prevent technical debt, the following strict 
 4. **Automated Enforcement via ESLint**:
    - `eslint.config.mjs` strictly enforces rules as `error` by default (including `max-lines: 300`, `max-lines-per-function: 50`, `sonarjs/cognitive-complexity: 15`, and `boundaries/dependencies` prohibiting direct DB imports from components).
    - A whitelist of pre-existing violating files is explicitly maintained in the `eslint.config.mjs` overrides, treating them as `warn` only. Any new files are fully subject to errors.
+   - Progressive localization (i18n) checks are enforced via `eslint-plugin-i18next`'s `no-literal-string` rule, targeting fully-translated files (e.g. `DeleteConfirmModal.tsx`, `HistoryTab.tsx`) to prevent future raw text/translation leaks.
    - The helper script `scratch/auto-sync-eslint.js` dynamically compiles and synchronizes these whitelists. As developers refactor legacy files, executing this script automatically removes them from exceptions, permanently locking in the strict rules.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -14,7 +14,7 @@ tags: []
 
 ## Key Libraries
 
-- **Localization (i18n)**: `i18next` & `react-i18next` - Type-safe multi-language dictionaries (`en` / `ja`).
+- **Localization (i18n)**: `i18next` & `react-i18next` - Type-safe multi-language dictionaries (`en` / `ja`). `eslint-plugin-i18next` is used as a devDependency to enforce static i18n checks.
 - **Image Processing**: Canvas API (Native) / [satori](https://github.com/vercel/satori) (for card layout generation).
 - **Metadata/Exif**: `piexifjs` - For embedding/extracting JSON in images.
 - **QR Codes**: `jsQR` - For scanning/generating QR codes on cards.
@@ -48,4 +48,4 @@ tags: []
   - Incremental execution mode is enabled (`"incremental": true`), saving change states to `reports/stryker-incremental.json`.
   - Static mutants are ignored (`"ignoreStatic": true`) to eliminate dry-run/initialization overhead.
   - Concurrency is optimized (`"concurrency": 4`) to leverage multiple CPU cores without overloading memory.
-- **Linter Rule Testing**: A dedicated unit test `src/eslint-config.test.ts` validates that the ESLint configuration enforces the strict defaults, maintains specific whitelists for pre-existing files, and ensures that test files are properly exempted. This prevents configuration regressions that could weaken codebase constraints.
+- **Linter Rule Testing**: A dedicated unit test `src/eslint-config.test.ts` validates that the ESLint configuration enforces the strict defaults, maintains specific whitelists for pre-existing files, verifies that i18n literal rules (`eslint-plugin-i18next`) are enforced on fully-translated files, and ensures that test files are properly exempted. This prevents configuration regressions that could weaken codebase constraints.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ml-style-atelier",
       "version": "0.2.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@tanstack/query-async-storage-persister": "^5.101.0",
         "@tanstack/react-query": "^5.101.0",
@@ -51,6 +52,7 @@
         "eslint": "^10.4.1",
         "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-boundaries": "^6.0.2",
+        "eslint-plugin-i18next": "^6.1.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -10977,6 +10979,20 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/eslint-plugin-i18next": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18next/-/eslint-plugin-i18next-6.1.4.tgz",
+      "integrity": "sha512-BekXQu1VaVFkREepQGsntBYoKuPsf89V16n/s2xpKMtsw0/lDseds1wBhj3RtO1dKnHsfTPaG+xul1vF0R7LEQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "requireindex": "~1.1.0"
+      },
+      "engines": {
+        "node": ">=18.10.0"
+      }
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
@@ -14230,6 +14246,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.groupby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
@@ -16417,6 +16440,16 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.5"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.12",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint": "^10.4.1",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-boundaries": "^6.0.2",
+    "eslint-plugin-i18next": "^6.1.4",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/src/eslint-config.test.ts
+++ b/src/eslint-config.test.ts
@@ -71,4 +71,21 @@ describe("ESLint Configuration", () => {
     expect(testConfig.rules["sonarjs/cognitive-complexity"]).toBe("off")
     expect(testConfig.rules["boundaries/dependencies"]).toBe("off")
   })
+
+  it("should enforce i18n literal checks for fully-translated files", () => {
+    const i18nConfig = eslintConfig.find(
+      (cfg: any) =>
+        cfg.files &&
+        cfg.files.includes("src/components/molecules/DeleteConfirmModal.tsx")
+    )
+    expect(i18nConfig).toBeDefined()
+    expect(i18nConfig.rules["i18next/no-literal-string"]).toBeDefined()
+
+    const [severity, options] = i18nConfig.rules["i18next/no-literal-string"]
+    expect(severity).toBe("error")
+    expect(options.mode).toBe("jsx-only")
+    expect(options["jsx-attributes"].exclude).toContain("className")
+    expect(options["jsx-attributes"].exclude).toContain("variant")
+    expect(options.words.exclude).toContain("[0-9!-/:-@[-`{-~]+")
+  })
 })


### PR DESCRIPTION
Resolves #455