### PR TITLE
fix: resolve text truncation in GlobalDownloadIndicator on narrow viewports (#1405)

### DIFF
--- a/memory-bank/userJourneys.json
+++ b/memory-bank/userJourneys.json
@@ -611,6 +611,7 @@
         "src/components/organisms/WebLlmSettingsSection.tsx",
         "src/components/organisms/WebLlmSettingsSubComponents.tsx",
         "src/components/molecules/AiDownloadStatus.tsx",
+        "src/components/molecules/GlobalDownloadIndicator.tsx",
         "src/lib/ai/opfs-cache-manager.ts",
         "src/litert.worker.ts"
       ]

--- a/src/components/molecules/GlobalDownloadIndicator.tsx
+++ b/src/components/molecules/GlobalDownloadIndicator.tsx
@@ -37,22 +37,28 @@ interface DownloadingContentProps {
 
 function DownloadingContent({ progress, t }: DownloadingContentProps) {
   return (
-    <div className="flex items-center gap-3 w-full">
-      <div className="flex items-center gap-1.5 shrink-0 font-bold text-indigo-600 dark:text-indigo-400">
-        <Loader2 className="w-4 h-4 animate-spin" />
-        <span>📥 {progress}%</span>
-      </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-[10px] sm:text-xs text-slate-500 dark:text-slate-400 truncate font-medium">
-          {t.webLlmGlobalAnxietyMicrocopy ||
-            "Downloading safely in the background. You can navigate away."}
-        </p>
-        <div className="w-full bg-slate-100 dark:bg-slate-800 rounded-full h-1 mt-1 overflow-hidden">
-          <div
-            className="bg-indigo-600 dark:bg-indigo-500 h-full transition-all duration-300"
-            style={{ width: `${progress}%` }}
-          />
+    <div className="flex flex-col gap-1.5 w-full">
+      <div className="flex items-center justify-between text-[11px] sm:text-xs gap-3">
+        <div className="flex items-center gap-1.5 shrink-0 font-bold text-indigo-600 dark:text-indigo-400">
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          <span>📥 {progress}%</span>
         </div>
+        <p className="text-[10px] sm:text-xs text-slate-500 dark:text-slate-400 font-medium text-right leading-tight">
+          <span className="hidden sm:inline">
+            {t.webLlmGlobalAnxietyMicrocopy ||
+              "Downloading safely in the background. You can navigate away."}
+          </span>
+          <span className="inline sm:hidden">
+            {t.webLlmGlobalAnxietyMicrocopyShort ||
+              "Downloading in background. Feel free to navigate away."}
+          </span>
+        </p>
+      </div>
+      <div className="w-full bg-slate-100 dark:bg-slate-800 rounded-full h-1.5 overflow-hidden">
+        <div
+          className="bg-indigo-600 dark:bg-indigo-500 h-full transition-all duration-300"
+          style={{ width: `${progress}%` }}
+        />
       </div>
     </div>
   )

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -279,6 +279,7 @@
     "webLlmWebGpuOpenSettingsBtn": "Open Chrome Settings",
     "webLlmDownloadBtnUnsupported": "WebGPU Not Supported (Download Disabled)",
     "webLlmGlobalAnxietyMicrocopy": "Downloading safely in the background. You can navigate away from this screen.",
+    "webLlmGlobalAnxietyMicrocopyShort": "Downloading in background. Feel free to navigate away.",
     "webLlmGlobalQuotaWarning": "Insufficient space (Minimum 2GB required)",
     "webLlmGlobalCleanupBtn": "Clean up storage"
   },

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -279,6 +279,7 @@
     "webLlmWebGpuOpenSettingsBtn": "Chrome設定を開く",
     "webLlmDownloadBtnUnsupported": "WebGPU非対応のためダウンロード不可",
     "webLlmGlobalAnxietyMicrocopy": "バックグラウンドで安全に進行中。別の画面へ移動しても問題ありません",
+    "webLlmGlobalAnxietyMicrocopyShort": "バックグラウンドでダウンロード中。移動しても大丈夫です",
     "webLlmGlobalQuotaWarning": "空き容量が不足しています（最低2GB必要）",
     "webLlmGlobalCleanupBtn": "ストレージを整理する"
   },

--- a/tests/e2e/litert-global-indicator.spec.ts
+++ b/tests/e2e/litert-global-indicator.spec.ts
@@ -188,4 +188,92 @@ test.describe("Style Atelier Sandbox E2E Tests - LiteRT-LM Global Indicator & Qu
     await expect(storageWrapper).toBeVisible()
     console.log("Redirected to Storage Manager successfully on Clean Up click.")
   })
+
+  test("should display global progress indicator nicely on narrow viewport", async ({
+    page
+  }) => {
+    const screenshotsDir = path.join(__dirname, "../../tests/screenshots")
+    console.log(
+      "Navigating to sandbox page for LiteRT-LM Global Indicator narrow viewport test..."
+    )
+    await page.goto("/tests/sandbox/index.html")
+
+    // Shrink sidepanel frame width to 300px to simulate narrow viewport
+    await page.locator("#sidepanel-frame").evaluate((el) => {
+      el.style.width = "300px"
+    })
+    await page.waitForTimeout(500)
+
+    const spFrame = page.frameLocator("#sidepanel-frame")
+
+    // Skip welcome dialog
+    const skipButton = spFrame.locator("#welcome-skip-btn")
+    if (await skipButton.isVisible({ timeout: 15000 }).catch(() => false)) {
+      await skipButton.click({ force: true })
+    }
+
+    // 1. Setup mock config for slow download and trigger download from Settings
+    const settingsTabBtn = spFrame
+      .locator("button:has-text('Settings'), button:has-text('設定')")
+      .first()
+    await settingsTabBtn.click({ force: true })
+    await page.waitForTimeout(500)
+
+    // Open WebLLM accordion
+    const webllmHeader = spFrame.locator("#settings-accordion-webllm")
+    await webllmHeader.click({ force: true })
+    await page.waitForTimeout(500)
+
+    // Inject mock config setting
+    await spFrame.locator("body").evaluate(() => {
+      const config = (window as any).mockWebLlmConfig
+      if (config) {
+        config.quotaSufficient = true
+        config.failDownload = false
+        config.downloadSpeed = 800 // Slow speed to capture downloading state
+      }
+    })
+
+    // Click Download button inside WebLLM settings
+    const downloadBtn = spFrame
+      .locator(
+        "#webllm-settings-section-wrapper button:has-text('Download Model'), #webllm-settings-section-wrapper button:has-text('モデルをダウンロード')"
+      )
+      .first()
+    await downloadBtn.waitFor({ state: "visible" })
+    await downloadBtn.click()
+
+    // Click confirm download
+    const confirmDownloadBtn = spFrame
+      .locator(
+        "button:has-text('Start Download'), button:has-text('ダウンロードを開始する')"
+      )
+      .first()
+    await confirmDownloadBtn.waitFor({ state: "visible" })
+    await confirmDownloadBtn.click()
+    await page.waitForTimeout(500)
+
+    // 2. Navigate away to History tab and check global progress bar
+    const historyTabBtn = spFrame
+      .locator("button:has-text('History'), button:has-text('履歴')")
+      .first()
+    await historyTabBtn.click({ force: true })
+    await page.waitForTimeout(800)
+
+    // Verify global progress indicator is visible
+    const globalIndicator = spFrame.locator("#global-download-indicator")
+    await expect(globalIndicator).toBeVisible()
+
+    // Verify progress text presence
+    await expect(globalIndicator).toContainText(/📥/)
+
+    // Capture screenshot of global progress bar at the bottom in narrow viewport
+    await page.screenshot({
+      path: path.join(
+        screenshotsDir,
+        "litert-global-progress-indicator-narrow.png"
+      )
+    })
+    console.log("Global progress indicator narrow viewport screenshot saved.")
+  })
 })


### PR DESCRIPTION
# Walkthrough: Resolve Text Truncation in GlobalDownloadIndicator

Fixes the issue where progress indicator microcopy in `GlobalDownloadIndicator` gets truncated on narrow viewports/screens.

## Related Issue
- Resolves: #1405 (or similar issue for progress indicator truncation)

## Changes Implemented

### 1. Component Refactoring
- **[GlobalDownloadIndicator.tsx](file:///C:/Users/oculus/Desktop/worktrees/1405-fix-indicator-truncation/src/components/molecules/GlobalDownloadIndicator.tsx)**:
  - Redesigned layout to utilize responsive Tailwind classes (`sm:inline`, `hidden sm:inline`, `inline sm:hidden`).
  - Switched between full microcopy text (`webLlmGlobalAnxietyMicrocopy`) and shorter microcopy (`webLlmGlobalAnxietyMicrocopyShort`) depending on viewport width.
  - Increased progress bar thickness (from `h-1` to `h-1.5`) for better visibility.

### 2. Localization Additions
- **[en/translation.json](file:///C:/Users/oculus/Desktop/worktrees/1405-fix-indicator-truncation/src/locales/en/translation.json)**:
  - Added `"webLlmGlobalAnxietyMicrocopyShort": "Downloading in background. Feel free to navigate away."`
- **[ja/translation.json](file:///C:/Users/oculus/Desktop/worktrees/1405-fix-indicator-truncation/src/locales/ja/translation.json)**:
  - Added `"webLlmGlobalAnxietyMicrocopyShort": "バックグラウンドでダウンロード中。移動しても大丈夫です"`

### 3. Testing & Verification
- **[userJourneys.json](file:///C:/Users/oculus/Desktop/worktrees/1405-fix-indicator-truncation/memory-bank/userJourneys.json)**:
  - Registered `GlobalDownloadIndicator.tsx` under the corresponding user journey.
- **[litert-global-indicator.spec.ts](file:///C:/Users/oculus/Desktop/worktrees/1405-fix-indicator-truncation/tests/e2e/litert-global-indicator.spec.ts)**:
  - Added a new E2E test case `"should display global progress indicator nicely on narrow viewport"` that shrinks the side panel frame to `300px` to test responsive layout behavior and captures a verification screenshot.

## Verification Proofs

### Unit Tests
- Passed: 1219 / 1219 tests (134 test files)

### E2E Tests
- Passed successfully on Playwright Chromium environment.
- Narrow viewport responsive layout verified.

### E2E Screenshot (300px width Sidepanel)
![Narrow Viewport Screenshot](file:///C:/Users/oculus/.gemini/antigravity/brain/dbf0bd4a-3e7b-45c2-85f9-0b601fc17f70/litert-global-progress-indicator-narrow.png)
