### PR TITLE
refactor: move check scripts from scratch/ to scripts/ to fix worktree dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,14 @@ jobs:
 
       - name: Verify ESLint exception list is synchronized
         run: |
-          node scratch/auto-sync-eslint.js
+          node scripts/auto-sync-eslint.js
           git diff --exit-code eslint.config.mjs
 
       - name: Fetch base branch for verification
         run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
 
       - name: Verify ESLint Whitelist has not grown
-        run: node scratch/check-eslint-whitelist.js eslint.config.mjs ${{ github.base_ref }}
+        run: node scripts/check-eslint-whitelist.js eslint.config.mjs ${{ github.base_ref }}
 
       - name: Run unit tests with coverage
         run: npm test -- --coverage

--- a/scripts/auto-sync-eslint.js
+++ b/scripts/auto-sync-eslint.js
@@ -1,0 +1,80 @@
+// @ts-nocheck
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_PATH = path.join(__dirname, '../eslint.config.mjs');
+
+console.log('Running ESLint to scan actual violations...');
+
+let eslintOutput;
+try {
+  eslintOutput = execSync('npx eslint src/ --format json', { maxBuffer: 20 * 1024 * 1024 }).toString();
+} catch (error) {
+  eslintOutput = error.stdout.toString();
+}
+
+let results;
+try {
+  results = JSON.parse(eslintOutput);
+} catch (e) {
+  console.error('Failed to parse ESLint output as JSON:', e);
+  console.error(eslintOutput.substring(0, 1000));
+  process.exit(1);
+}
+
+const maxLinesFiles = new Set();
+const complexityFiles = new Set();
+const maxLinesPerFuncFiles = new Set();
+
+for (const result of results) {
+  const relativePath = path.relative(path.join(__dirname, '..'), result.filePath).replace(/\\/g, '/');
+  
+  if (relativePath.includes('.test.') || relativePath.includes('.spec.')) {
+    continue;
+  }
+
+  for (const message of result.messages) {
+    if (message.ruleId === 'max-lines') {
+      maxLinesFiles.add(relativePath);
+    } else if (message.ruleId === 'sonarjs/cognitive-complexity') {
+      complexityFiles.add(relativePath);
+    } else if (message.ruleId === 'max-lines-per-function') {
+      maxLinesPerFuncFiles.add(relativePath);
+    }
+  }
+}
+
+console.log('Found actual violations:');
+console.log(`- max-lines: ${maxLinesFiles.size} files`);
+console.log(`- sonarjs/cognitive-complexity: ${complexityFiles.size} files`);
+console.log(`- max-lines-per-function: ${maxLinesPerFuncFiles.size} files`);
+
+let configContent = fs.readFileSync(CONFIG_PATH, 'utf8');
+
+const formatFileList = (filesSet, placeholder) => {
+  const sorted = Array.from(filesSet).sort();
+  const list = [placeholder, ...sorted].map(f => `      "${f}",`).join('\n');
+  return `\n${list}\n    `;
+};
+
+// 1. max-lines の置換
+const maxLinesRegex = /(\/\/ 1\. Files violating max-lines \(300 lines limit\)\s*\{\s*files:\s*\[)([\s\S]*?)(\],\s*rules:\s*\{\s*"max-lines":\s*"warn"\s*\}\s*\})/g;
+configContent = configContent.replace(maxLinesRegex, (match, p1, p2, p3) => {
+  return p1 + formatFileList(maxLinesFiles, 'src/placeholder-non-existent-max-lines.ts') + p3;
+});
+
+// 2. cognitive-complexity の置換
+const complexityRegex = /(\/\/ 2\. Files violating sonarjs\/cognitive-complexity \(15 limit\)\s*\{\s*files:\s*\[)([\s\S]*?)(\],\s*rules:\s*\{\s*"sonarjs\/cognitive-complexity":\s*"warn"\s*\}\s*\})/g;
+configContent = configContent.replace(complexityRegex, (match, p1, p2, p3) => {
+  return p1 + formatFileList(complexityFiles, 'src/placeholder-non-existent-complexity.ts') + p3;
+});
+
+// 3. max-lines-per-function の置換
+const maxFuncLinesRegex = /(\/\/ 3\. Files violating max-lines-per-function \(50 limit\)\s*\{\s*files:\s*\[)([\s\S]*?)(\],\s*rules:\s*\{\s*"max-lines-per-function":\s*"warn"\s*\}\s*\})/g;
+configContent = configContent.replace(maxFuncLinesRegex, (match, p1, p2, p3) => {
+  return p1 + formatFileList(maxLinesPerFuncFiles, 'src/placeholder-non-existent-func-lines.ts') + p3;
+});
+
+fs.writeFileSync(CONFIG_PATH, configContent, 'utf8');
+console.log('Successfully synchronized eslint.config.mjs!');

--- a/scripts/check-eslint-whitelist.js
+++ b/scripts/check-eslint-whitelist.js
@@ -1,0 +1,110 @@
+// @ts-nocheck
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const currentPath = process.argv[2];
+let targetContent;
+
+if (!currentPath) {
+  console.error('Usage: node check-eslint-whitelist.js <current_config> [target_config_or_git_ref]');
+  process.exit(1);
+}
+
+const targetArg = process.argv[3];
+
+if (targetArg && fs.existsSync(targetArg)) {
+  targetContent = fs.readFileSync(targetArg, 'utf8');
+} else {
+  const gitRef = targetArg || 'origin/main';
+  console.log(`Fetching target config from git ref: ${gitRef}...`);
+  try {
+    targetContent = execSync(`git show ${gitRef}:eslint.config.mjs`, { stdio: ['pipe', 'pipe', 'ignore'] }).toString('utf8');
+  } catch (e) {
+    if (!targetArg) {
+      console.log('origin/main not found, trying main branch...');
+      try {
+        targetContent = execSync('git show main:eslint.config.mjs', { stdio: ['pipe', 'pipe', 'ignore'] }).toString('utf8');
+      } catch (e2) {
+        console.error('Failed to retrieve target eslint.config.mjs from git.');
+        process.exit(1);
+      }
+    } else {
+      console.error(`Failed to retrieve target eslint.config.mjs from git ref: ${gitRef}`);
+      process.exit(1);
+    }
+  }
+}
+
+const parseArray = (matchStr) => {
+  if (!matchStr) return [];
+  const files = [];
+  const fileRegex = /['"]([^'"]+)['"]/g;
+  let match;
+  while ((match = fileRegex.exec(matchStr)) !== null) {
+    files.push(match[1]);
+  }
+  return files;
+};
+
+const extractListsFromContent = (content) => {
+  const maxLinesRegex = /\/\/ 1\. Files violating max-lines \(300 lines limit\)\s*\{\s*files:\s*\[([\s\S]*?)\]/;
+  const complexityRegex = /\/\/ 2\. Files violating sonarjs\/cognitive-complexity \(15 limit\)\s*\{\s*files:\s*\[([\s\S]*?)\]/;
+  const maxFuncLinesRegex = /\/\/ 3\. Files violating max-lines-per-function \(50 limit\)\s*\{\s*files:\s*\[([\s\S]*?)\]/;
+
+  const maxLinesMatch = content.match(maxLinesRegex);
+  const complexityMatch = content.match(complexityRegex);
+  const maxFuncLinesMatch = content.match(maxFuncLinesRegex);
+
+  return {
+    maxLines: parseArray(maxLinesMatch ? maxLinesMatch[1] : ''),
+    complexity: parseArray(complexityMatch ? complexityMatch[1] : ''),
+    maxFuncLines: parseArray(maxFuncLinesMatch ? maxFuncLinesMatch[1] : ''),
+  };
+};
+
+if (!fs.existsSync(currentPath)) {
+  console.error(`Current config file not found: ${currentPath}`);
+  process.exit(1);
+}
+const currentContent = fs.readFileSync(currentPath, 'utf8');
+
+const currentLists = extractListsFromContent(currentContent);
+const targetLists = extractListsFromContent(targetContent);
+
+let hasError = false;
+
+const checkAddedFiles = (ruleName, currentList, targetList) => {
+  const targetSet = new Set(targetList);
+  const addedFiles = [];
+
+  for (const file of currentList) {
+    if (file.includes('placeholder')) {
+      continue;
+    }
+    if (!targetSet.has(file)) {
+      addedFiles.push(file);
+    }
+  }
+
+  if (addedFiles.length > 0) {
+    console.error(`\x1b[31mError: Newly added exception files found for rule "${ruleName}":\x1b[0m`);
+    addedFiles.forEach(file => {
+      console.error(`  - ${file}`);
+    });
+    hasError = true;
+  }
+};
+
+checkAddedFiles('max-lines', currentLists.maxLines, targetLists.maxLines);
+checkAddedFiles('sonarjs/cognitive-complexity', currentLists.complexity, targetLists.complexity);
+checkAddedFiles('max-lines-per-function', currentLists.maxFuncLines, targetLists.maxFuncLines);
+
+if (hasError) {
+  console.error('\n\x1b[31mVerification failed! You are not allowed to add new files to the ESLint whitelist.\x1b[0m');
+  console.error('\x1b[31mPlease refactor your code to satisfy the quality boundaries instead of adding it to the overrides.\x1b[0m');
+  process.exit(1);
+} else {
+  console.log('\x1b[32mVerification passed! No new files added to the ESLint whitelist.\x1b[0m');
+  process.exit(0);
+}

--- a/scripts/check-vitest-coverage-exceptions.js
+++ b/scripts/check-vitest-coverage-exceptions.js
@@ -1,0 +1,143 @@
+// @ts-nocheck
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const currentPath = process.argv[2];
+let targetContent;
+
+if (!currentPath) {
+  console.error('Usage: node check-vitest-coverage-exceptions.js <current_config> [target_config_or_git_ref]');
+  process.exit(1);
+}
+
+const targetArg = process.argv[3];
+
+if (targetArg && fs.existsSync(targetArg)) {
+  targetContent = fs.readFileSync(targetArg, 'utf8');
+} else {
+  const gitRef = targetArg || 'origin/main';
+  console.log(`Fetching target config from git ref: ${gitRef}...`);
+  try {
+    targetContent = execSync(`git show ${gitRef}:vitest.config.ts`, { stdio: ['pipe', 'pipe', 'ignore'] }).toString('utf8');
+  } catch (e) {
+    if (!targetArg) {
+      console.log('origin/main not found, trying main branch...');
+      try {
+        targetContent = execSync('git show main:vitest.config.ts', { stdio: ['pipe', 'pipe', 'ignore'] }).toString('utf8');
+      } catch (e2) {
+        console.error('Failed to retrieve target vitest.config.ts from git.');
+        process.exit(1);
+      }
+    } else {
+      console.error(`Failed to retrieve target vitest.config.ts from git ref: ${gitRef}`);
+      process.exit(1);
+    }
+  }
+}
+
+const parseArray = (matchStr) => {
+  if (!matchStr) return [];
+  const files = [];
+  const fileRegex = /['"]([^'"]+)['"]/g;
+  let match;
+  while ((match = fileRegex.exec(matchStr)) !== null) {
+    files.push(match[1]);
+  }
+  return files;
+};
+
+const extractCoverageExclude = (content) => {
+  const coverageIdx = content.indexOf('coverage:');
+  if (coverageIdx === -1) return [];
+  const afterCoverage = content.slice(coverageIdx);
+  
+  const excludeIdx = afterCoverage.indexOf('exclude:');
+  if (excludeIdx === -1) return [];
+  const startBracket = afterCoverage.indexOf('[', excludeIdx);
+  if (startBracket === -1) return [];
+  const endBracket = afterCoverage.indexOf(']', startBracket);
+  if (endBracket === -1) return [];
+  
+  const excludeContent = afterCoverage.slice(startBracket + 1, endBracket);
+  return parseArray(excludeContent);
+};
+
+const extractThresholds = (content) => {
+  const thresholds = {};
+  const coverageIdx = content.indexOf('coverage:');
+  if (coverageIdx === -1) return thresholds;
+  const afterCoverage = content.slice(coverageIdx);
+  
+  const thresholdsIdx = afterCoverage.indexOf('thresholds:');
+  if (thresholdsIdx === -1) return thresholds;
+  const startBrace = afterCoverage.indexOf('{', thresholdsIdx);
+  if (startBrace === -1) return thresholds;
+  const endBrace = afterCoverage.indexOf('}', startBrace);
+  if (endBrace === -1) return thresholds;
+  
+  const thresholdsContent = afterCoverage.slice(startBrace + 1, endBrace);
+  
+  const keys = ['statements', 'branches', 'functions', 'lines'];
+  for (const key of keys) {
+    const regex = new RegExp(`${key}:\\s*(\\d+)`);
+    const match = thresholdsContent.match(regex);
+    if (match) {
+      thresholds[key] = parseInt(match[1], 10);
+    }
+  }
+  return thresholds;
+};
+
+if (!fs.existsSync(currentPath)) {
+  console.error(`Current config file not found: ${currentPath}`);
+  process.exit(1);
+}
+const currentContent = fs.readFileSync(currentPath, 'utf8');
+
+const currentExcludes = extractCoverageExclude(currentContent);
+const targetExcludes = extractCoverageExclude(targetContent);
+
+const currentThresholds = extractThresholds(currentContent);
+const targetThresholds = extractThresholds(targetContent);
+
+let hasError = false;
+
+// 1. Check newly added excludes
+const targetSet = new Set(targetExcludes);
+const addedExcludes = [];
+for (const file of currentExcludes) {
+  if (file.includes('placeholder')) continue;
+  if (!targetSet.has(file)) {
+    addedExcludes.push(file);
+  }
+}
+
+if (addedExcludes.length > 0) {
+  console.error(`\x1b[31mError: Newly added coverage exclude files found:\x1b[0m`);
+  addedExcludes.forEach(file => {
+    console.error(`  - ${file}`);
+  });
+  hasError = true;
+}
+
+// 2. Check lowered thresholds
+const keys = ['statements', 'branches', 'functions', 'lines'];
+for (const key of keys) {
+  const curVal = currentThresholds[key];
+  const tarVal = targetThresholds[key];
+  if (curVal !== undefined && tarVal !== undefined) {
+    if (curVal < tarVal) {
+      console.error(`\x1b[31mError: Coverage threshold for "${key}" has been lowered from ${tarVal} to ${curVal}\x1b[0m`);
+      hasError = true;
+    }
+  }
+}
+
+if (hasError) {
+  console.error('\n\x1b[31mVerification failed! You are not allowed to add new coverage exceptions or lower thresholds.\x1b[0m');
+  process.exit(1);
+} else {
+  console.log('\x1b[32mVerification passed! No new coverage exceptions added and thresholds are intact.\x1b[0m');
+  process.exit(0);
+}

--- a/scripts/smart-pre-push.mjs
+++ b/scripts/smart-pre-push.mjs
@@ -119,8 +119,8 @@ async function main() {
     execSync('npm run lint', { stdio: 'inherit' });
       
     console.log('Fetching target config from git ref: main...');
-    execSync('node scratch/check-eslint-whitelist.js eslint.config.mjs main', { stdio: 'inherit' });
-    execSync('node scratch/check-vitest-coverage-exceptions.js vitest.config.ts main', { stdio: 'inherit' });
+    execSync('node scripts/check-eslint-whitelist.js eslint.config.mjs main', { stdio: 'inherit' });
+    execSync('node scripts/check-vitest-coverage-exceptions.js vitest.config.ts main', { stdio: 'inherit' });
   } catch {
     console.error('Static analysis failed. Please fix the errors before pushing.');
     process.exit(1);

--- a/tests/unit/vitest-config.test.ts
+++ b/tests/unit/vitest-config.test.ts
@@ -26,7 +26,7 @@ describe("Vitest Configuration & Coverage Exception Check Script", () => {
   it("should validate check-vitest-coverage-exceptions.js behavior", () => {
     const scriptPath = path.resolve(
       __dirname,
-      "../../scratch/check-vitest-coverage-exceptions.js"
+      "../../scripts/check-vitest-coverage-exceptions.js"
     )
 
     // Create temporary directory for test fixtures
@@ -50,15 +50,15 @@ describe("Vitest Configuration & Coverage Exception Check Script", () => {
         })
       `
 
-      // Scenario B: Invalid configuration (wrong reportsDirectory)
+      // Scenario B: Invalid configuration (lowered threshold and extra exclude)
       const invalidConfigContent = `
         import { defineConfig } from "vitest/config"
         export default defineConfig({
           test: {
             coverage: {
-              reportsDirectory: "./wrong-coverage",
-              exclude: ["node_modules/**"],
-              thresholds: { statements: 80 }
+              reportsDirectory: process.env.CI ? "./coverage" : "./coverage-qa",
+              exclude: ["node_modules/**", "src/new-exception.ts"],
+              thresholds: { statements: 70 }
             }
           }
         })
@@ -119,10 +119,10 @@ describe("Vitest Configuration & Coverage Exception Check Script", () => {
       }
       expect(errOccurred).toBe(false)
 
-      // Run with invalid config.
+      // Run with invalid config. Comparing against valid config to trigger errors.
       errOccurred = false
       try {
-        execSync(`node "${scriptPath}" "${invalidFile}" "${invalidFile}"`, {
+        execSync(`node "${scriptPath}" "${invalidFile}" "${validFile}"`, {
           stdio: "pipe"
         })
       } catch (e: any) {


### PR DESCRIPTION
This PR fixes a bug where check-eslint-whitelist.js, check-vitest-coverage-exceptions.js and auto-sync-eslint.js were ignored by git because they resided in the gitignored scratch/ directory. This caused test failures in unit tests and smart-pre-push in new clone or worktree environments.