### PR TITLE
fix: CI テストジョブのパフォーマンス改善とキャッシュ競合回避 (#637)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ concurrency:
 
 jobs:
   # ---------------------------------------------------
-  # Job 1: ユニットテストとビルド（CPU・メモリ重視）
+  # Job 1: セットアップとキャッシュ作成
   # ---------------------------------------------------
-  unit-and-build:
+  setup:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -30,6 +30,24 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
+  # ---------------------------------------------------
+  # Job 2: ユニットテストとビルド（CPU・メモリ重視）
+  # ---------------------------------------------------
+  unit-and-build:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
       - name: Run lint
         run: npm run lint
 
@@ -40,9 +58,10 @@ jobs:
         run: npm run build
 
   # ---------------------------------------------------
-  # Job 2: E2Eテスト（ネットワーク・プロセッサ分離）
+  # Job 3: E2Eテスト（ネットワーク・プロセッサ分離）
   # ---------------------------------------------------
   e2e-test:
+    needs: unit-and-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/tests/e2e/drag-and-drop.spec.ts
+++ b/tests/e2e/drag-and-drop.spec.ts
@@ -78,7 +78,7 @@ test.describe("Style Atelier Sandbox E2E Tests - Drag and Drop @J-WB-EXPERT-02",
           id: "340ae0f9-c2f0-459c-ad45-95f7249049e8",
           fullCommand:
             "超高層ビルを見上げた景色, 観葉植物, noon, skyscraper --ar 16:9 --sref 2496378872 3886212479 --stylize 200 --profile buibsja",
-          imageUrl: "./index_files/0_0_640_N.webp",
+          imageUrl: "/tests/fixtures/midjourney/index_files/0_0_640_N.webp",
           timestamp: Date.now()
         }
 
@@ -298,7 +298,7 @@ test.describe("Style Atelier Sandbox E2E Tests - Drag and Drop @J-WB-EXPERT-02",
       id: "easy-mode-drop-job-123",
       fullCommand:
         "A peaceful forest with rays of sunlight --ar 16:9 --sref 123456789",
-      imageUrl: "./index_files/0_0_640_N.webp",
+      imageUrl: "/tests/fixtures/midjourney/index_files/0_0_640_N.webp",
       timestamp: Date.now()
     }
 

--- a/tests/e2e/history-scroll.spec.ts
+++ b/tests/e2e/history-scroll.spec.ts
@@ -50,7 +50,7 @@ test.describe("Style Atelier Sandbox E2E Tests - History Scroll @J-SYS-01", () =
       const mockItems = Array.from({ length: 70 }, (_, i) => ({
         id: `mock-history-${i}`,
         fullCommand: `Cyberpunk prompt number ${i} --ar 16:9`,
-        imageUrl: `./index_files/0_0_640_N.webp`,
+        imageUrl: `/tests/fixtures/midjourney/index_files/0_0_640_N.webp`,
         timestamp: Date.now() - i * 1000
       }))
       await database.historyItems.bulkAdd(mockItems)

--- a/tests/e2e/mint-expert.spec.ts
+++ b/tests/e2e/mint-expert.spec.ts
@@ -45,7 +45,7 @@ test.describe("Style Atelier Sandbox E2E Tests - Expert Minting", () => {
         id: "mock-history-item-to-mint-expert",
         fullCommand:
           "a beautiful cyberpunk warrior --ar 16:9 --sref https://example.com/sref1 --p p-code",
-        imageUrl: "./index_files/0_0_640_N.webp",
+        imageUrl: "/tests/fixtures/midjourney/index_files/0_0_640_N.webp",
         timestamp: Date.now()
       })
       await database.categories.clear()

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -4,6 +4,15 @@ import { expect, test } from "@playwright/test"
 
 test.describe("Style Atelier Sandbox E2E Tests - Settings @J-SET-01", () => {
   test.beforeEach(async ({ page }) => {
+    // Mock all Google APIs globally for settings tests to prevent 401 retries
+    await page.route("https://www.googleapis.com/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({})
+      })
+    })
+
     page.on("console", (msg) => {
       console.log(`[BROWSER CONSOLE] ${msg.type()}: ${msg.text()}`)
     })


### PR DESCRIPTION
Resolves #637. 

- E2EテストでのGoogle Drive APIトークンリトライ（401）をグローバルモックで解消。
- 404エラーの原因となっていたテスト用画像パスを修正。
- GitHub Actions の \ci.yml\ を3ジョブ構成（Setup → Unit & Build → E2E Test）の直列実行にリファクタリングし、キャッシュの競合を解消。さらに、Lintエラー等でCIが早期失敗した場合にE2Eテストがムダに走らないように最適化しました。