### PR TITLE
fix(e2e): skip extension tests on non-extension browser projects to avoid XServer errors

### DIFF
--- a/artifacts/test-proof.enc
+++ b/artifacts/test-proof.enc
@@ -1,6 +1,6 @@
 {
-  "encryptedAesKey": "Crhf0dXbEWnK4K1tACi0e2Au3QnQgLh8Y0GO9TdilbAWB9JkAmg3ek6YZftI8ohRJt45ybt6gLEeEkQZsoFQYHbsLk50hjpibX4Lq5FPrwH8ZQC4T2VEN8jblIr/6CQWi3P5aG/rFNULQPMq1YwAHgousC+/nMHQGSKSqWK9RYo33WlFxZcz9NowSz3ylhnXIqiebX7wBB41eYNbV1jD8rhde01r8+WQJeHr9o55W6ss20DIXEXHyTyepTJoDXpnM4Wo0dGOmVBy1lghAmNvOLG+rqidc4iP8kU/+HiHxGlBq6eoQcMf56NpaxtxQskluGsCiWhTdLyJvFqk+bxT/A==",
-  "iv": "oaqOeeZl3Xe7pOPw411AAg==",
-  "authTag": "t39JBRbND5/3C+di+xc/Fg==",
-  "encryptedBody": "vAydMBT2VBOj8aROYemcMHz7tmwofgNvwcEQN3bXQRJL0/dl11sw+OC+hwOLoRUmocu8vtWHXtWo2QzB80dEkQ4W3MyJP04sJvrRqtBKtH/gu643oksYzVnTO5adbZ0dGW5fuwKqM1u+w98gmwystNc/aoe5/lccOiXcy0kHdzvD9Ir3rOxbTq3Ck/wb4utfB77AIMhYwWjFROZ2HhHgbakhdUlB8Q=="
+  "encryptedAesKey": "clOAFrC/A2t3MkDrIEnn5rzGZnVRJwBT0KXWjqK3BAa4MHKLvxS6fbvvoKRIX2b+WJUjnTiYQcdJC5V9UZUVn+h+Ipyg+Nkb6ULk/YMo9aYUMfTEer1oOBwOZMy1OUNjttNao+Ts9Xm/eJXclf++kFRRkm0T2BnGNdeHKmLzNkjmDhwntQwqJsixHG102k+v2+QarNK5L2BDDeecXf/FMydr68/zbNQElL9rpCJebE8u7YKGVsg3Fx2Ci1i4KOe0YVMi056CuKMUDHGCjCsITr2TSlNf+5kFxezMbo+yQD7yFR3U5TGHM2zHF1AkC1JB82LtCpQm3Vzm1+h5XX7nGg==",
+  "iv": "CnyA19+knMkusWS1El5nfg==",
+  "authTag": "6c0I3At8vasjr00d5AADzg==",
+  "encryptedBody": "JqcFlY6taqJU8UGBn8K4CdhJlLUaMdpv+HGvWBbbl2LP2TSpA3glhvmk+1UyvM4VULVkiViTK5Py9aQHTXAHhjww+MTBbrZ0TLLhHJwmzX55YQk+j65QOBdOIRetuTJmsBvj9gMpft1/v1MrOkDEbKh9wZiHjnJq/I3QgKSjQujK/kgVSIatOMcmvAvmVT5y0ySKnuds0o9Y4f/RFL2hmY8DHpgdsg1Wec46QN1bwoRXvzy/hJJ68pnuh9/dTo5lfg=="
 }

--- a/artifacts/test-proof.enc
+++ b/artifacts/test-proof.enc
@@ -1,6 +1,6 @@
 {
-  "encryptedAesKey": "ifEYVAN2ecvgNwJEK2/+x2PdJliHC6LLAwmeuIwIfYl5XMKVu0cmYEnemW81Fv/1401A3UKQJrsfsiO/tPlXXWZGGP6hmzZRay07h9md6f9Y6NqKKMQ2Qy8sFESAphHGuu3Ug6pcvpw+oRO7GWFD4RVwuO566RQSWtVjy8eFnHhzkjTfIx1XqJAc4jD3gLMUQr34twCbgwxb5keYbkUMqVbokNeS4j3UDDj/BixCPWjybFQbhC4Bw5BSmbLre8F9W4nAmCi6Y3OhNmD7ILiRlZR9rITJm2a1SsAnBq9L501wdIvXTL7dvMKauSPnxVfryFAHOQfgOZK1odsv2uui2w==",
-  "iv": "je2P7Vcqvmz5wzgXciVN3Q==",
-  "authTag": "CwCCpWaGIJXOOdB6JgpbLw==",
-  "encryptedBody": "aH8Y5Qix4l+xjp/POiOmdiw9jIyd+TTr+ZJXcM0yUkbo2EJ8YuS81MdevKTAOqBEQ+ruMXs/Wob8xcknqw5+WHdl/aG0D1mjmZ7PREse7TVabIDXmkIJPWazmGg7/DHPu0q3E4jSeQewDX/nor6Ys8vEULN6LqLautaLOiDJ/48EHr5zwm8UxqFmKv6qeSGtyrCOmivkq/T+R3JJUuLEEu4/GcxgKuNlmbA4bw=="
+  "encryptedAesKey": "Crhf0dXbEWnK4K1tACi0e2Au3QnQgLh8Y0GO9TdilbAWB9JkAmg3ek6YZftI8ohRJt45ybt6gLEeEkQZsoFQYHbsLk50hjpibX4Lq5FPrwH8ZQC4T2VEN8jblIr/6CQWi3P5aG/rFNULQPMq1YwAHgousC+/nMHQGSKSqWK9RYo33WlFxZcz9NowSz3ylhnXIqiebX7wBB41eYNbV1jD8rhde01r8+WQJeHr9o55W6ss20DIXEXHyTyepTJoDXpnM4Wo0dGOmVBy1lghAmNvOLG+rqidc4iP8kU/+HiHxGlBq6eoQcMf56NpaxtxQskluGsCiWhTdLyJvFqk+bxT/A==",
+  "iv": "oaqOeeZl3Xe7pOPw411AAg==",
+  "authTag": "t39JBRbND5/3C+di+xc/Fg==",
+  "encryptedBody": "vAydMBT2VBOj8aROYemcMHz7tmwofgNvwcEQN3bXQRJL0/dl11sw+OC+hwOLoRUmocu8vtWHXtWo2QzB80dEkQ4W3MyJP04sJvrRqtBKtH/gu643oksYzVnTO5adbZ0dGW5fuwKqM1u+w98gmwystNc/aoe5/lccOiXcy0kHdzvD9Ir3rOxbTq3Ck/wb4utfB77AIMhYwWjFROZ2HhHgbakhdUlB8Q=="
 }

--- a/tests/e2e/extension-fixture.ts
+++ b/tests/e2e/extension-fixture.ts
@@ -36,6 +36,9 @@ export const test = base.extend<{
     logPhase("テスト開始", testInfo.title)
 
     const project = testInfo.project
+    if (project.name !== "extension") {
+      testInfo.skip(true, "Skip extension tests on non-extension browser projects")
+    }
     // playwright.config.ts から args を取得。なければデフォルト
     const args = project.use?.args || []
 


### PR DESCRIPTION
This PR fixes a bug in E2E tests where the headless chromium project attempted to load extension tests, crashing due to missing XServer in CI environment. It now skips extension tests when project name is not 'extension'.