### PR TITLE
fix: responsive modal overlay background for light/dark mode (#565)

### DIFF
--- a/src/components/molecules/AliasEditModal.tsx
+++ b/src/components/molecules/AliasEditModal.tsx
@@ -231,7 +231,7 @@ export const AliasEditModal: React.FC<AliasEditModalProps> = (props) => {
   } = useAliasEdit(props)
 
   return (
-    <div className="fixed inset-0 bg-slate-900/60 backdrop-blur-sm z-[100] flex items-center justify-center animate-in fade-in duration-200">
+    <div className="fixed inset-0 bg-black/20 dark:bg-slate-900/60 backdrop-blur-sm z-[100] flex items-center justify-center animate-in fade-in duration-200">
       <div className="bg-white border border-slate-200 rounded-xl p-4 w-80 shadow-2xl space-y-4 animate-in zoom-in-95 duration-200 text-slate-700">
         <ModalHeader onClose={onClose} />
         <AliasEditForm

--- a/src/components/molecules/ConfirmationDialog.tsx
+++ b/src/components/molecules/ConfirmationDialog.tsx
@@ -44,7 +44,7 @@ export function ConfirmationDialog({
   return (
     <div
       id="confirmation-dialog-backdrop"
-      className="fixed inset-0 z-[9999] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200"
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/20 dark:bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200"
       onClick={onCancel}>
       <div
         id="confirmation-dialog-container"

--- a/src/components/molecules/DeleteConfirmModal.tsx
+++ b/src/components/molecules/DeleteConfirmModal.tsx
@@ -24,7 +24,7 @@ export function DeleteConfirmModal({
   return (
     <div
       data-testid="delete-confirm-modal"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 backdrop-blur-sm p-4 animate-in fade-in duration-200">
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 dark:bg-slate-950/60 backdrop-blur-sm p-4 animate-in fade-in duration-200">
       <div className="w-full max-w-sm bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl shadow-2xl overflow-hidden p-6 space-y-4 animate-in zoom-in-95 duration-200">
         <div className="flex flex-col items-center gap-3">
           <div className="w-12 h-12 rounded-full bg-red-100 dark:bg-red-950/50 flex items-center justify-center text-red-600 dark:text-red-400">

--- a/src/components/molecules/GDriveSyncStrategyDialog.tsx
+++ b/src/components/molecules/GDriveSyncStrategyDialog.tsx
@@ -134,7 +134,7 @@ export function GDriveSyncStrategyDialog({
   return (
     <div
       id="sync-strategy-dialog-backdrop"
-      className="fixed inset-0 z-[9999] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200"
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/20 dark:bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200"
       onClick={onCancel}>
       <div
         id="sync-strategy-dialog-container"

--- a/src/components/organisms/CategoryManagerModal.tsx
+++ b/src/components/organisms/CategoryManagerModal.tsx
@@ -69,7 +69,7 @@ export function CategoryManagerModal({
   const parentOptions = categories.filter((c) => !excludedIds.includes(c.id))
 
   return (
-    <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm z-[100] flex flex-col justify-end">
+    <div className="absolute inset-0 bg-black/20 dark:bg-slate-900/60 backdrop-blur-sm z-[100] flex flex-col justify-end">
       {/* Drawer Container */}
       <div className="bg-white rounded-t-xl max-h-[85%] flex flex-col shadow-2xl transition-all duration-300 transform translate-y-0">
         {/* Header */}

--- a/src/components/organisms/EvolutionSuccessModal.tsx
+++ b/src/components/organisms/EvolutionSuccessModal.tsx
@@ -97,7 +97,7 @@ export const EvolutionSuccessModal: React.FC<EvolutionSuccessModalProps> = ({
   const oldConfig = RARITY_CONFIG[oldTier]
 
   return (
-    <div className="fixed inset-0 bg-slate-950/80 backdrop-blur-md flex items-center justify-center z-50 animate-in fade-in duration-300">
+    <div className="fixed inset-0 bg-black/20 dark:bg-slate-950/80 backdrop-blur-md flex items-center justify-center z-50 animate-in fade-in duration-300">
       {/* Dynamic Confetti */}
       <div className="absolute inset-0 pointer-events-none overflow-hidden z-10">
         {confetti.map((piece) => (

--- a/src/components/organisms/ExpertModeView.tsx
+++ b/src/components/organisms/ExpertModeView.tsx
@@ -28,7 +28,7 @@ function WelcomeDialog({
 }) {
   const { t } = useLanguage()
   return (
-    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200">
+    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/20 dark:bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200">
       <div className="w-full max-w-xs bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl overflow-hidden text-slate-200 animate-in zoom-in-95 duration-200">
         <div className="p-5 flex flex-col items-center gap-3">
           <div className="w-14 h-14 rounded-full bg-blue-600/10 border border-blue-500/30 flex items-center justify-center">

--- a/src/components/organisms/HandBar.tsx
+++ b/src/components/organisms/HandBar.tsx
@@ -294,7 +294,7 @@ export function HandBar({
 
       {isMergeOpen &&
         createPortal(
-          <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200">
+          <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/20 dark:bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200">
             <div className="w-full max-w-sm bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl shadow-2xl overflow-hidden text-slate-800 dark:text-slate-200 animate-in zoom-in-95 duration-200 flex flex-col max-h-[85vh]">
               <div className="p-4 bg-slate-50 dark:bg-slate-800/50 border-b dark:border-slate-800 flex items-center justify-between">
                 <h3 className="font-bold text-sm text-slate-800 dark:text-slate-200 flex items-center gap-1.5">

--- a/src/components/organisms/MergeStackModal.tsx
+++ b/src/components/organisms/MergeStackModal.tsx
@@ -95,7 +95,7 @@ export const MergeStackModal: React.FC<MergeStackModalProps> = ({
   const previewUsageCount = (baseCard?.usageCount || 0) + additionalUses
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/20 dark:bg-slate-950/80 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200">
       <div className="w-full max-w-sm bg-white border border-slate-200 rounded-2xl shadow-2xl overflow-hidden text-slate-800 animate-in zoom-in-95 duration-200 flex flex-col max-h-[85vh]">
         <div className="p-4 bg-slate-50 border-b flex items-center justify-between">
           <h3 className="font-bold text-sm text-slate-800 flex items-center gap-1.5">

--- a/src/components/organisms/OnboardingGuide.tsx
+++ b/src/components/organisms/OnboardingGuide.tsx
@@ -195,7 +195,7 @@ export function OnboardingGuide({ isOpen, onClose }: OnboardingGuideProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 font-sans select-none animate-in fade-in duration-200"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 dark:bg-slate-950/80 backdrop-blur-sm p-4 font-sans select-none animate-in fade-in duration-200"
       data-testid="onboarding-modal"
     >
       <div className="w-full max-w-sm max-h-[calc(100vh-2rem)] bg-slate-900 border border-slate-800 rounded-2xl shadow-2xl flex flex-col overflow-hidden text-slate-200 animate-in zoom-in-95 duration-200">

--- a/src/components/organisms/ShareCardModal.tsx
+++ b/src/components/organisms/ShareCardModal.tsx
@@ -93,7 +93,7 @@ export function ShareCardModal({ card, onClose, addLog }: ShareCardModalProps) {
   return (
     <div
       data-testid="share-card-modal-overlay"
-      className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm z-[100] flex flex-col justify-end"
+      className="absolute inset-0 bg-black/20 dark:bg-slate-900/60 backdrop-blur-sm z-[100] flex flex-col justify-end"
       onClick={onClose}>
       {/* Drawer Container */}
       <div

--- a/src/components/organisms/SimpleWorkbenchModal.tsx
+++ b/src/components/organisms/SimpleWorkbenchModal.tsx
@@ -150,7 +150,7 @@ export function SimpleWorkbenchModal({
   }
 
   return (
-    <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm z-[100] flex flex-col justify-end">
+    <div className="absolute inset-0 bg-black/20 dark:bg-slate-900/60 backdrop-blur-sm z-[100] flex flex-col justify-end">
       {/* Drawer Container */}
       <div className="bg-white rounded-t-xl max-h-[90%] flex flex-col shadow-2xl transition-all duration-300 transform translate-y-0">
         {/* Header */}

--- a/tests/e2e/modal-background-theme.spec.ts
+++ b/tests/e2e/modal-background-theme.spec.ts
@@ -1,0 +1,91 @@
+import path from "path"
+import { expect, test } from "@playwright/test"
+
+test.describe("Style Atelier - Modal Background Theme Verification @J-MODAL-01", () => {
+  test("should have light/dark responsive overlay backgrounds in modals", async ({ page }) => {
+    const screenshotsDir = path.join(__dirname, "../../tests/screenshots")
+
+    // Go to sandbox page
+    console.log("Navigating to sandbox page...")
+    await page.goto("/tests/sandbox/index.html")
+
+    const spFrame = page.frameLocator("#sidepanel-frame")
+
+    // 1. Check Welcome dialog overlay in default/light mode
+    console.log("Checking welcome dialog in light mode...")
+    const welcomeOverlay = spFrame.locator("div.fixed.inset-0.z-\\[110\\]")
+    await expect(welcomeOverlay).toBeVisible({ timeout: 10000 })
+
+    // Check overlay class contains bg-black/20 and dark:bg-slate-950/80
+    const className = await welcomeOverlay.getAttribute("class")
+    expect(className).toContain("bg-black/20")
+    expect(className).toContain("dark:bg-slate-950/80")
+
+    // Take a screenshot of the welcome modal in light mode
+    await page.screenshot({
+      path: path.join(screenshotsDir, "modal-light-mode.png")
+    })
+    console.log("Light mode modal screenshot saved.")
+
+    // 2. Skip welcome to switch theme in Settings
+    const skipButton = spFrame.locator("#welcome-skip-btn")
+    await skipButton.click()
+
+    // Open Settings Tab
+    const settingsNavBtn = spFrame.locator("#settings-nav-btn")
+    await expect(settingsNavBtn).toBeVisible()
+    await settingsNavBtn.click()
+
+    // Expand Maintenance section
+    const maintenanceAccordionHeader = spFrame.locator("#settings-accordion-maintenance")
+    await expect(maintenanceAccordionHeader).toBeVisible()
+    await maintenanceAccordionHeader.click()
+    await page.waitForTimeout(300)
+
+    // Click Reset Database button to trigger ConfirmationDialog
+    const resetBtn = spFrame.locator("#reset-db-btn")
+    await expect(resetBtn).toBeVisible()
+    await resetBtn.click()
+
+    // Verify ConfirmationDialog overlay in Light mode
+    const dialogOverlay = spFrame.locator("#confirmation-dialog-backdrop")
+    await expect(dialogOverlay).toBeVisible()
+
+    const dialogClassName = await dialogOverlay.getAttribute("class")
+    expect(dialogClassName).toContain("bg-black/20")
+    expect(dialogClassName).toContain("dark:bg-slate-950/80")
+
+    // Close dialog
+    const cancelBtn = spFrame.locator("#confirm-dialog-cancel-btn")
+    await expect(cancelBtn).toBeVisible()
+    await cancelBtn.click()
+    await expect(dialogOverlay).not.toBeVisible()
+
+    // 3. Switch to Dark Mode via evaluation
+    console.log("Switching to Dark Mode via evaluation...")
+    await spFrame.locator("body").evaluate(() => {
+      document.documentElement.classList.add("dark")
+    })
+
+    // Wait for the UI to apply dark theme
+    await page.waitForTimeout(500)
+
+    // Trigger the ConfirmationDialog again in Dark mode
+    await resetBtn.click()
+    await expect(dialogOverlay).toBeVisible()
+
+    const darkDialogClassName = await dialogOverlay.getAttribute("class")
+    expect(darkDialogClassName).toContain("bg-black/20")
+    expect(darkDialogClassName).toContain("dark:bg-slate-950/80")
+
+    // Take screenshot of dark mode modal
+    await page.screenshot({
+      path: path.join(screenshotsDir, "modal-dark-mode.png")
+    })
+    console.log("Dark mode modal screenshot saved.")
+
+    // Clean up
+    await cancelBtn.click()
+    await expect(dialogOverlay).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
Resolve #565

## Summary of Changes
- Replaced hardcoded dark background overlay classes (`bg-slate-950/80` or `bg-slate-900/60`) with responsive light/dark theme overlay classes (`bg-black/20 dark:bg-slate-950/80` or `bg-black/20 dark:bg-slate-900/60`) in the following modal and dialog components:
  - `AliasEditModal.tsx`
  - `ConfirmationDialog.tsx`
  - `DeleteConfirmModal.tsx`
  - `GDriveSyncStrategyDialog.tsx`
  - `CategoryManagerModal.tsx`
  - `EvolutionSuccessModal.tsx`
  - `ExpertModeView.tsx` (Welcome dialog)
  - `HandBar.tsx` (Merge dialog)
  - `MergeStackModal.tsx`
  - `OnboardingGuide.tsx`
  - `ShareCardModal.tsx`
  - `SimpleWorkbenchModal.tsx`

## E2E Tests Verification
- Added a new E2E test file: `tests/e2e/modal-background-theme.spec.ts`
- Verifies overlay class contains `bg-black/20` and `dark:bg-slate-950/80` responsive colors.
- Takes screenshots in both Light and Dark modes.

## Screenshots
### Light Mode Modal Overlay
![modal-light-mode.png](https://github.com/user-attachments/assets/2af4376e-227a-46ec-87c0-c120dcee8964)

### Dark Mode Modal Overlay
![modal-dark-mode.png](https://github.com/user-attachments/assets/5e31d636-244a-4168-99c7-091b0bfda70b)
