### PR TITLE
[Test/Quality] MockStyleAtelierDatabase において Dexie.js Collection の .first() メソッドをサポートするよう改善 (#725)

### DIFF
--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -153,6 +153,7 @@ To maintain clean architecture and prevent technical debt, the following strict 
 2. **Pure Test Mocks**:
    - Mock databases and utility mocks (e.g., in `tests/mocks/`) must remain pure mocks and not contain business logic.
    - Test expectations should verify interactions with the mock rather than replicating real database logic or state transitions inside the mock.
+   - Database mocks (e.g., `MockStyleAtelierDatabase`) should support consistent interface contract simulations (such as Dexie Collection API's `.first()`, `.last()`, `.each()`, `.limit()`, and `.reverse()`) to prevent mock-related exceptions in the tested components.
 3. **File Length Limits**:
    - Component files should not exceed 300 lines of code (excluding comments and blank lines).
    - Functions should be kept under 50 lines.

--- a/tests/mocks/db.ts
+++ b/tests/mocks/db.ts
@@ -8,6 +8,62 @@ import type {
   UserSettings
 } from "../../src/lib/db-schema"
 
+class MockCollection<T> {
+  private items: T[]
+  private onModify?: (modifiedItems: T[]) => Promise<void>
+
+  constructor(items: T[], onModify?: (modifiedItems: T[]) => Promise<void>) {
+    this.items = [...items]
+    this.onModify = onModify
+  }
+
+  toArray = vi.fn().mockImplementation(async () => {
+    return this.items
+  })
+
+  first = vi.fn().mockImplementation(async () => {
+    return this.items[0] || undefined
+  })
+
+  last = vi.fn().mockImplementation(async () => {
+    return this.items[this.items.length - 1] || undefined
+  })
+
+  each = vi.fn().mockImplementation(async (callback: (item: T) => any) => {
+    for (const item of this.items) {
+      await callback(item)
+    }
+  })
+
+  count = vi.fn().mockImplementation(async () => {
+    return this.items.length
+  })
+
+  limit = vi.fn().mockImplementation((n: number) => {
+    this.items = this.items.slice(0, n)
+    return this
+  })
+
+  offset = vi.fn().mockImplementation((n: number) => {
+    this.items = this.items.slice(n)
+    return this
+  })
+
+  reverse = vi.fn().mockImplementation(() => {
+    this.items.reverse()
+    return this
+  })
+
+  modify = vi.fn().mockImplementation(async (modifyFn: (item: any) => void) => {
+    this.items.forEach((item) => {
+      modifyFn(item)
+    })
+    if (this.onModify) {
+      await this.onModify(this.items)
+    }
+  })
+}
+
 class MockTable<T extends { id: string } | any, Key = string> {
   private items: Map<any, T> = new Map()
   hooks: Record<string, any> = {}
@@ -88,18 +144,12 @@ class MockTable<T extends { id: string } | any, Key = string> {
       return valA > valB ? 1 : valA < valB ? -1 : 0
     })
 
-    const chain: any = {
-      reverse: () => {
-        sorted.reverse()
-        return chain
-      },
-      limit: (n: number) => {
-        sorted.splice(n)
-        return chain
-      },
-      toArray: async () => sorted
-    }
-    return chain
+    return new MockCollection(sorted, async (modified) => {
+      modified.forEach((item) => {
+        const key = item.id || item.userId || item.timestamp
+        this.items.set(key, item)
+      })
+    })
   })
 
   bulkPut = vi.fn().mockImplementation(async (items: T[]) => {
@@ -118,9 +168,12 @@ class MockTable<T extends { id: string } | any, Key = string> {
 
   filter = vi.fn().mockImplementation((fn: (item: T) => boolean) => {
     const filtered = Array.from(this.items.values()).filter(fn)
-    return {
-      toArray: async () => filtered
-    }
+    return new MockCollection(filtered, async (modified) => {
+      modified.forEach((item) => {
+        const key = item.id || item.userId || item.timestamp
+        this.items.set(key, item)
+      })
+    })
   })
 
   where = vi.fn().mockImplementation((indexName: string) => {
@@ -129,17 +182,12 @@ class MockTable<T extends { id: string } | any, Key = string> {
         const matched = Array.from(this.items.values()).filter(
           (item: any) => item[indexName] === val
         )
-        return {
-          first: async () => matched[0] || undefined,
-          toArray: async () => matched,
-          modify: async (modifyFn: (item: any) => void) => {
-            matched.forEach((item) => {
-              modifyFn(item)
-              const key = item.id || item.userId || item.timestamp
-              this.items.set(key, item)
-            })
-          }
-        }
+        return new MockCollection(matched, async (modified) => {
+          modified.forEach((item) => {
+            const key = item.id || item.userId || item.timestamp
+            this.items.set(key, item)
+          })
+        })
       }
     }
   })

--- a/tests/unit/mocks/db.test.ts
+++ b/tests/unit/mocks/db.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest"
+
+import { MockStyleAtelierDatabase } from "../../../tests/mocks/db"
+
+describe("MockStyleAtelierDatabase", () => {
+  it("should support basic CRUD operations", async () => {
+    const mockDb = new MockStyleAtelierDatabase()
+    const id = await mockDb.styleCards.add({ id: "card-1", name: "Card 1" })
+    expect(id).toBe("card-1")
+
+    const card = await mockDb.styleCards.get("card-1")
+    expect(card).toEqual({ id: "card-1", name: "Card 1" })
+
+    await mockDb.styleCards.update("card-1", { name: "Updated Card" })
+    const updated = await mockDb.styleCards.get("card-1")
+    expect(updated.name).toBe("Updated Card")
+
+    await mockDb.styleCards.delete("card-1")
+    const deleted = await mockDb.styleCards.get("card-1")
+    expect(deleted).toBeUndefined()
+  })
+
+  it("should support Collection operations through filter()", async () => {
+    const mockDb = new MockStyleAtelierDatabase()
+    await mockDb.styleCards.add({ id: "1", name: "Alice", active: true })
+    await mockDb.styleCards.add({ id: "2", name: "Bob", active: false })
+    await mockDb.styleCards.add({ id: "3", name: "Charlie", active: true })
+
+    const collection = mockDb.styleCards.filter((item: any) => item.active)
+
+    // toArray
+    const arr = await collection.toArray()
+    expect(arr).toHaveLength(2)
+    expect(arr[0].name).toBe("Alice")
+    expect(arr[1].name).toBe("Charlie")
+
+    // count
+    const count = await collection.count()
+    expect(count).toBe(2)
+
+    // first
+    const firstItem = await collection.first()
+    expect(firstItem?.name).toBe("Alice")
+
+    // last
+    const lastItem = await collection.last()
+    expect(lastItem?.name).toBe("Charlie")
+
+    // each
+    const names: string[] = []
+    await collection.each((item: any) => {
+      names.push(item.name)
+    })
+    expect(names).toEqual(["Alice", "Charlie"])
+  })
+
+  it("should support Collection chain methods (limit, offset, reverse, modify)", async () => {
+    const mockDb = new MockStyleAtelierDatabase()
+    await mockDb.styleCards.add({ id: "1", index: 1, val: "A" })
+    await mockDb.styleCards.add({ id: "2", index: 2, val: "B" })
+    await mockDb.styleCards.add({ id: "3", index: 3, val: "C" })
+
+    // orderBy & reverse
+    const orderedDesc = await mockDb.styleCards
+      .orderBy("index")
+      .reverse()
+      .toArray()
+    expect(orderedDesc.map((item: any) => item.val)).toEqual(["C", "B", "A"])
+
+    // orderBy & limit & offset
+    const partial = await mockDb.styleCards
+      .orderBy("index")
+      .offset(1)
+      .limit(1)
+      .toArray()
+    expect(partial.map((item: any) => item.val)).toEqual(["B"])
+
+    // modify
+    await mockDb.styleCards
+      .filter((item: any) => item.index > 1)
+      .modify((item: any) => {
+        item.val = "Modified"
+      })
+
+    const c2 = await mockDb.styleCards.get("2")
+    const c3 = await mockDb.styleCards.get("3")
+    expect(c2.val).toBe("Modified")
+    expect(c3.val).toBe("Modified")
+  })
+
+  it("should support equals and modify in where query", async () => {
+    const mockDb = new MockStyleAtelierDatabase()
+    await mockDb.styleCards.add({ id: "1", type: "type-a", val: "old" })
+    await mockDb.styleCards.add({ id: "2", type: "type-b", val: "old" })
+
+    const res = await mockDb.styleCards.where("type").equals("type-a").first()
+    expect(res?.id).toBe("1")
+
+    await mockDb.styleCards
+      .where("type")
+      .equals("type-a")
+      .modify((item: any) => {
+        item.val = "new"
+      })
+
+    const item1 = await mockDb.styleCards.get("1")
+    const item2 = await mockDb.styleCards.get("2")
+    expect(item1.val).toBe("new")
+    expect(item2.val).toBe("old")
+  })
+})


### PR DESCRIPTION
Closes #725.

### What
This PR addresses issue #725. It introduces \MockCollection\ to simulate Dexie Collection methods (specifically \.first()\, \.last()\, \.each()\, \.limit()\, \.offset()\, \.reverse()\, and \.modify()\) within \	ests/mocks/db.ts\ to ensure consistent interface contract simulations and resolve mock-related warnings during test execution.

### Changes
1. Added \MockCollection\ to simulate Dexie Collection APIs.
2. Refactored \MockTable.filter\, \MockTable.orderBy\, and \MockTable.where\ to return instances of \MockCollection\.
3. Created a new unit test suite in \	ests/unit/mocks/db.test.ts\ to verify correct simulation behavior.
4. Updated systemPatterns.md to clarify database mock contract requirements.

All tests passed successfully.