### PR TITLE
chore: resolve issue #1319

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -79,20 +79,24 @@ export default defineConfig({
         viewport: { width: 1920, height: 1080 }
       }
     },
-    {
-      name: "extension",
-      use: {
-        ...devices["Desktop Chrome"],
-        viewport: { width: 1920, height: 1080 },
-        headless: false,
-        args: [
-          `--disable-extensions-except=${path.resolve(__dirname, "build/chrome-mv3-prod")}`,
-          `--load-extension=${path.resolve(__dirname, "build/chrome-mv3-prod")}`,
-          "--no-sandbox",
-          "--disable-setuid-sandbox"
+    ...(!process.env.SKIP_EXTENSION_TESTS
+      ? [
+          {
+            name: "extension",
+            use: {
+              ...devices["Desktop Chrome"],
+              viewport: { width: 1920, height: 1080 },
+              headless: false,
+              args: [
+                `--disable-extensions-except=${path.resolve(__dirname, "build/chrome-mv3-prod")}`,
+                `--load-extension=${path.resolve(__dirname, "build/chrome-mv3-prod")}`,
+                "--no-sandbox",
+                "--disable-setuid-sandbox"
+              ]
+            }
+          }
         ]
-      }
-    }
+      : [])
   ],
 
   /* Run local dev server before starting the tests */

--- a/scripts/smart-pre-push.mjs
+++ b/scripts/smart-pre-push.mjs
@@ -3,6 +3,19 @@ import fs from 'fs/promises';
 import { execSync } from 'child_process';
 import crypto from 'crypto';
 
+function isHeadlessEnvironment() {
+  if (process.env.SKIP_EXTENSION_TESTS === 'true') {
+    return true;
+  }
+  if (process.env.CI) {
+    return true;
+  }
+  if (process.platform !== 'win32' && process.platform !== 'darwin' && !process.env.DISPLAY) {
+    return true;
+  }
+  return false;
+}
+
 async function main() {
   console.log('Running Smart Pre-Push...');
   
@@ -142,6 +155,11 @@ async function main() {
 
   // 8. Run E2E
   console.log('\n--- Running E2E Tests ---');
+  if (isHeadlessEnvironment()) {
+    console.log('⚠️ Headless environment detected. Skipping extension E2E tests (SKIP_EXTENSION_TESTS will be set).');
+    process.env.SKIP_EXTENSION_TESTS = 'true';
+  }
+
   if (testedJourneys.length > 0) {
     try {
       // Create grep pattern: e.g. "(@J-01|@J-02)"
@@ -157,13 +175,17 @@ async function main() {
     // If src files changed but NO journey was matched, it means we don't have coverage defined, OR it's an orphan file.
     // We should probably run ALL E2E just to be safe, or fail.
     console.log('WARNING: Changed files did not map to any View Components defined in userJourneys.json.');
-    console.log('Running ALL E2E tests to be safe.');
-    try {
-      execSync(`npx playwright test --retries=2`, { stdio: 'inherit' });
-      testedJourneys.push('ALL'); // Indicate all were run
-    } catch {
-      console.error('E2E tests failed.');
-      process.exit(1);
+    if (isHeadlessEnvironment()) {
+      console.warn('⚠️ WARNING: Headless environment detected. Skipping E2E tests fallback to prevent browser startup failure.');
+    } else {
+      console.log('Running ALL E2E tests to be safe.');
+      try {
+        execSync(`npx playwright test --retries=2`, { stdio: 'inherit' });
+        testedJourneys.push('ALL'); // Indicate all were run
+      } catch {
+        console.error('E2E tests failed.');
+        process.exit(1);
+      }
     }
   } else {
     console.log('No source code changes requiring E2E tests.');


### PR DESCRIPTION
# Walkthrough: Headless E2E Test Stabilization

This PR resolves #1319 by introducing a headless environment check and a mechanism to opt out of the Chromium extension E2E tests in GUI-less environments.

## 🛠️ Changes

### 1. Playwright Configuration ([playwright.config.ts](file:///c:/Users/oculus/Desktop/worktrees/1319-ci-headless-test-stabilize/playwright.config.ts))
- Conditionally registers the `extension` project (which requires a GUI session because of `headless: false` with extension loading) only if `process.env.SKIP_EXTENSION_TESTS` is not set.

### 2. Smart Pre-Push Script ([scripts/smart-pre-push.mjs](file:///c:/Users/oculus/Desktop/worktrees/1319-ci-headless-test-stabilize/scripts/smart-pre-push.mjs))
- Added `isHeadlessEnvironment()` to detect whether the environment has GUI capabilities. It returns `true` if `SKIP_EXTENSION_TESTS` is already set, if `CI` is set, or if running on Linux/macOS without a `DISPLAY` env var.
- Sets `process.env.SKIP_EXTENSION_TESTS = 'true'` automatically in headless environments prior to running Playwright tests.
- Skips the fallback "ALL E2E" tests block in headless environments with a warning rather than failing or timing out.

## 🧪 Verification

- Verified that listing Playwright tests with `SKIP_EXTENSION_TESTS=true` correctly filters out the `extension` project and only includes the `chromium` project:
  ```bash
  $env:SKIP_EXTENSION_TESTS="true"; npx playwright test --list
  # Total: 170 tests in 75 files (only chromium project)
  ```
- Checked that running normally includes both projects:
  ```bash
  npx playwright test --list
  # Total: 340 tests in 75 files (both chromium and extension)
  ```
