### PR TITLE
feat: Chrome extension metadata i18n support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps
 
+      - name: Build extension for manifest tests
+        run: npm run build
+
       - name: Run E2E tests
         run: npm run test:e2e -- --reporter=html
 

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "extName": {
+    "message": "Style Atelier",
+    "description": "The name of the extension"
+  },
+  "extDescription": {
+    "message": "Style Atelier is a prompt manager for Midjourney.",
+    "description": "The description of the extension"
+  }
+}

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -1,0 +1,10 @@
+{
+  "extName": {
+    "message": "Style Atelier",
+    "description": "The name of the extension"
+  },
+  "extDescription": {
+    "message": "Style AtelierはMidjourney向けのプロンプト管理ツールです。",
+    "description": "The description of the extension"
+  }
+}

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -14,7 +14,7 @@ tags: []
 
 ## Key Libraries
 
-- **Localization (i18n)**: `i18next` & `react-i18next` - Type-safe multi-language dictionaries (`en` / `ja`). `eslint-plugin-i18next` is used as a devDependency to enforce static i18n checks.
+- **Localization (i18n)**: `i18next` & `react-i18next` for UI components - Type-safe multi-language dictionaries (`en` / `ja`). `eslint-plugin-i18next` is used as a devDependency to enforce static i18n checks. Additionally, Chrome extension store metadata (manifest name and description) is localized via Plasmo's native `_locales` directory support (`locales/ja/messages.json` and `locales/en/messages.json` at the project root).
 - **Image Processing**: Canvas API (Native) / [satori](https://github.com/vercel/satori) (for card layout generation).
 - **Metadata/Exif**: `piexifjs` - For embedding/extracting JSON in images.
 - **QR Codes**: `jsQR` - For scanning/generating QR codes on cards.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ml-style-atelier",
-  "displayName": "Style Atelier",
+  "displayName": "__MSG_extName__",
   "version": "0.2.0",
-  "description": "Style Atelier is a prompt manager for midjourney.",
+  "description": "__MSG_extDescription__",
   "author": "tmaeda11235@gmail.com",
   "alias": {
     "jiti": false,
@@ -85,6 +85,9 @@
     "vitest-canvas-mock": "^1.1.4"
   },
   "manifest": {
+    "name": "__MSG_extName__",
+    "description": "__MSG_extDescription__",
+    "default_locale": "ja",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx4tc0SD4KZanpUgJQqG3GHsOoyhbqGaN7heBnOsnb8p4KJDbP1MFfMJ8d8M5XKQsKCs/Tsf2XM/1yXNSOBSlFUoAA4QXLuhk76A6o40720FjrzauyMqTXJY8E/Dp/VtZxwfXMziTROhVeBTGV1Z0CmF7WDc2jQqBt4jaxUqmMU4QRWUyQpx1s6dw4ITX2aRPBybBQBOr1SL64ZQE6B7YUzv8IqvVN04QpFn1TajltePpG4Th0K8/bibcf6RQI3A669ITzw6fb67kVWiOPaPtwWMVRfgwSWvUy7UR2XUhLqmUGQPJuXRPReKRw+nkcfRsbbf/TV33Cz+HEcy0aC3itwIDAQAB",
     "permissions": [
       "activeTab",

--- a/tests/e2e/manifest-i18n.spec.ts
+++ b/tests/e2e/manifest-i18n.spec.ts
@@ -1,0 +1,49 @@
+import fs from "fs"
+import path from "path"
+import { expect, test } from "@playwright/test"
+
+test.describe("Extension Manifest & Locale Files Metadata Verification @J-SYS-04", () => {
+  const prodBuildDir = path.join(__dirname, "../../build/chrome-mv3-prod")
+  const devBuildDir = path.join(__dirname, "../../build/chrome-mv3-dev")
+
+  // Choose the build folder that exists; fallback to dev if prod is not built yet
+  const buildDir = fs.existsSync(prodBuildDir) ? prodBuildDir : devBuildDir
+
+  test("should have default_locale and correctly referenced localized metadata in manifest", async () => {
+    const manifestPath = path.join(buildDir, "manifest.json")
+    expect(fs.existsSync(manifestPath)).toBe(true)
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"))
+
+    // Verify critical metadata keys are mapped to i18n variables
+    expect(manifest.name).toBe("__MSG_extName__")
+    expect(manifest.description).toBe("__MSG_extDescription__")
+    expect(manifest.default_locale).toBe("ja")
+  })
+
+  test("should have valid ja and en locale files with extName and extDescription defined", async () => {
+    const localesDir = path.join(buildDir, "_locales")
+    expect(fs.existsSync(localesDir)).toBe(true)
+
+    const jaMessagesPath = path.join(localesDir, "ja/messages.json")
+    const enMessagesPath = path.join(localesDir, "en/messages.json")
+
+    expect(fs.existsSync(jaMessagesPath)).toBe(true)
+    expect(fs.existsSync(enMessagesPath)).toBe(true)
+
+    const jaMessages = JSON.parse(fs.readFileSync(jaMessagesPath, "utf-8"))
+    const enMessages = JSON.parse(fs.readFileSync(enMessagesPath, "utf-8"))
+
+    // Check Japanese definitions
+    expect(jaMessages.extName).toBeDefined()
+    expect(jaMessages.extName.message).toBe("Style Atelier")
+    expect(jaMessages.extDescription).toBeDefined()
+    expect(jaMessages.extDescription.message).toContain("Midjourney")
+
+    // Check English definitions
+    expect(enMessages.extName).toBeDefined()
+    expect(enMessages.extName.message).toBe("Style Atelier")
+    expect(enMessages.extDescription).toBeDefined()
+    expect(enMessages.extDescription.message).toContain("Midjourney")
+  })
+})


### PR DESCRIPTION
Resolves #519

### 🎯 Overview / Changes
- Introduced localization (i18n) for Chrome extension store metadata (`name`, `description`).
- Created `locales/ja/messages.json` and `locales/en/messages.json` inside the project root directory.
- Configured `package.json` manifest properties to map to i18n keys and added `"default_locale": "ja"`.
- Added Playwright E2E tests in `tests/e2e/manifest-i18n.spec.ts` to assert that the built `manifest.json` and locales files have correct configurations.

### 📸 UX Verification Screenshots (Japanese / English)
![i18n-comprehensive-ja.png](https://github.com/user-attachments/assets/1fbeb7ec-35a4-4584-9ede-1daef298961f)
![i18n-comprehensive-en.png](https://github.com/user-attachments/assets/ce3e197e-7a8f-41d5-85bf-df7c39074e05)
