### PR TITLE
fix: resolve light mode display bug in sandbox environment

### DIFF
--- a/tests/sandbox/main.tsx
+++ b/tests/sandbox/main.tsx
@@ -1135,7 +1135,7 @@ function SandboxWrapper() {
   const renderProfiler = () => {
     if (isNarrow) return null
     return (
-      <div className="flex flex-1 h-full p-6 overflow-y-auto border-r border-slate-800/80 flex-col justify-between">
+      <div className="dark bg-slate-950 text-slate-50 flex flex-1 h-full p-6 overflow-y-auto border-r border-slate-800/80 flex-col justify-between">
         <div className="space-y-6">
           <div className="flex items-center justify-between border-b border-slate-800/60 pb-4">
             <div>
@@ -1334,7 +1334,7 @@ function SandboxWrapper() {
   return (
     <div
       ref={containerRef}
-      className="dark h-screen w-screen overflow-hidden bg-slate-950 text-slate-50 flex relative">
+      className="h-screen w-screen overflow-hidden flex relative">
       {/* Onboarding Trigger Button (Floating Absolute for E2E Tests) */}
       <button
         id="test-open-onboarding-btn"

--- a/tests/sandbox/sidepanel.html
+++ b/tests/sandbox/sidepanel.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Style Atelier - Sidepanel Mock</title>
 </head>
-<body style="margin: 0; padding: 0; overflow: hidden; background-color: #020617;">
+<body style="margin: 0; padding: 0; overflow: hidden;">
   <div id="root"></div>
   <script type="module" src="./main.tsx"></script>
 </body>


### PR DESCRIPTION
# Walkthrough - Resolve Sandbox Light Mode Display Bug (#1422)

## Overview
In the sandbox environment, switching to Light Mode did not change the sidebar panels' styling (it remained dark navy with white text). This was caused by:
1. The wrapper `div` in `tests/sandbox/main.tsx` having hardcoded Tailwind classes `dark bg-slate-950 text-slate-50`.
2. The `body` element in `tests/sandbox/sidepanel.html` having a hardcoded background color style `background-color: #020617;`.

This PR removes these global overrides so that the sandbox correctly respects the selected Theme, while preserving the dark theme specifically for the LiteRT-LM developer profiler dashboard.

## Key Changes
- **[main.tsx](file:///c:/Users/oculus/Desktop/worktrees/1422-fix-sandbox-light-mode/tests/sandbox/main.tsx)**:
  - Removed `dark bg-slate-950 text-slate-50` from the root wrapper `div` in `SandboxWrapper`.
  - Added `dark bg-slate-950 text-slate-50` specifically to the outer container in `renderProfiler` so the developer dashboard's layout styling doesn't break.
- **[sidepanel.html](file:///c:/Users/oculus/Desktop/worktrees/1422-fix-sandbox-light-mode/tests/sandbox/sidepanel.html)**:
  - Removed `background-color: #020617;` from the inline style of the `body` tag.

## Verification & Screenshots
All 32 E2E tests have passed successfully. Here are the screenshots captured during verification to prove that Light Mode renders correctly now:

### Light Mode Screenshots
- **Global Settings Panel Theme Switch**:
  ![theme-light.png](https://github.com/user-attachments/assets/1e4812f3-26b0-44a9-81ea-2e1c34827acc)
- **Workbench Layout in Light Mode**:
  ![workbench-theme-light.png](https://github.com/user-attachments/assets/46696c0f-5f6a-4221-8a27-f8899da5145c)

Notice that the sidebar panels (on the right) are correctly rendered in light mode styling while the developer controller (on the left) retains its developer-oriented dark theme.
