### PR TITLE
feat: resolve issue #1214

### DIFF
--- a/memory-bank/userJourneys.json
+++ b/memory-bank/userJourneys.json
@@ -748,6 +748,7 @@
         "src/mobile-app/sw.template.js",
         "scripts/build-mobile.mjs",
         "src/mobile-app/components/A2HSPrompt.tsx",
+        "src/mobile-app/a2hs.ts",
         "src/hooks/useOpfsImage.ts"
       ]
     },

--- a/src/mobile-app/a2hs.ts
+++ b/src/mobile-app/a2hs.ts
@@ -1,0 +1,133 @@
+let deferredPrompt: any = null
+let hasPrompted = false
+
+export function initA2HS() {
+  const isStandalone =
+    window.matchMedia("(display-mode: standalone)").matches ||
+    (navigator as any).standalone
+  if (isStandalone) {
+    return
+  }
+
+  // Dismiss control check
+  const dismissedUntil = localStorage.getItem("a2hs-dismissed-until")
+  if (dismissedUntil && Date.now() < parseInt(dismissedUntil, 10)) {
+    return
+  }
+
+  const isIOS =
+    /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream
+  // Chrome on iOS contains 'CriOS', Safari on iOS doesn't contain 'Chrome' or 'CriOS'
+  const isSafari =
+    /Safari/.test(navigator.userAgent) &&
+    !/Chrome/.test(navigator.userAgent) &&
+    !/CriOS/.test(navigator.userAgent)
+
+  setupA2HSEvents(isIOS, isSafari)
+}
+
+function setupA2HSEvents(isIOS: boolean, isSafari: boolean) {
+  const androidDialog = document.getElementById("androidInstallDialog")
+  const iosTooltip = document.getElementById("iosInstallTooltip")
+
+  // 1. Android/Chrome prompt event listener
+  window.addEventListener("beforeinstallprompt", (e: any) => {
+    e.preventDefault()
+    deferredPrompt = e
+    setTimeout(showAndroidDialog, 3000)
+  })
+
+  // 2. iOS/Safari handler
+  if (isIOS && isSafari) {
+    setTimeout(showIosTooltip, 3000)
+  }
+
+  // 3. User interaction (Wow moment: 3D Flip)
+  const cardContainer = document.getElementById("cardContainer")
+  if (cardContainer) {
+    cardContainer.addEventListener("click", () => {
+      setTimeout(() => {
+        if (deferredPrompt) {
+          showAndroidDialog()
+        } else if (isIOS && isSafari) {
+          showIosTooltip()
+        }
+      }, 1000)
+    })
+  }
+
+  setupA2HSControls(androidDialog, iosTooltip)
+}
+
+function showAndroidDialog() {
+  if (hasPrompted) return
+  hasPrompted = true
+  const androidDialog = document.getElementById("androidInstallDialog")
+  if (androidDialog) {
+    androidDialog.style.display = "flex"
+    void androidDialog.offsetHeight // force reflow
+    androidDialog.classList.add("show")
+  }
+}
+
+function showIosTooltip() {
+  if (hasPrompted) return
+  hasPrompted = true
+  const iosTooltip = document.getElementById("iosInstallTooltip")
+  if (iosTooltip) {
+    iosTooltip.style.display = "block"
+    void iosTooltip.offsetHeight // force reflow
+    iosTooltip.classList.add("show")
+  }
+}
+
+function setupA2HSControls(
+  androidDialog: HTMLElement | null,
+  iosTooltip: HTMLElement | null
+) {
+  const androidInstallBtn = document.getElementById("androidInstallBtn")
+  const androidCloseBtn = document.getElementById("androidCloseBtn")
+  const androidDismissBtn = document.getElementById("androidDismissBtn")
+  const iosCloseBtn = document.getElementById("iosCloseBtn")
+
+  const dismissA2HS = () => {
+    const dismissedUntilTime = Date.now() + 14 * 24 * 60 * 60 * 1000
+    localStorage.setItem("a2hs-dismissed-until", dismissedUntilTime.toString())
+
+    if (androidDialog) {
+      androidDialog.classList.remove("show")
+      setTimeout(() => {
+        androidDialog.style.display = "none"
+      }, 300)
+    }
+    if (iosTooltip) {
+      iosTooltip.classList.remove("show")
+      setTimeout(() => {
+        iosTooltip.style.display = "none"
+      }, 300)
+    }
+  }
+
+  if (androidInstallBtn) {
+    androidInstallBtn.addEventListener("click", async () => {
+      if (!deferredPrompt) return
+      deferredPrompt.prompt()
+      try {
+        const { outcome } = await deferredPrompt.userChoice
+        console.log(`User response to the install prompt: ${outcome}`)
+      } catch (err) {
+        console.error("Install prompt error:", err)
+      }
+      deferredPrompt = null
+      if (androidDialog) {
+        androidDialog.classList.remove("show")
+        androidDialog.style.display = "none"
+      }
+    })
+  }
+
+  if (androidCloseBtn) androidCloseBtn.addEventListener("click", dismissA2HS)
+  if (androidDismissBtn)
+    androidDismissBtn.addEventListener("click", dismissA2HS)
+  if (iosCloseBtn) iosCloseBtn.addEventListener("click", dismissA2HS)
+}

--- a/src/mobile-app/index.html
+++ b/src/mobile-app/index.html
@@ -138,6 +138,36 @@
     </div>
   </div>
 
+  <!-- A2HS Android/Chrome Install Dialog -->
+  <div class="a2hs-dialog" id="androidInstallDialog" style="display: none;">
+    <div class="a2hs-content">
+      <button class="a2hs-close-btn" id="androidCloseBtn" aria-label="閉じる">&times;</button>
+      <div class="a2hs-icon-wrapper">
+        <img src="/mobile/icon-192.png" alt="Style Atelier Icon" class="a2hs-app-icon">
+      </div>
+      <h3 class="a2hs-title">Style Atelier をインストール</h3>
+      <p class="a2hs-desc">ホーム画面に追加して、オフライン表示や高速起動など、より快適なアプリ体験をお楽しみください。</p>
+      <button class="action-btn action-btn-primary" id="androidInstallBtn">インストールする</button>
+      <button class="a2hs-dismiss-btn" id="androidDismissBtn">今回は見送る</button>
+    </div>
+  </div>
+
+  <!-- A2HS iOS/Safari Install Tooltip -->
+  <div class="a2hs-ios-tooltip" id="iosInstallTooltip" style="display: none;">
+    <div class="a2hs-ios-content">
+      <button class="a2hs-close-btn" id="iosCloseBtn" aria-label="閉じる">&times;</button>
+      <div class="a2hs-ios-step">
+        <span class="a2hs-step-num">1</span>
+        <span>Safariの共有ボタン <span class="a2hs-safari-icon"><svg style="width: 18px; height: 18px; display: inline; vertical-align: middle; stroke: #8b5cf6;" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" /></svg></span> をタップします。</span>
+      </div>
+      <div class="a2hs-ios-step">
+        <span class="a2hs-step-num">2</span>
+        <span>メニューから「ホーム画面に追加」を選択します。</span>
+      </div>
+    </div>
+    <div class="a2hs-ios-arrow"></div>
+  </div>
+
   <script type="module" src="./index.ts"></script>
 </body>
 </html>

--- a/src/mobile-app/index.ts
+++ b/src/mobile-app/index.ts
@@ -1,6 +1,7 @@
 import type { StyleCard } from "../lib/db-schema"
 import { buildPromptString } from "../lib/prompt-utils"
 import { decompressCardData } from "../lib/qr-utils"
+import { initA2HS } from "./a2hs"
 import {
   initGisClient,
   isMock,
@@ -140,17 +141,15 @@ function updateHologramProperties(
   y: number,
   cardContainer: HTMLElement
 ) {
-  const frontCard = cardContainer.querySelector(".card-front") as HTMLElement
-  const backCard = cardContainer.querySelector(".card-back") as HTMLElement
-  if (frontCard && backCard) {
-    const setHolo = (el: HTMLElement) => {
+  const front = cardContainer.querySelector(".card-front") as HTMLElement
+  const back = cardContainer.querySelector(".card-back") as HTMLElement
+  if (front && back) {
+    ;[front, back].forEach((el) => {
       el.style.setProperty("--glow-x", `${x}%`)
       el.style.setProperty("--glow-y", `${y}%`)
       el.style.setProperty("--holo-x", `${x}%`)
       el.style.setProperty("--holo-y", `${y}%`)
-    }
-    setHolo(frontCard)
-    setHolo(backCard)
+    })
   }
 }
 
@@ -300,21 +299,21 @@ function setupButtonEvents(
 }
 
 function setupEventHandlers() {
-  const cardContainer = document.getElementById("cardContainer") as HTMLElement
-  const copyBtn = document.getElementById("copyBtn") as HTMLButtonElement
-  const promptText = document.getElementById("promptText") as HTMLElement
-  const saveCloudBtn = document.getElementById(
-    "saveCloudBtn"
-  ) as HTMLButtonElement
-  setupCardContainerEvents(cardContainer)
-  setupButtonEvents(copyBtn, promptText, saveCloudBtn)
+  setupCardContainerEvents(
+    document.getElementById("cardContainer") as HTMLElement
+  )
+  setupButtonEvents(
+    document.getElementById("copyBtn") as HTMLButtonElement,
+    document.getElementById("promptText") as HTMLElement,
+    document.getElementById("saveCloudBtn") as HTMLButtonElement
+  )
 }
 
 document.addEventListener("DOMContentLoaded", () => {
   loadCardFromUrl()
   setupEventHandlers()
+  initA2HS()
 
-  // Register Service Worker for offline support
   if (
     "serviceWorker" in navigator &&
     (import.meta.env.PROD || window.location.search.includes("pwa=true"))

--- a/src/mobile-app/styles/mobile.css
+++ b/src/mobile-app/styles/mobile.css
@@ -412,3 +412,203 @@ body {
   pointer-events: none;
   visibility: hidden;
 }
+
+/* A2HS Android Dialog Styling */
+.a2hs-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.a2hs-dialog.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.a2hs-content {
+  background: linear-gradient(
+    135deg,
+    rgba(22, 15, 41, 0.95) 0%,
+    rgba(9, 7, 15, 0.95) 100%
+  );
+  border: 1px solid rgba(167, 139, 250, 0.3);
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.8),
+    0 0 20px rgba(139, 92, 246, 0.2);
+  border-radius: 1.5rem;
+  width: 90%;
+  max-width: 340px;
+  padding: 2rem 1.5rem;
+  text-align: center;
+  position: relative;
+  transform: translateY(20px);
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.a2hs-dialog.show .a2hs-content {
+  transform: translateY(0);
+}
+
+.a2hs-close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 1.5rem;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.a2hs-close-btn:hover {
+  color: var(--color-text-primary);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.a2hs-icon-wrapper {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto 1.25rem;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  box-shadow:
+    0 8px 16px rgba(0, 0, 0, 0.4),
+    0 0 12px rgba(139, 92, 246, 0.3);
+  border: 1px solid rgba(167, 139, 250, 0.3);
+}
+
+.a2hs-app-icon {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.a2hs-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: var(--color-text-primary);
+}
+
+.a2hs-desc {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin-bottom: 1.5rem;
+}
+
+.a2hs-dismiss-btn {
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  margin-top: 0.75rem;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0.5rem;
+  transition: color 0.2s ease;
+}
+
+.a2hs-dismiss-btn:hover {
+  color: var(--color-text-primary);
+}
+
+/* A2HS iOS Tooltip Styling */
+.a2hs-ios-tooltip {
+  position: fixed;
+  bottom: 24px; /* iOS Safariの下部ツールバーの近く */
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  width: calc(100% - 32px);
+  max-width: 360px;
+  background: linear-gradient(
+    135deg,
+    rgba(22, 15, 41, 0.95) 0%,
+    rgba(9, 7, 15, 0.95) 100%
+  );
+  border: 1px solid rgba(167, 139, 250, 0.3);
+  box-shadow:
+    0 15px 35px rgba(0, 0, 0, 0.7),
+    0 0 15px rgba(139, 92, 246, 0.2);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  z-index: 1000;
+  opacity: 0;
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  pointer-events: none;
+}
+
+.a2hs-ios-tooltip.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+  pointer-events: auto;
+}
+
+.a2hs-ios-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: relative;
+  padding-right: 1.5rem;
+}
+
+.a2hs-ios-step {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--color-text-primary);
+}
+
+.a2hs-step-num {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--color-accent-purple);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 700;
+  font-size: 0.75rem;
+  flex-shrink: 0;
+  box-shadow: 0 2px 4px rgba(139, 92, 246, 0.4);
+}
+
+.a2hs-safari-icon {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.a2hs-ios-arrow {
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 16px;
+  height: 16px;
+  background: rgba(9, 7, 15, 0.95);
+  border-right: 1px solid rgba(167, 139, 250, 0.3);
+  border-bottom: 1px solid rgba(167, 139, 250, 0.3);
+  box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.3);
+}

--- a/tests/e2e/mobile-pwa.spec.ts
+++ b/tests/e2e/mobile-pwa.spec.ts
@@ -96,4 +96,139 @@ test.describe("Mobile PWA Support @J-PWA-A2HS-OFFLINE-01", () => {
     // Clean up: return online
     await context.setOffline(false)
   })
+
+  test.describe("A2HS Installation Prompts", () => {
+    test.beforeEach(async ({ page }) => {
+      // Clear localStorage before each test
+      await page.goto("/src/mobile-app/index.html")
+      await page.evaluate(() => localStorage.clear())
+    })
+
+    test("should display Android install dialog when beforeinstallprompt fires and hide on dismiss", async ({
+      page
+    }) => {
+      await page.goto("/src/mobile-app/index.html")
+
+      // Dispatch beforeinstallprompt
+      await page.evaluate(() => {
+        const event = new Event("beforeinstallprompt")
+        ;(event as any).userChoice = Promise.resolve({ outcome: "accepted" })
+        ;(event as any).prompt = function () {
+          ;(window as any).mockPromptCalled = true
+          return Promise.resolve()
+        }
+        window.dispatchEvent(event)
+      })
+
+      // Trigger card flip (Wow moment) to trigger prompt immediately
+      await page.click("#cardContainer")
+
+      // Wait for the show transition
+      const dialog = page.locator("#androidInstallDialog")
+      await expect(dialog).toBeVisible()
+      await expect(dialog).toHaveClass(/show/)
+
+      // Click install button
+      const installBtn = page.locator("#androidInstallBtn")
+      await installBtn.click()
+
+      // The dialog should close
+      await expect(dialog).not.toBeVisible()
+
+      // Verify prompt was called
+      const mockPromptCalled = await page.evaluate(
+        () => (window as any).mockPromptCalled
+      )
+      expect(mockPromptCalled).toBe(true)
+    })
+
+    test("should save dismissal and not show dialog on reload", async ({
+      page
+    }) => {
+      await page.goto("/src/mobile-app/index.html")
+
+      // Trigger beforeinstallprompt
+      await page.evaluate(() => {
+        const event = new Event("beforeinstallprompt")
+        ;(event as any).userChoice = Promise.resolve({ outcome: "dismissed" })
+        ;(event as any).prompt = () => Promise.resolve()
+        window.dispatchEvent(event)
+      })
+
+      // Trigger flip to show dialog
+      await page.click("#cardContainer")
+      const dialog = page.locator("#androidInstallDialog")
+      await expect(dialog).toBeVisible()
+
+      // Click dismiss button
+      const dismissBtn = page.locator("#androidDismissBtn")
+      await dismissBtn.click()
+
+      // Dialog should close
+      await expect(dialog).not.toBeVisible()
+
+      // Check localStorage has dismissal timestamp
+      const dismissedUntil = await page.evaluate(() =>
+        localStorage.getItem("a2hs-dismissed-until")
+      )
+      expect(dismissedUntil).toBeTruthy()
+      expect(Number(dismissedUntil)).toBeGreaterThan(Date.now())
+
+      // Reload page
+      await page.reload()
+
+      // Dispatch event again
+      await page.evaluate(() => {
+        const event = new Event("beforeinstallprompt")
+        ;(event as any).userChoice = Promise.resolve({ outcome: "dismissed" })
+        ;(event as any).prompt = () => Promise.resolve()
+        window.dispatchEvent(event)
+      })
+
+      // Trigger flip
+      await page.click("#cardContainer")
+
+      // The dialog should NOT show because of dismissal
+      await expect(dialog).not.toBeVisible()
+    })
+
+    test("should display iOS install tooltip when on iOS Safari and hide on close", async ({
+      page
+    }) => {
+      // Mock iOS UserAgent and standalone = false
+      await page.addInitScript(() => {
+        Object.defineProperty(navigator, "userAgent", {
+          value:
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1",
+          configurable: true
+        })
+        Object.defineProperty(navigator, "standalone", {
+          value: false,
+          configurable: true
+        })
+      })
+
+      await page.goto("/src/mobile-app/index.html")
+
+      // Trigger flip to show iOS tooltip
+      await page.click("#cardContainer")
+
+      const tooltip = page.locator("#iosInstallTooltip")
+      await expect(tooltip).toBeVisible()
+      await expect(tooltip).toHaveClass(/show/)
+
+      // Close iOS tooltip
+      const closeBtn = page.locator("#iosCloseBtn")
+      await closeBtn.click()
+
+      // Tooltip should close
+      await expect(tooltip).not.toBeVisible()
+
+      // Check localStorage
+      const dismissedUntil = await page.evaluate(() =>
+        localStorage.getItem("a2hs-dismissed-until")
+      )
+      expect(dismissedUntil).toBeTruthy()
+    })
+  })
 })


### PR DESCRIPTION
# Walkthrough: PWA A2HS Installation Dialogs (#1214)

Implement platform-optimized "Add to Home Screen" (A2HS) installation prompts for iOS and Android within the Style Atelier Mobile PWA Viewer, matching the codebase's premium styling and strict linting rules.

## 🛠️ Key Implementations

### 1. Platform-Optimized UI & Markup
* **Android/Chrome**: Designed a glassmorphism-based install dialog matching the Atelier theme (radial backgrounds, neon glow, and rounded borders). It allows users to directly launch the browser's native installation prompt.
* **iOS/Safari**: Created a specialized floating callout pointing to the bottom of the screen (where the Safari share button resides) guiding users step-by-step to click "Share" -> "Add to Home Screen". It embeds custom SVG Safari sharing icons.
* Added corresponding semantic HTML elements in [index.html](file:///c:/Users/oculus/Desktop/worktrees/1214-pwa-a2hs-dialog/src/mobile-app/index.html) and premium transition/styling classes in [mobile.css](file:///c:/Users/oculus/Desktop/worktrees/1214-pwa-a2hs-dialog/src/mobile-app/styles/mobile.css).

### 2. A2HS Controller & Modular Logic
* To avoid cluttering the main script and respect the `300-line` limit, we isolated all installation prompts inside [a2hs.ts](file:///c:/Users/oculus/Desktop/worktrees/1214-pwa-a2hs-dialog/src/mobile-app/a2hs.ts).
* **Wow Moment Triggers**: Prompts are deferred and triggered after either a 3-second page load or when the user flips the Style Card for the first time.
* **Dismissal Control**: If the user dismisses the prompt, it saves a timestamp to `localStorage` (`a2hs-dismissed-until`) and suppresses prompts for 14 days.
* **Standalone Mode Protection**: Checks `display-mode: standalone` / `navigator.standalone` to completely bypass initializing the elements if already installed.

### 3. Automated E2E Verification
* Expanded [mobile-pwa.spec.ts](file:///c:/Users/oculus/Desktop/worktrees/1214-pwa-a2hs-dialog/tests/e2e/mobile-pwa.spec.ts) with three new test cases:
  1. **Android Installation Flow**: Mocking `beforeinstallprompt` event dispatch, Wow moment trigger, and verifying that clicking "Install" triggers the native prompt.
  2. **Dismissal & Reload Suppression**: Verifies dismissing the dialog writes a valid timestamp to `localStorage` and blocks prompts on page reload.
  3. **iOS Safari Callout**: Mocks iOS Safari UserAgent and `navigator.standalone = false` environment, verifying the custom guide callout displays and behaves correctly.

## 🧪 Verification Results
* All 136 Vitest Unit Tests pass successfully.
* All 75 Playwright E2E Tests pass successfully, including the updated PWA service worker and new A2HS installation flow tests.
