### PR TITLE
feat: prevent test config path mismatch (#1327)

### DIFF
--- a/scratch/check-vitest-coverage-exceptions.js
+++ b/scratch/check-vitest-coverage-exceptions.js
@@ -175,35 +175,6 @@ for (const key of keys) {
   }
 }
 
-// 3. Check reportsDirectory mismatch (Issue #1327)
-const extractReportsDirectory = (content) => {
-  const match = content.match(/reportsDirectory:\s*([^\n,]+)/);
-  return match ? match[1].trim() : null;
-};
-
-const currentReportsDir = extractReportsDirectory(currentContent);
-if (currentReportsDir) {
-  const isCIValid = (
-    (currentReportsDir.includes('process.env.CI') && (
-      currentReportsDir.includes('"./coverage"') || 
-      currentReportsDir.includes("'./coverage'") || 
-      currentReportsDir.includes('"coverage"') || 
-      currentReportsDir.includes("'coverage'")
-    )) ||
-    currentReportsDir === '"./coverage"' ||
-    currentReportsDir === "'./coverage'" ||
-    currentReportsDir === '"coverage"' ||
-    currentReportsDir === "'coverage'"
-  );
-
-  if (!isCIValid) {
-    console.error(`\x1b[31mError: reportsDirectory in vitest.config.ts is set to: ${currentReportsDir}\x1b[0m`);
-    console.error(`\x1b[31mIn CI environments, the reportsDirectory MUST resolve to "./coverage" (or "coverage") to match .github/workflows/ci.yml.\x1b[0m`);
-    console.error(`\x1b[31mPlease use: reportsDirectory: process.env.CI ? "./coverage" : "./coverage-qa" (or omit it entirely).\x1b[0m`);
-    hasError = true;
-  }
-}
-
 if (hasError) {
   console.error('\n\x1b[31mVerification failed! You are not allowed to add new coverage exceptions, lower thresholds, or break reportsDirectory consistency.\x1b[0m');
   process.exit(1);
@@ -211,3 +182,4 @@ if (hasError) {
   console.log('\x1b[32mVerification passed! Coverage exclusions, thresholds, and reportsDirectory are all valid.\x1b[0m');
   process.exit(0);
 }
+

--- a/scratch/check-vitest-coverage-exceptions.js
+++ b/scratch/check-vitest-coverage-exceptions.js
@@ -88,6 +88,38 @@ const extractThresholds = (content) => {
   return thresholds;
 };
 
+const extractReportsDirectory = (content) => {
+  const coverageIdx = content.indexOf('coverage:');
+  if (coverageIdx === -1) return null;
+  const afterCoverage = content.slice(coverageIdx);
+  
+  const regex = /reportsDirectory:\s*([^\n,]+)/;
+  const match = afterCoverage.match(regex);
+  if (match) {
+    return match[1].trim();
+  }
+  return null;
+};
+
+const isValidReportsDirectory = (value) => {
+  if (!value) return true; // Undefined defaults to ./coverage in vitest
+  
+  const normalized = value.replace(/'/g, '"');
+  
+  // Case 1: Hardcoded to "./coverage" or "coverage"
+  if (normalized === '"./coverage"' || normalized === '"coverage"') {
+    return true;
+  }
+  
+  // Case 2: Conditional expression that resolves to "./coverage" or "coverage" when process.env.CI is true
+  const ciCondRegex = /process\.env\.CI\s*\?\s*"(\.?\/coverage)"\s*:\s*.+/;
+  if (ciCondRegex.test(normalized)) {
+    return true;
+  }
+  
+  return false;
+};
+
 if (!fs.existsSync(currentPath)) {
   console.error(`Current config file not found: ${currentPath}`);
   process.exit(1);
@@ -101,6 +133,16 @@ const currentThresholds = extractThresholds(currentContent);
 const targetThresholds = extractThresholds(targetContent);
 
 let hasError = false;
+
+// 0. Check reportsDirectory mismatch
+const currentReportsDir = extractReportsDirectory(currentContent);
+if (!isValidReportsDirectory(currentReportsDir)) {
+  console.error(`\x1b[31mError: reportsDirectory is set to an invalid path: "${currentReportsDir}"\x1b[0m`);
+  console.error(`  reportsDirectory must either be undefined (defaulting to ./coverage), hardcoded to "./coverage",`);
+  console.error(`  or use a condition that falls back to "./coverage" when process.env.CI is true`);
+  console.error(`  (e.g., process.env.CI ? "./coverage" : "./coverage-qa").`);
+  hasError = true;
+}
 
 // 1. Check newly added excludes
 const targetSet = new Set(targetExcludes);

--- a/tests/unit/vitest-config.test.ts
+++ b/tests/unit/vitest-config.test.ts
@@ -90,10 +90,15 @@ describe("Vitest Configuration & Coverage Exception Check Script", () => {
       let errOccurred = false
       try {
         execSync(`node "${scriptPath}" "${validFile}" "${validFile}"`, {
-          stdio: "ignore"
+          stdio: "pipe"
         })
-      } catch (e) {
+      } catch (e: any) {
         errOccurred = true
+        console.error(
+          "Scenario A failed:",
+          e.stdout?.toString(),
+          e.stderr?.toString()
+        )
       }
       expect(errOccurred).toBe(false)
 
@@ -102,10 +107,15 @@ describe("Vitest Configuration & Coverage Exception Check Script", () => {
       try {
         execSync(
           `node "${scriptPath}" "${validStaticFile}" "${validStaticFile}"`,
-          { stdio: "ignore" }
+          { stdio: "pipe" }
         )
-      } catch (e) {
+      } catch (e: any) {
         errOccurred = true
+        console.error(
+          "Scenario B failed:",
+          e.stdout?.toString(),
+          e.stderr?.toString()
+        )
       }
       expect(errOccurred).toBe(false)
 
@@ -113,16 +123,18 @@ describe("Vitest Configuration & Coverage Exception Check Script", () => {
       errOccurred = false
       try {
         execSync(`node "${scriptPath}" "${invalidFile}" "${invalidFile}"`, {
-          stdio: "ignore"
+          stdio: "pipe"
         })
-      } catch (e) {
+      } catch (e: any) {
         errOccurred = true
       }
       expect(errOccurred).toBe(true)
     } finally {
-      // Clean up
-      if (fs.existsSync(tempDir)) {
+      // Cleanup
+      try {
         fs.rmSync(tempDir, { recursive: true, force: true })
+      } catch (e) {
+        // Ignore cleanup errors
       }
     }
   })

--- a/tests/unit/vitest-config.test.ts
+++ b/tests/unit/vitest-config.test.ts
@@ -1,0 +1,129 @@
+import { execSync } from "child_process"
+import fs from "fs"
+import path from "path"
+import { describe, expect, it } from "vitest"
+
+describe("Vitest Configuration & Coverage Exception Check Script", () => {
+  it("should have correct reportsDirectory resolving dynamically based on CI env", async () => {
+    const configModule = await import("../../vitest.config")
+    const config = configModule.default
+
+    expect(config.test).toBeDefined()
+    expect(config.test.coverage).toBeDefined()
+
+    const originalCI = process.env.CI
+    try {
+      if (originalCI) {
+        expect(config.test.coverage.reportsDirectory).toBe("./coverage")
+      } else {
+        expect(config.test.coverage.reportsDirectory).toBe("./coverage-qa")
+      }
+    } finally {
+      process.env.CI = originalCI
+    }
+  })
+
+  it("should validate check-vitest-coverage-exceptions.js behavior", () => {
+    const scriptPath = path.resolve(
+      __dirname,
+      "../../scratch/check-vitest-coverage-exceptions.js"
+    )
+
+    // Create temporary directory for test fixtures
+    const tempDir = path.resolve(__dirname, "temp-fixtures")
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir)
+    }
+
+    try {
+      // Scenario A: Valid configuration with process.env.CI dynamic expression
+      const validConfigContent = `
+        import { defineConfig } from "vitest/config"
+        export default defineConfig({
+          test: {
+            coverage: {
+              reportsDirectory: process.env.CI ? "./coverage" : "./coverage-qa",
+              exclude: ["node_modules/**"],
+              thresholds: { statements: 80 }
+            }
+          }
+        })
+      `
+
+      // Scenario B: Invalid configuration (wrong reportsDirectory)
+      const invalidConfigContent = `
+        import { defineConfig } from "vitest/config"
+        export default defineConfig({
+          test: {
+            coverage: {
+              reportsDirectory: "./wrong-coverage",
+              exclude: ["node_modules/**"],
+              thresholds: { statements: 80 }
+            }
+          }
+        })
+      `
+
+      // Scenario C: Valid static configuration (direct "./coverage")
+      const validStaticConfigContent = `
+        import { defineConfig } from "vitest/config"
+        export default defineConfig({
+          test: {
+            coverage: {
+              reportsDirectory: "./coverage",
+              exclude: ["node_modules/**"],
+              thresholds: { statements: 80 }
+            }
+          }
+        })
+      `
+
+      const validFile = path.join(tempDir, "vitest.valid.config.ts")
+      const invalidFile = path.join(tempDir, "vitest.invalid.config.ts")
+      const validStaticFile = path.join(tempDir, "vitest.validstatic.config.ts")
+
+      fs.writeFileSync(validFile, validConfigContent, "utf8")
+      fs.writeFileSync(invalidFile, invalidConfigContent, "utf8")
+      fs.writeFileSync(validStaticFile, validStaticConfigContent, "utf8")
+
+      // Run the script with valid config. Comparing against valid config (itself) to skip threshold check errors.
+      let errOccurred = false
+      try {
+        execSync(`node "${scriptPath}" "${validFile}" "${validFile}"`, {
+          stdio: "ignore"
+        })
+      } catch (e) {
+        errOccurred = true
+      }
+      expect(errOccurred).toBe(false)
+
+      // Run with static valid config.
+      errOccurred = false
+      try {
+        execSync(
+          `node "${scriptPath}" "${validStaticFile}" "${validStaticFile}"`,
+          { stdio: "ignore" }
+        )
+      } catch (e) {
+        errOccurred = true
+      }
+      expect(errOccurred).toBe(false)
+
+      // Run with invalid config.
+      errOccurred = false
+      try {
+        execSync(`node "${scriptPath}" "${invalidFile}" "${invalidFile}"`, {
+          stdio: "ignore"
+        })
+      } catch (e) {
+        errOccurred = true
+      }
+      expect(errOccurred).toBe(true)
+    } finally {
+      // Clean up
+      if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true, force: true })
+      }
+    }
+  })
+})


### PR DESCRIPTION
Resolves #1327 by enforcing vitest reportsDirectory path matching in pre-push check.