### PR TITLE
refactor: sync eslint exception whitelist and resolve issue #639

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -153,7 +153,6 @@ export default ts.config(
       "src/placeholder-non-existent-func-lines.ts",
       "src/components/molecules/AssociatedImageGallery.tsx",
       "src/components/molecules/AutocompleteDropdown.tsx",
-      "src/components/molecules/CardThumbnail.tsx",
       "src/components/molecules/ConfirmationDialog.tsx",
       "src/components/molecules/ConnectionAlert.tsx",
       "src/components/molecules/GenealogySection.tsx",


### PR DESCRIPTION
Resolves #639. Synced the ESLint overrides list to remove the now-compliant CardThumbnail.tsx.