### PR TITLE
test: implement E2E test for @J-ORG-CARD-TOOLTIP-01

### DIFF
--- a/memory-bank/e2e-traceability-matrix.md
+++ b/memory-bank/e2e-traceability-matrix.md
@@ -41,11 +41,11 @@
 | **@J-ORG-QUICK-SEND-01**        | クイックワークベンチ送信                                                         | ✔️ `tests\e2e\quick-send.spec.ts`                                                                                                         |
 | **@J-ORG-SEMANTIC-SEARCH-01**   | セマンティック検索による自然言語フィルタリング                                   | ✔️ `tests\e2e\library-semantic-search.spec.ts`                                                                                            |
 | **@J-WB-AI-ADVICE-01**          | AI調合アドバイス表示                                                             | ✔️ `tests\e2e\ai-recipe-advice.spec.ts`                                                                                                   |
-| **@J-ORG-CARD-TOOLTIP-01**      | カードアクションツールチップ＆レスポンシブメニュー                               | ❌ 未カバー (Missing)                                                                                                                     |
+| **@J-ORG-CARD-TOOLTIP-01**      | カードアクションツールチップ＆レスポンシブメニュー                               | ✔️ `tests\e2e\card-management.spec.ts`                                                                                                    |
 | **@J-WB-EMPTY-CAULDRON-01**     | 空状態の大釜アフォーダンス                                                       | ✔️ `tests\e2e\workbench-empty-cauldron.spec.ts`                                                                                           |
 
 ## サマリー
 
 - 全ジャーニー数: 39
-- カバー済み: 38
-- 未カバー: 1
+- カバー済み: 39
+- 未カバー: 0

--- a/src/components/molecules/CardThumbnailActions.tsx
+++ b/src/components/molecules/CardThumbnailActions.tsx
@@ -78,6 +78,7 @@ function getButtonsConfig(
       content: t("libraryTab.tooltips.inject"),
       variant: "blue",
       click: props.onInjectClick!,
+      dataId: "inject-card-button",
       icon: InjectIcon
     },
     {
@@ -120,6 +121,7 @@ function PinButton({ props }: { props: CardThumbnailActionsProps }) {
       variant={props.isPinned ? "yellow" : "white"}
       onClick={props.onPinClick!}
       className=""
+      dataTestId="pin-card-button"
       icon={props.isPinned ? PinnedIcon : PinIcon}
     />
   )

--- a/tests/e2e/card-management.spec.ts
+++ b/tests/e2e/card-management.spec.ts
@@ -439,7 +439,7 @@ test.describe("Style Atelier Sandbox E2E Tests - Card Management @J-ORG-EXPERT-0
     expect(cardInDb.name).toBe("Initial Version")
   })
 
-  test("should display tooltips on hover and collapse low-priority actions on narrow container", async ({
+  test("should display tooltips on hover and collapse low-priority actions on narrow container @J-ORG-CARD-TOOLTIP-01", async ({
     page
   }) => {
     const screenshotsDir = path.join(__dirname, "../../tests/screenshots")
@@ -476,52 +476,172 @@ test.describe("Style Atelier Sandbox E2E Tests - Card Management @J-ORG-EXPERT-0
     const libraryTabButton = spFrame.locator("button:has-text('Library')")
     await libraryTabButton.click()
 
-    // 4. Hover over Edit button to check tooltip content
+    // 4. Hover over buttons to check English tooltip content (Default)
     const editBtn = spFrame.locator("[data-testid='edit-card-button']").first()
+    const shareBtn = spFrame
+      .locator("[data-testid='share-card-button']")
+      .first()
+    const quickSendBtn = spFrame
+      .locator("[data-testid='quick-send-button']")
+      .first()
+    const pinBtn = spFrame.locator("[data-testid='pin-card-button']").first()
+    const injectBtn = spFrame
+      .locator("[data-testid='inject-card-button']")
+      .first()
+
     await expect(editBtn).toBeVisible({ timeout: 10000 })
     await editBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^Edit Card$/ })
+    ).toBeVisible()
 
-    const tooltip = spFrame.locator("[data-testid='tooltip-content']").first()
-    await expect(tooltip).toBeVisible()
+    await shareBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^Share Card$/ })
+    ).toBeVisible()
 
-    // Take a screenshot of the tooltip shown on hover
+    await quickSendBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^Quick Send to Workbench$/ })
+    ).toBeVisible()
+
+    await pinBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^Send to Workbench$/ })
+    ).toBeVisible()
+
+    await injectBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^Inject Prompt$/ })
+    ).toBeVisible()
+
+    // Take a screenshot of the tooltip shown on hover (English)
     await page.screenshot({
-      path: path.join(screenshotsDir, "card-action-tooltip.png")
+      path: path.join(screenshotsDir, "card-action-tooltip-en.png")
     })
 
-    // 5. Change viewport width to very narrow (e.g. 320px) to test collapsing actions
+    // 5. Open Settings and Switch to Japanese (ja)
+    const settingsNavBtn = spFrame.locator("#settings-nav-btn")
+    await expect(settingsNavBtn).toBeVisible()
+    await settingsNavBtn.click()
+
+    const langSelect = spFrame.locator("#language-select")
+    await expect(langSelect).toBeVisible()
+    await langSelect.selectOption("ja")
+
+    // Switch back to Library tab (the text is still 'Library' in i18n test context for tab buttons)
+    await libraryTabButton.click()
+
+    // Verify Japanese Tooltips
+    await editBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^カードを編集$/ })
+    ).toBeVisible()
+
+    await shareBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^カードを共有$/ })
+    ).toBeVisible()
+
+    await quickSendBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^ワークベンチへ送って遷移$/ })
+    ).toBeVisible()
+
+    await pinBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^ワークベンチに送る$/ })
+    ).toBeVisible()
+
+    await injectBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^大釜へ適用$/ })
+    ).toBeVisible()
+
+    // Take a screenshot of the tooltip shown on hover (Japanese)
+    await page.screenshot({
+      path: path.join(screenshotsDir, "card-action-tooltip-ja.png")
+    })
+
+    // 6. Change viewport width to very narrow (e.g. 320px) to test collapsing actions
     await page.setViewportSize({ width: 320, height: 600 })
 
     // Wait for layout updates
     await page.waitForTimeout(500)
 
-    // 6. Verify that "Edit" action button (with hide-on-narrow) is hidden and "More" button is visible
+    // 7. Verify that action buttons (with hide-on-narrow) are hidden and "More" button is visible
     await expect(editBtn).not.toBeVisible()
+    await expect(shareBtn).not.toBeVisible()
+    await expect(quickSendBtn).not.toBeVisible()
+
     const moreBtn = spFrame
       .locator("[data-testid='more-actions-button']")
       .first()
     await expect(moreBtn).toBeVisible()
+
+    // Hover "More" button to check Japanese tooltip
+    await moreBtn.hover()
+    await expect(
+      spFrame
+        .locator("[data-testid='tooltip-content']")
+        .filter({ hasText: /^その他のアクション$/ })
+    ).toBeVisible()
 
     // Take screenshot of the collapsed layout
     await page.screenshot({
       path: path.join(screenshotsDir, "card-actions-collapsed.png")
     })
 
-    // 7. Click "More" button to show popover menu
+    // 8. Click "More" button to show popover menu
     await moreBtn.click()
 
-    // 8. Verify popup items are visible
+    // 9. Verify popup items are visible and translated in Japanese
     const moreEditBtn = spFrame.locator("[data-testid='more-edit-card-button']")
     await expect(moreEditBtn).toBeVisible()
+    await expect(moreEditBtn).toHaveText(/カードを編集/)
+
+    const moreShareBtn = spFrame.locator(
+      "[data-testid='more-share-card-button']"
+    )
+    await expect(moreShareBtn).toBeVisible()
+    await expect(moreShareBtn).toHaveText(/カードを共有/)
+
+    const moreQuickSendBtn = spFrame.locator(
+      "[data-testid='more-quick-send-button']"
+    )
+    await expect(moreQuickSendBtn).toBeVisible()
+    await expect(moreQuickSendBtn).toHaveText(/ワークベンチへ送って遷移/)
 
     // Take screenshot of the popup menu
     await page.screenshot({
       path: path.join(screenshotsDir, "card-actions-more-menu.png")
     })
 
-    // 9. Click "Edit" item inside popup and verify it opens Card Details
+    // 10. Click "Edit" item inside popup and verify it opens Card Details (in Japanese context: カード詳細)
     await moreEditBtn.click()
-    const detailTitle = spFrame.locator("h2:has-text('Card Details')")
+    const detailTitle = spFrame
+      .locator("h2:has-text('Card Details')")
+      .or(spFrame.locator("h2:has-text('カード詳細')"))
     await expect(detailTitle).toBeVisible()
 
     // Reset viewport size


### PR DESCRIPTION
This PR implements E2E testing for user journey `@J-ORG-CARD-TOOLTIP-01` to verify tooltip visibility in both English and Japanese (i18n), and collapsing behavior on narrow viewport size (320px width).

### Changes
- Implemented `@J-ORG-CARD-TOOLTIP-01` E2E test suite in `tests/e2e/card-management.spec.ts`.
- Added `dataId` and `dataTestId` for Inject and Pin buttons inside `CardThumbnailActions.tsx` for robust element selection.
- Verified tooltips (EN/JA) for Edit, Share, Quick Send, Pin, and Inject action buttons.
- Checked responsive menu functionality on narrow layouts.

### Verification Screenshots
#### English Tooltips on Hover
![card-action-tooltip-en.png](https://github.com/user-attachments/assets/add51085-0c07-4fa2-be07-b415b646b20e)

#### Japanese Tooltips on Hover
![card-action-tooltip-ja.png](https://github.com/user-attachments/assets/347115cf-fe26-49e8-a196-27859e058932)

#### Collapsed Action Buttons on Narrow Viewport (320px)
![card-actions-collapsed.png](https://github.com/user-attachments/assets/54ff8f69-173c-4023-8f4c-15d96e4f2c26)

#### More Actions Popup Menu (Japanese)
![card-actions-more-menu.png](https://github.com/user-attachments/assets/19d6cf94-51d4-4e59-86c5-767306669cc6)

Closes #732
