### PR TITLE
feat: resolve issue #1213

### DIFF
--- a/memory-bank/userJourneys.json
+++ b/memory-bank/userJourneys.json
@@ -745,7 +745,8 @@
       "viewComponents": [
         "src/mobile-app/index.html",
         "src/mobile-app/manifest.json",
-        "src/mobile-app/sw.ts",
+        "src/mobile-app/sw.template.js",
+        "scripts/build-mobile.mjs",
         "src/mobile-app/components/A2HSPrompt.tsx",
         "src/hooks/useOpfsImage.ts"
       ]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:mobile": "vite --config vite.config.mobile.ts",
     "serve:cache": "node scripts/serve-cache.mjs",
     "build": "plasmo build",
-    "build:mobile": "vite build --config vite.config.mobile.ts",
+    "build:mobile": "node scripts/build-mobile.mjs",
     "package": "plasmo package",
     "test": "vitest run",
     "test:ui": "vitest --ui",

--- a/scripts/build-mobile.mjs
+++ b/scripts/build-mobile.mjs
@@ -1,0 +1,42 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+console.log('Building mobile application with Vite...');
+execSync('npx vite build --config vite.config.mobile.ts', { stdio: 'inherit', cwd: rootDir });
+
+console.log('Generating Service Worker...');
+
+const distDir = path.join(rootDir, 'dist-mobile');
+const assetsDir = path.join(distDir, 'assets');
+
+// Get compiled JS and CSS files
+const files = fs.readdirSync(assetsDir);
+const jsFile = files.find(f => f.startsWith('main-') && f.endsWith('.js'));
+const cssFile = files.find(f => f.startsWith('main-') && f.endsWith('.css'));
+
+if (!jsFile || !cssFile) {
+  throw new Error('Failed to find compiled assets in dist-mobile/assets');
+}
+
+const jsPath = `/mobile/assets/${jsFile}`;
+const cssPath = `/mobile/assets/${cssFile}`;
+
+// Read sw.template.js
+const templatePath = path.join(rootDir, 'src/mobile-app/sw.template.js');
+let swContent = fs.readFileSync(templatePath, 'utf8');
+
+// Replace placeholders
+swContent = swContent
+  .replace('__JS_PATH__', jsPath)
+  .replace('__CSS_PATH__', cssPath);
+
+// Write to dist-mobile/sw.js
+fs.writeFileSync(path.join(distDir, 'sw.js'), swContent, 'utf8');
+console.log(`Service Worker generated successfully at dist-mobile/sw.js`);
+console.log(`Cached assets: \n - ${jsPath}\n - ${cssPath}`);

--- a/src/mobile-app/index.ts
+++ b/src/mobile-app/index.ts
@@ -313,4 +313,15 @@ function setupEventHandlers() {
 document.addEventListener("DOMContentLoaded", () => {
   loadCardFromUrl()
   setupEventHandlers()
+
+  // Register Service Worker for offline support
+  if (
+    "serviceWorker" in navigator &&
+    (import.meta.env.PROD || window.location.search.includes("pwa=true"))
+  ) {
+    navigator.serviceWorker
+      .register("/mobile/sw.js")
+      .then((reg) => console.log("ServiceWorker registered: ", reg.scope))
+      .catch((err) => console.error("ServiceWorker failed: ", err))
+  }
 })

--- a/src/mobile-app/sw.template.js
+++ b/src/mobile-app/sw.template.js
@@ -1,0 +1,85 @@
+/* eslint-disable */
+const CACHE_NAME = "style-atelier-mobile-v1"
+const ASSETS = [
+  "/mobile/",
+  "/mobile/index.html",
+  "/mobile/manifest.json",
+  "/mobile/icon-192.png",
+  "/mobile/icon-512.png",
+  "__CSS_PATH__",
+  "__JS_PATH__"
+]
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => {
+        // プレースホルダーが置換されていない場合は除外
+        const cleanAssets = ASSETS.filter(
+          (asset) =>
+            !asset.includes("__CSS_PATH__") && !asset.includes("__JS_PATH__")
+        )
+        return cache.addAll(cleanAssets)
+      })
+      .then(() => self.skipWaiting())
+  )
+})
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => {
+        return Promise.all(
+          keys.map((key) => {
+            if (key !== CACHE_NAME) {
+              return caches.delete(key)
+            }
+          })
+        )
+      })
+      .then(() => self.clients.claim())
+  )
+})
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url)
+
+  // Google GIS や外部API、および Google Drive 等への外部リクエストはキャッシュしない
+  if (url.origin !== self.location.origin) {
+    return
+  }
+
+  // /mobile/ 配下のリクエストに対するキャッシュ戦略
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          // レスポンスが正常かつGETリクエストの場合のみ、動的キャッシュに追加する
+          if (
+            response &&
+            response.status === 200 &&
+            response.type === "basic" &&
+            event.request.method === "GET"
+          ) {
+            const responseToCache = response.clone()
+            caches.open(CACHE_NAME).then((cache) => {
+              cache.put(event.request, responseToCache)
+            })
+          }
+          return response
+        })
+        .catch(() => {
+          // オフライン時のナビゲーションフォールバック
+          if (event.request.mode === "navigate") {
+            return caches.match("/mobile/index.html")
+          }
+        })
+    })
+  )
+})

--- a/tests/e2e/mobile-pwa.spec.ts
+++ b/tests/e2e/mobile-pwa.spec.ts
@@ -51,4 +51,49 @@ test.describe("Mobile PWA Support @J-PWA-A2HS-OFFLINE-01", () => {
     expect(icon512Response.ok()).toBe(true)
     expect(icon512Response.headers()["content-type"]).toBe("image/png")
   })
+
+  test("should register service worker and work offline", async ({
+    page,
+    context
+  }) => {
+    // Start waiting for the service worker registration
+    const swPromise = context.waitForEvent("serviceworker")
+
+    // Visit PWA with pwa=true
+    await page.goto("/mobile/?pwa=true")
+
+    // Wait for registration
+    const sw = await swPromise
+    expect(sw).toBeTruthy()
+
+    // Wait for the Service Worker to be activated
+    await page.evaluate(async () => {
+      const reg = await navigator.serviceWorker.ready
+      if (reg.active && reg.active.state !== "activated") {
+        await new Promise<void>((resolve) => {
+          reg.active!.addEventListener("statechange", (e: any) => {
+            if (e.target.state === "activated") {
+              resolve()
+            }
+          })
+        })
+      }
+    })
+
+    // Simulate going offline
+    await context.setOffline(true)
+
+    // Reload the page while offline
+    await page.reload()
+
+    // Assert that the page is still loaded and interactive
+    const title = page.locator(".app-title")
+    await expect(title).toHaveText("STYLE ATELIER")
+
+    const cardTitle = page.locator("#cardTitleFront")
+    await expect(cardTitle).toBeVisible()
+
+    // Clean up: return online
+    await context.setOffline(false)
+  })
 })

--- a/tests/sandbox/vite.config.ts
+++ b/tests/sandbox/vite.config.ts
@@ -17,6 +17,29 @@ export default defineConfig({
         server.middlewares.use((req, res, next) => {
           if (req.url && req.url.startsWith("/mobile/")) {
             const urlPath = req.url.slice("/mobile/".length).split("?")[0]
+
+            // Try serving from dist-mobile (built PWA assets) first if it exists
+            const distFilePath = path.join(
+              __dirname,
+              "../../dist-mobile",
+              urlPath || "index.html"
+            )
+            if (
+              fs.existsSync(distFilePath) &&
+              fs.statSync(distFilePath).isFile()
+            ) {
+              const ext = path.extname(distFilePath)
+              let contentType = "application/octet-stream"
+              if (ext === ".html") contentType = "text/html"
+              else if (ext === ".js") contentType = "application/javascript"
+              else if (ext === ".css") contentType = "text/css"
+              else if (ext === ".json") contentType = "application/json"
+              else if (ext === ".png") contentType = "image/png"
+              res.setHeader("Content-Type", contentType)
+              res.end(fs.readFileSync(distFilePath))
+              return
+            }
+
             const filePath = path.join(
               __dirname,
               "../../src/mobile-app/public",


### PR DESCRIPTION
# Walkthrough: PWA Service Worker Offline Cache Implementation (#1213)

## 🔮 背景と目的 (Background & Objectives)
モバイル PWA Viewer がオフライン状態でも正しく起動・ロードできるようにするため、Service Worker による静的アセットの Cache API キャッシュ（Offline Shell）を実装しました。これにより、ネットワークがない状態でも、HTML, JS, CSS, PWAマニフェスト、およびアイコン画像等の主要アセットがローカルにキャッシュされ、オフライン起動が可能になります。

## 🛠️ 実装内容 (Implementation Details)

### 1. Service Worker テンプレート (`src/mobile-app/sw.template.js`)
* バニラ JS による Service Worker ライフサイクル制御とアセットキャッシュ戦略の実装。
* ビルド時に Vite で生成されたハッシュ付き CSS/JS をプレキャッシュアセットとして動的に埋め込めるよう、プレースホルダー (`__CSS_PATH__`, `__JS_PATH__`) を用意。
* ナビゲーションリクエスト（オフライン時のページ遷移など）に対して、常に `/mobile/index.html` をフォールバックとして返せるように制御。

### 2. カスタムビルドスクリプト (`scripts/build-mobile.mjs` & `package.json`)
* Vite のビルド成果物（`dist-mobile`）から、コンパイルされた `main-[hash].js` と `main-[hash].css` のファイル名を取得し、Service Worker テンプレートのプレースホルダーを自動的に置換して `dist-mobile/sw.js` に出力するスクリプトを構築。
* `package.json` の `build:mobile` コマンドをこのカスタムスクリプトに変更。

### 3. Service Worker の登録処理 (`src/mobile-app/index.ts`)
* `DOMContentLoaded` イベント発生時に `navigator.serviceWorker.register` を実行。
* 開発サーバーでの動作（アセットのハッシュが存在しない）時にキャッシュが開発を阻害しないよう、本番ビルド環境（`import.meta.env.PROD`）またはE2Eテスト用のURLパラメータ (`?pwa=true`) が付与されている場合のみ登録されるよう制御。

### 4. テストサンドボックスの設定調整 (`tests/sandbox/vite.config.ts`)
* E2Eテストを実行する際、本番ビルド成果物 `dist-mobile` が存在するならば、`/mobile/` 配下のリクエストに対してそれを優先的にサーブするように Vite Sandbox サーバー of カスタムミドルウェアを調整。これによって、E2E環境でも実際のハッシュ付きアセットと Service Worker を使ったテストが可能に。

### 5. E2Eテストの拡張 (`tests/e2e/mobile-pwa.spec.ts`)
* `@J-PWA-A2HS-OFFLINE-01` ユーザー・ジャーニーの検証として、`should register service worker and work offline` テストケースを追加。
* テストで実際に `/mobile/?pwa=true` にアクセスし、Service Worker がアクティブ化されるのを待機後、Playwright の `context.setOffline(true)` でオフラインをシミュレートしてリロードし、オフラインでも正常にアプリの要素がレンダリングされることを検証。

## 🧪 検証結果 (Verification Results)
* **ESLint / Linter**: エラーなし (`npm run lint` パス)
* **Unit Tests**: パス (Vitest)
* **E2E Tests**: `tests/e2e/mobile-pwa.spec.ts` 内の全テストが正常にパス
