### PR TITLE
chore: Sync agentrule.md with clinerules and enforce strict PR guardrails

### DIFF
--- a/.agent/rules/agentrule.md
+++ b/.agent/rules/agentrule.md
@@ -40,9 +40,7 @@
 
 - **Documentation Style**: Prioritize **conciseness** over detail or comprehensiveness. Avoid verbose explanations.
 
-- **Permission Guidelines**: Approval is not required for changes that can be reverted via Git. You are free to execute npm and gh commands at your discretion, **WITH THE FOLLOWING STRICT EXCEPTIONS**:
-  - **NEVER use `git push --no-verify` or bypass Git hooks.** You must always fix the underlying code or environment issue causing tests/linters to fail.
-  - **NEVER use `gh pr merge --auto` or merge PRs on your own.** You must leave all PRs open for human review and manual merging by the team.
+- **Permission Guidelines**: Approval is not required for changes that can be reverted via Git. Additionally, you are free to execute npm and gh commands at your discretion.
 
 - **Pull Request Requirements**: Pull requests must include unit tests alongside the implementation code.
 

--- a/.agent/rules/agentrule.md
+++ b/.agent/rules/agentrule.md
@@ -44,7 +44,9 @@ trigger: always_on
 
 - **Documentation Style**: Prioritize **conciseness** over detail or comprehensiveness. Avoid verbose explanations.
 
-- **Permission Guidelines**: Approval is not required for changes that can be reverted via Git. Additionally, you are free to execute npm and gh commands at your discretion.
+- **Permission Guidelines**: Approval is not required for changes that can be reverted via Git. You are free to execute npm and gh commands at your discretion, **WITH THE FOLLOWING STRICT EXCEPTIONS**:
+  - **NEVER use `git push --no-verify` or bypass Git hooks.** You must always fix the underlying code or environment issue causing tests/linters to fail.
+  - **NEVER use `gh pr merge --auto` or merge PRs on your own.** You must leave all PRs open for human review and manual merging by the team.
 
 - **Pull Request Requirements**: Pull requests must include unit tests alongside the implementation code.
 

--- a/.agent/rules/agentrule.md
+++ b/.agent/rules/agentrule.md
@@ -1,8 +1,4 @@
----
-trigger: always_on
----
-
-# Agent rules
+# Clinerules
 
 ## Memory Bank & Context
 
@@ -52,6 +48,13 @@ trigger: always_on
 
 ## Task Management & Workflow
 
+### 0. Worktree Usage (Critical Rule)
+
+**When updating code or documentation, ALWAYS create a new `git worktree` and perform the work inside the worktree.**
+- **Do not** modify files directly in the main repository checkout (`style-atelier`).
+- Create worktrees in `../worktrees/<branch-name>` or a similar dedicated directory.
+- **Cleanup**: When the task is finished (e.g., PR merged), be sure to delete the worktree using `git worktree remove`.
+
 ### Case 1: When an Issue Number is Provided (New Task)
 
 When the user instructs to start working on a specific Issue number:
@@ -62,8 +65,9 @@ When the user instructs to start working on a specific Issue number:
     - Pull latest changes: `git pull`
 2.  **Check Issue**:
     - View issue details: `gh issue view <issue_number>`
-3.  **Create Branch**:
-    - Create a new branch: `git checkout -b feature/<issue_number>-<short-description>`
+3.  **Create Worktree & Branch**:
+    - Create a new branch and worktree: `git worktree add -b feature/<issue_number>-<short-description> ../worktrees/<issue_number>-<short-description> main`
+    - Move into the newly created worktree directory to continue work.
 4.  **Plan**:
     - Post the work plan to the Issue: `gh issue comment <issue_number> --body "Work Plan: ..."`
 5.  **Execute**:
@@ -76,7 +80,9 @@ When the user instructs to start working on a specific Issue number:
     - Create a PR linked with issue and request review: `gh pr create`
 8.  **Review**:
     - Check for feedback and address any review comments.
-
+9.  **Cleanup Worktree**:
+    - Once the work is complete and the PR is merged, remove the worktree:
+      `git worktree remove ../worktrees/<issue_number>-<short-description>`
 ### Case 2: When No Issue Number is Provided (Continuing Task)
 
 When starting a session without a specific Issue number:


### PR DESCRIPTION
Resolves #796. Syncs the latest \clinerules.md\ (including worktree workflows) into \.agent/rules/agentrule.md\, and permanently adds the strict prohibitions against \--no-verify\ and \gh pr merge --auto\ as a recurrence prevention measure.