### PR TITLE
feat(i18n): implement multi-language support for AliasEditModal (#534)

### DIFF
--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -53,4 +53,5 @@ tags: []
   - Incremental execution mode is enabled (`"incremental": true`), saving change states to `reports/stryker-incremental.json`.
   - Static mutants are ignored (`"ignoreStatic": true`) to eliminate dry-run/initialization overhead.
   - Concurrency is optimized (`"concurrency": 4`) to leverage multiple CPU cores without overloading memory.
+- **E2E Tests**: [Playwright](https://playwright.dev/) is used for End-to-End browser-level testing (configured in `playwright.config.ts`). E2E tests verify complete user journeys, settings preferences, and localization switches (e.g., in sandbox environments). Screenshots are captured to verify UX changes across English and Japanese locales.
 - **Linter Rule Testing**: A dedicated unit test `src/eslint-config.test.ts` validates that the ESLint configuration enforces the strict defaults, maintains specific whitelists for pre-existing files, verifies that i18n literal rules (`eslint-plugin-i18next`) are enforced on fully-translated files, and ensures that test files are properly exempted. This prevents configuration regressions that could weaken codebase constraints.

--- a/src/components/molecules/AliasEditModal.tsx
+++ b/src/components/molecules/AliasEditModal.tsx
@@ -1,6 +1,7 @@
 import { Edit3, X } from "lucide-react"
 import React, { useState } from "react"
 
+import { useLanguage } from "../../contexts/LanguageContext"
 import type { ParameterAlias, ParameterFolder } from "../../lib/db-schema"
 
 interface AliasEditModalProps {
@@ -20,20 +21,23 @@ interface AliasEditModalProps {
   deleteAlias: (id: string) => Promise<void>
 }
 
-const ModalHeader: React.FC<{ onClose: () => void }> = ({ onClose }) => (
-  <div className="flex justify-between items-center border-b border-slate-100 pb-2">
-    <h4 className="text-xs font-bold text-slate-800 flex items-center gap-1.5">
-      <Edit3 className="w-3.5 h-3.5 text-blue-600" />
-      Edit Parameter Alias
-    </h4>
-    <button
-      onClick={onClose}
-      className="text-slate-400 hover:text-slate-600"
-      type="button">
-      <X className="w-4 h-4" />
-    </button>
-  </div>
-)
+const ModalHeader: React.FC<{ onClose: () => void }> = ({ onClose }) => {
+  const { t } = useLanguage()
+  return (
+    <div className="flex justify-between items-center border-b border-slate-100 pb-2">
+      <h4 className="text-xs font-bold text-slate-800 flex items-center gap-1.5">
+        <Edit3 className="w-3.5 h-3.5 text-blue-600" />
+        {t.aliasEdit.editTitle}
+      </h4>
+      <button
+        onClick={onClose}
+        className="text-slate-400 hover:text-slate-600"
+        type="button">
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}
 
 interface FolderSelectProps {
   folders: ParameterFolder[]
@@ -50,6 +54,7 @@ const FolderSelect: React.FC<FolderSelectProps> = ({
   newFolderNameInput,
   setNewFolderNameInput
 }) => {
+  const { t } = useLanguage()
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedFolderId(e.target.value || undefined)
     if (e.target.value !== "__new__") {
@@ -60,26 +65,26 @@ const FolderSelect: React.FC<FolderSelectProps> = ({
   return (
     <div className="space-y-1">
       <label className="text-[9px] font-bold text-slate-400 uppercase">
-        Folder / Category
+        {t.aliasEdit.folderCategory}
       </label>
       <select
         value={selectedFolderId || ""}
         onChange={handleSelectChange}
         className="w-full text-xs border border-slate-200 rounded p-1.5 bg-white font-semibold">
-        <option value="">(No Folder)</option>
+        <option value="">{t.aliasEdit.noFolder}</option>
         {folders.map((f) => (
           <option key={f.id} value={f.id}>
             {f.name}
           </option>
         ))}
-        <option value="__new__">+ Create New Folder...</option>
+        <option value="__new__">{t.aliasEdit.createNewFolder}</option>
       </select>
       {selectedFolderId === "__new__" && (
         <input
           type="text"
           value={newFolderNameInput}
           onChange={(e) => setNewFolderNameInput(e.target.value)}
-          placeholder="Enter new folder name"
+          placeholder={t.aliasEdit.enterFolderName}
           className="w-full text-xs border border-slate-200 rounded p-1.5 mt-1 focus:outline-none focus:ring-1 focus:ring-blue-500 font-semibold"
         />
       )}
@@ -108,11 +113,12 @@ const AliasEditForm: React.FC<AliasEditFormProps> = ({
   newFolderNameInput,
   setNewFolderNameInput
 }) => {
+  const { t } = useLanguage()
   return (
     <div className="space-y-3">
       <div className="space-y-1">
         <label className="text-[9px] font-bold text-slate-400 uppercase">
-          Parameter Value
+          {t.aliasEdit.parameterValue}
         </label>
         <div className="text-xs font-mono text-slate-600 bg-slate-50 p-1.5 rounded border border-slate-100 truncate">
           {editingValue}
@@ -121,13 +127,13 @@ const AliasEditForm: React.FC<AliasEditFormProps> = ({
 
       <div className="space-y-1">
         <label className="text-[9px] font-bold text-slate-400 uppercase">
-          Alias Name
+          {t.aliasEdit.aliasName}
         </label>
         <input
           type="text"
           value={aliasNameInput}
           onChange={(e) => setAliasNameInput(e.target.value)}
-          placeholder="My Custom Style"
+          placeholder={t.aliasEdit.enterAliasNamePlaceholder}
           className="w-full text-xs border border-slate-200 rounded p-1.5 focus:outline-none focus:ring-1 focus:ring-blue-500 font-semibold"
         />
       </div>
@@ -148,41 +154,31 @@ interface ModalActionsProps {
   onSave: () => void
 }
 
-const ModalActions: React.FC<ModalActionsProps> = ({ onDelete, onSave }) => (
-  <div className="flex justify-end gap-2 pt-2 border-t border-slate-100 text-xs">
-    <button
-      onClick={onDelete}
-      className="px-2.5 py-1.5 text-[10px] font-bold text-red-600 hover:bg-red-50 rounded-md border border-red-100 transition-colors"
-      type="button">
-      Delete
-    </button>
-    <button
-      onClick={onSave}
-      className="px-3 py-1.5 text-[10px] font-bold text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors shadow-sm"
-      type="button">
-      Save
-    </button>
-  </div>
-)
+const ModalActions: React.FC<ModalActionsProps> = ({ onDelete, onSave }) => {
+  const { t } = useLanguage()
+  return (
+    <div className="flex justify-end gap-2 pt-2 border-t border-slate-100 text-xs">
+      <button
+        onClick={onDelete}
+        className="px-2.5 py-1.5 text-[10px] font-bold text-red-600 hover:bg-red-50 rounded-md border border-red-100 transition-colors"
+        type="button">
+        {t.aliasEdit.delete}
+      </button>
+      <button
+        onClick={onSave}
+        className="px-3 py-1.5 text-[10px] font-bold text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors shadow-sm"
+        type="button">
+        {t.aliasEdit.save}
+      </button>
+    </div>
+  )
+}
 
 const useAliasEdit = (props: AliasEditModalProps) => {
-  const {
-    editingValue,
-    typeAliases,
-    addFolder,
-    saveAlias,
-    deleteAlias,
-    onClose,
-    parameterType
-  } = props
+  const { editingValue, typeAliases, addFolder, saveAlias, deleteAlias, onClose, parameterType } = props
   const existing = typeAliases.find((a) => a.value === editingValue)
-
-  const [aliasNameInput, setAliasNameInput] = useState(
-    existing ? existing.alias || (existing as any).name : ""
-  )
-  const [selectedFolderId, setSelectedFolderId] = useState<string | undefined>(
-    existing ? existing.folderId : undefined
-  )
+  const [aliasNameInput, setAliasNameInput] = useState(existing ? existing.alias || (existing as any).name : "")
+  const [selectedFolderId, setSelectedFolderId] = useState<string | undefined>(existing ? existing.folderId : undefined)
   const [newFolderNameInput, setNewFolderNameInput] = useState("")
 
   const handleDelete = async () => {
@@ -206,14 +202,10 @@ const useAliasEdit = (props: AliasEditModalProps) => {
   }
 
   return {
-    aliasNameInput,
-    setAliasNameInput,
-    selectedFolderId,
-    setSelectedFolderId,
-    newFolderNameInput,
-    setNewFolderNameInput,
-    handleDelete,
-    handleSave
+    aliasNameInput, setAliasNameInput,
+    selectedFolderId, setSelectedFolderId,
+    newFolderNameInput, setNewFolderNameInput,
+    handleDelete, handleSave
   }
 }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -516,5 +516,17 @@
     "noInputTitle": "Input Not Found",
     "noInputDesc": "Could not find the chat input. Please ensure you are on the \"Create\" page or the Midjourney gallery details view.",
     "noInputBtn": "Retry Connection"
+  },
+  "aliasEdit": {
+    "editTitle": "Edit Parameter Alias",
+    "folderCategory": "Folder / Category",
+    "parameterValue": "Parameter Value",
+    "aliasName": "Alias Name",
+    "delete": "Delete",
+    "save": "Save",
+    "noFolder": "(No Folder)",
+    "createNewFolder": "+ Create New Folder...",
+    "enterFolderName": "Enter new folder name",
+    "enterAliasNamePlaceholder": "My Custom Style"
   }
 }

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -516,5 +516,17 @@
     "noInputTitle": "入力エリアが見つかりません",
     "noInputDesc": "チャット入力エリアが見つかりませんでした。現在「Create」ページ、またはMidjourneyギャラリーの詳細表示画面を開いていることを確認してください。",
     "noInputBtn": "接続を再試行"
+  },
+  "aliasEdit": {
+    "editTitle": "パラメータエイリアスの編集",
+    "folderCategory": "フォルダ / カテゴリ",
+    "parameterValue": "パラメータ値",
+    "aliasName": "エイリアス名",
+    "delete": "削除",
+    "save": "保存",
+    "noFolder": "(フォルダなし)",
+    "createNewFolder": "+ 新しいフォルダを作成...",
+    "enterFolderName": "新しいフォルダ名を入力",
+    "enterAliasNamePlaceholder": "マイカスタムスタイル"
   }
 }

--- a/tests/e2e/parameter-alias-i18n.spec.ts
+++ b/tests/e2e/parameter-alias-i18n.spec.ts
@@ -1,0 +1,147 @@
+import path from "path"
+import { expect, test } from "@playwright/test"
+
+test.describe("Parameter Alias i18n E2E Tests @J-ORGAN-UX-PARAM-01", () => {
+  test.beforeEach(async ({ page }) => {
+    page.on("console", (msg) => {
+      console.log(`[BROWSER CONSOLE] ${msg.type()}: ${msg.text()}`)
+    })
+    page.on("pageerror", (err) => {
+      console.error(`[BROWSER ERROR] ${err.message}\n${err.stack}`)
+    })
+  })
+
+  test("should show localized Parameter Alias edit modal and take screenshots", async ({
+    page
+  }) => {
+    const screenshotsDir = path.join(__dirname, "../../tests/screenshots")
+    console.log("Navigating to sandbox page...")
+    await page.goto("/tests/sandbox/index.html")
+
+    const spFrame = page.frameLocator("#sidepanel-frame")
+
+    // 1. Skip welcome dialog if visible
+    const skipButton = spFrame.locator("#welcome-skip-btn")
+    if (await skipButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await skipButton.click()
+    }
+
+    // 2. Seed database
+    await spFrame.locator("body").evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const database = (window as any).db
+      for (let i = 0; i < 50; i++) {
+        const count = await database.categories.count()
+        if (count > 0) break
+        await new Promise((r) => setTimeout(r, 100))
+      }
+
+      await database.styleCards.clear()
+      await database.parameterAliases.clear()
+      await database.parameterFolders.clear()
+
+      await database.styleCards.add({
+        id: "style-i18n-1",
+        name: "Neon Forest",
+        promptSegments: [{ type: "text", value: "mystic neon forest" }],
+        parameters: {
+          sref: ["https://example.com/forest.png"]
+        },
+        masking: {},
+        tier: "Rare",
+        dominantColor: "#a855f7",
+        accentColor: "#ec4899",
+        thumbnailData:
+          "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'><rect width='100' height='100' fill='purple'/></svg>",
+        isPinned: false
+      })
+    })
+
+    await page.waitForTimeout(1000)
+
+    // 3. Switch to Settings and set language to English first (just in case)
+    console.log("Setting language to English...")
+    const settingsNavBtn = spFrame.locator("#settings-nav-btn")
+    await expect(settingsNavBtn).toBeVisible()
+    await settingsNavBtn.click()
+    await page.waitForTimeout(500)
+
+    const langSelect = spFrame.locator("#language-select")
+    await expect(langSelect).toBeVisible()
+    await langSelect.selectOption("en")
+    await page.waitForTimeout(500)
+
+    // 4. Navigate to Workbench tab
+    const workbenchTab = spFrame.locator("[data-tutorial='workbench-tab']").first()
+    await expect(workbenchTab).toBeVisible()
+    await workbenchTab.click()
+    await page.waitForTimeout(500)
+
+    // 5. Pin the card (since it was not pinned, we need to Gacha or pin it. Let's Gacha Pick to quickly show it in Workbench)
+    const gachaBtn = spFrame.locator("#workbench-gacha-btn").first()
+    await expect(gachaBtn).toBeVisible()
+    await gachaBtn.click()
+    await page.waitForTimeout(1000)
+
+    // 6. Open alias editing modal (English)
+    const srefEditBtn = spFrame.locator("button[title='Edit alias']").first()
+    await expect(srefEditBtn).toBeVisible()
+    await srefEditBtn.click()
+    await page.waitForTimeout(500)
+
+    // 7. Verify modal headers and labels are in English
+    const modalHeaderEn = spFrame.locator("h4:has-text('Edit Parameter Alias')")
+    await expect(modalHeaderEn).toBeVisible()
+    await expect(spFrame.locator("label:has-text('Folder / Category')")).toBeVisible()
+    await expect(spFrame.locator("label:has-text('Parameter Value')")).toBeVisible()
+    await expect(spFrame.locator("label:has-text('Alias Name')")).toBeVisible()
+    await expect(spFrame.locator("button:has-text('Delete')")).toBeVisible()
+    await expect(spFrame.locator("button:has-text('Save')")).toBeVisible()
+
+    // Take English screenshot
+    await page.screenshot({
+      path: path.join(screenshotsDir, "parameter-alias-modal-en.png")
+    })
+    console.log("English Alias Modal screenshot saved.")
+
+    // Cancel modal via X button
+    const closeBtn = spFrame.locator(".w-80.shadow-2xl button").first()
+    await closeBtn.click()
+    await page.waitForTimeout(1000)
+
+    // 8. Switch to Settings and set language to Japanese (ja)
+    console.log("Setting language to Japanese...")
+    await settingsNavBtn.click()
+    await page.waitForTimeout(500)
+    await langSelect.selectOption("ja")
+    await page.waitForTimeout(500)
+
+    // 9. Go back to Workbench
+    await workbenchTab.click()
+    await page.waitForTimeout(500)
+
+    // 10. Open alias editing modal again (Japanese)
+    await expect(srefEditBtn).toBeVisible()
+    await srefEditBtn.click()
+    await page.waitForTimeout(500)
+
+    // 11. Verify modal headers and labels are in Japanese
+    const modalHeaderJa = spFrame.locator("h4:has-text('パラメータエイリアスの編集')")
+    await expect(modalHeaderJa).toBeVisible()
+    await expect(spFrame.locator("label:has-text('フォルダ / カテゴリ')")).toBeVisible()
+    await expect(spFrame.locator("label:has-text('パラメータ値')")).toBeVisible()
+    await expect(spFrame.locator("label:has-text('エイリアス名')")).toBeVisible()
+    await expect(spFrame.locator("button:has-text('削除')")).toBeVisible()
+    await expect(spFrame.locator("button:has-text('保存')")).toBeVisible()
+
+    // Take Japanese screenshot
+    await page.screenshot({
+      path: path.join(screenshotsDir, "parameter-alias-modal-ja.png")
+    })
+    console.log("Japanese Alias Modal screenshot saved.")
+
+    // Close modal via X button
+    await closeBtn.click()
+    await page.waitForTimeout(1000)
+  })
+})


### PR DESCRIPTION
This PR implements internationalization (i18n) for the AliasEditModal component, resolving #534. E2E tests with Playwright have been added to verify the translation switches between English and Japanese.