### PR TITLE
refactor: resolve issue #1238

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -126,7 +126,6 @@ export default ts.config(
   {
     files: [
       "src/placeholder-non-existent-max-lines.ts",
-      "src/components/organisms/Workbench.tsx",
     ],
     rules: {
       "max-lines": "warn"
@@ -145,11 +144,6 @@ export default ts.config(
   {
     files: [
       "src/placeholder-non-existent-func-lines.ts",
-      "src/components/molecules/ConnectionAlert.tsx",
-      "src/components/organisms/OnboardingGuide.tsx",
-      "src/components/organisms/SimpleMintingView.tsx",
-      "src/components/organisms/Workbench.tsx",
-      "src/hooks/useEasyModeView.ts",
     ],
     rules: {
       "max-lines-per-function": "warn"


### PR DESCRIPTION
# Walkthrough: Remove Obsolete ESLint Exceptions

## Overview
This PR removes obsolete ESLint overrides from [eslint.config.mjs](file:///c:/Users/oculus/Desktop/worktrees/1238-remove-eslint-exceptions/eslint.config.mjs). These overrides were originally added to prevent build failures during migration, but the target files now fully comply with the standard linting rules (max-lines and max-lines-per-function).

Applying the standard rules to these files prevents future code regression.

## Changes
The following files were removed from their respective overrides under `eslint.config.mjs`:

1. **`max-lines` (300 lines limit) Exception Removal:**
   - [src/components/organisms/Workbench.tsx](file:///c:/Users/oculus/Desktop/worktrees/1238-remove-eslint-exceptions/src/components/organisms/Workbench.tsx)
2. **`max-lines-per-function` (50 lines limit) Exception Removal:**
   - [src/components/molecules/ConnectionAlert.tsx](file:///c:/Users/oculus/Desktop/worktrees/1238-remove-eslint-exceptions/src/components/molecules/ConnectionAlert.tsx)
   - [src/components/organisms/OnboardingGuide.tsx](file:///c:/Users/oculus/Desktop/worktrees/1238-remove-eslint-exceptions/src/components/organisms/OnboardingGuide.tsx)
   - [src/components/organisms/SimpleMintingView.tsx](file:///c:/Users/oculus/Desktop/worktrees/1238-remove-eslint-exceptions/src/components/organisms/SimpleMintingView.tsx)
   - [src/components/organisms/Workbench.tsx](file:///c:/Users/oculus/Desktop/worktrees/1238-remove-eslint-exceptions/src/components/organisms/Workbench.tsx)
   - [src/hooks/useEasyModeView.ts](file:///c:/Users/oculus/Desktop/worktrees/1238-remove-eslint-exceptions/src/hooks/useEasyModeView.ts)

## Verification Results
- **Linter**: Executed `npm run lint` successfully with no errors or warnings.
- **Unit Tests**: Executed `npm run test` successfully; all 126 test files (1,172 tests) passed.

Closes #1238
