### PR TITLE
chore(ci): add paths-ignore for marketing strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'memory-bank/marketingStrategy.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
マーケタースキル（act-as-marketer）が memory-bank/marketingStrategy.md を動的に更新する際、余計なCI（テスト・ビルド）がトリガーされないよう paths-ignore を追加しました。