### PR TITLE
refactor: Button and IconButton to use CVA and cn utility (#1386)

### DIFF
--- a/docs/agent-component-catalog.md
+++ b/docs/agent-component-catalog.md
@@ -33,11 +33,25 @@ No description provided.
 
 ### Props
 
-| Prop        | Type                                                           | Required | Default   | Description |
-| ----------- | -------------------------------------------------------------- | -------- | --------- | ----------- |
-| `variant`   | `"primary" \| "secondary" \| "ghost" \| "danger" \| "outline"` | No       | `primary` | -           |
-| `size`      | `"xs" \| "sm" \| "md" \| "lg" \| "icon"`                       | No       | `md`      | -           |
-| `fullWidth` | `boolean`                                                      | No       | `false`   | -           |
+| Prop        | Type                                                           | Required | Default | Description |
+| ----------- | -------------------------------------------------------------- | -------- | ------- | ----------- |
+| `variant`   | `"primary" \| "secondary" \| "ghost" \| "danger" \| "outline"` | No       | `-`     | -           |
+| `size`      | `"xs" \| "sm" \| "md" \| "lg" \| "icon"`                       | No       | `-`     | -           |
+| `fullWidth` | `boolean`                                                      | No       | `-`     | -           |
+
+## buttonVariants
+
+プロジェクト全体の標準的なボタンスタイルを提供するAtomコンポーネント。
+
+### Props
+
+| Prop        | Type                                                           | Required | Default | Description |
+| ----------- | -------------------------------------------------------------- | -------- | ------- | ----------- |
+| `variant`   | `"primary" \| "secondary" \| "ghost" \| "danger" \| "outline"` | No       | `-`     | -           |
+| `size`      | `"xs" \| "sm" \| "md" \| "lg" \| "icon"`                       | No       | `-`     | -           |
+| `fullWidth` | `boolean`                                                      | No       | `-`     | -           |
+| `class`     | `ClassValue`                                                   | No       | `-`     | -           |
+| `className` | `ClassValue`                                                   | No       | `-`     | -           |
 
 ## HelpTooltip
 
@@ -59,9 +73,23 @@ No description provided.
 
 | Prop      | Type                                                               | Required | Default | Description |
 | --------- | ------------------------------------------------------------------ | -------- | ------- | ----------- |
-| `rounded` | `boolean`                                                          | No       | `true`  | -           |
-| `size`    | `"xs" \| "sm" \| "md" \| "lg"`                                     | No       | `sm`    | -           |
-| `variant` | `"danger" \| "slate" \| "white" \| "indigo" \| "yellow" \| "blue"` | No       | `slate` | -           |
+| `variant` | `"danger" \| "slate" \| "white" \| "indigo" \| "yellow" \| "blue"` | No       | `-`     | -           |
+| `size`    | `"xs" \| "sm" \| "md" \| "lg"`                                     | No       | `-`     | -           |
+| `rounded` | `boolean`                                                          | No       | `-`     | -           |
+
+## iconButtonVariants
+
+アイコンを表示するための円形または四角形のボタン。
+
+### Props
+
+| Prop        | Type                                                               | Required | Default | Description |
+| ----------- | ------------------------------------------------------------------ | -------- | ------- | ----------- |
+| `variant`   | `"danger" \| "slate" \| "white" \| "indigo" \| "yellow" \| "blue"` | No       | `-`     | -           |
+| `size`      | `"xs" \| "sm" \| "md" \| "lg"`                                     | No       | `-`     | -           |
+| `rounded`   | `boolean`                                                          | No       | `-`     | -           |
+| `class`     | `ClassValue`                                                       | No       | `-`     | -           |
+| `className` | `ClassValue`                                                       | No       | `-`     | -           |
 
 ## ImageThumbnailItem
 

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,57 +1,62 @@
+import { cva, type VariantProps } from "class-variance-authority"
 import React from "react"
+
+import { cn } from "../../lib/utils"
 
 /**
  * プロジェクト全体の標準的なボタンスタイルを提供するAtomコンポーネント。
- *
- * @param {Object} props
- * @param {React.ReactNode} props.children - ボタンのラベルやコンテンツ
- * @param {'primary' | 'secondary' | 'ghost' | 'danger' | 'outline'} [props.variant='primary'] - ボタンの視覚スタイル
- * @param {'sm' | 'md' | 'lg' | 'icon'} [props.size='md'] - ボタンのサイズ
- * @param {boolean} [props.fullWidth=false] - 幅を100%にするかどうか
- * @param {string} [props.className=''] - 追加のカスタムクラス
  */
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "primary" | "secondary" | "ghost" | "danger" | "outline"
-  size?: "xs" | "sm" | "md" | "lg" | "icon"
-  fullWidth?: boolean
-}
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center font-medium transition-colors rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none",
+  {
+    variants: {
+      variant: {
+        primary:
+          "bg-indigo-600 text-white hover:bg-indigo-700 focus:ring-indigo-500",
+        secondary:
+          "bg-muted text-text-primary hover:bg-surface-hover focus:ring-slate-500",
+        ghost:
+          "bg-transparent text-text-secondary hover:bg-surface-hover focus:ring-slate-500",
+        danger: "bg-red-500 text-white hover:bg-red-600 focus:ring-red-500",
+        outline:
+          "bg-transparent border border-border-primary text-text-primary hover:bg-surface-hover focus:ring-slate-500"
+      },
+      size: {
+        xs: "px-2 py-1 text-[10px]",
+        sm: "px-3 py-1.5 text-xs",
+        md: "px-4 py-2 text-sm",
+        lg: "px-6 py-3 text-base",
+        icon: "p-2"
+      },
+      fullWidth: {
+        true: "w-full",
+        false: ""
+      }
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "md",
+      fullWidth: false
+    }
+  }
+)
+
+export interface ButtonProps
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
 
 export function Button({
   children,
-  variant = "primary",
-  size = "md",
-  fullWidth = false,
-  className = "",
+  variant,
+  size,
+  fullWidth,
+  className,
   ...props
 }: ButtonProps) {
-  const baseStyles =
-    "inline-flex items-center justify-center font-medium transition-colors rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none"
-
-  const variants = {
-    primary:
-      "bg-indigo-600 text-white hover:bg-indigo-700 focus:ring-indigo-500",
-    secondary:
-      "bg-muted text-text-primary hover:bg-surface-hover focus:ring-slate-500",
-    ghost:
-      "bg-transparent text-text-secondary hover:bg-surface-hover focus:ring-slate-500",
-    danger: "bg-red-500 text-white hover:bg-red-600 focus:ring-red-500",
-    outline:
-      "bg-transparent border border-border-primary text-text-primary hover:bg-surface-hover focus:ring-slate-500"
-  }
-
-  const sizes = {
-    xs: "px-2 py-1 text-[10px]",
-    sm: "px-3 py-1.5 text-xs",
-    md: "px-4 py-2 text-sm",
-    lg: "px-6 py-3 text-base",
-    icon: "p-2"
-  }
-
-  const widthStyle = fullWidth ? "w-full" : ""
-
   return (
     <button
-      className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${widthStyle} ${className}`}
+      className={cn(buttonVariants({ variant, size, fullWidth, className }))}
       {...props}>
       {children}
     </button>

--- a/src/components/atoms/IconButton.tsx
+++ b/src/components/atoms/IconButton.tsx
@@ -1,53 +1,59 @@
+import { cva, type VariantProps } from "class-variance-authority"
 import React from "react"
+
+import { cn } from "../../lib/utils"
 
 /**
  * アイコンを表示するための円形または四角形のボタン。
- *
- * @param {Object} props
- * @param {React.ReactNode} props.children - SVGアイコンなど
- * @param {boolean} [props.rounded=true] - 円形にするかどうか
- * @param {'sm' | 'md' | 'lg'} [props.size='sm'] - ボタンのサイズ
- * @param {'slate' | 'white' | 'indigo' | 'danger'} [props.variant='slate'] - カラースタイル
  */
-interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: React.ReactNode
-  rounded?: boolean
-  size?: "xs" | "sm" | "md" | "lg"
-  variant?: "slate" | "white" | "indigo" | "danger" | "yellow" | "blue"
-}
+export const iconButtonVariants = cva(
+  "inline-flex items-center justify-center transition-all focus:outline-none",
+  {
+    variants: {
+      variant: {
+        slate: "bg-slate-800 text-white hover:bg-slate-700",
+        white: "bg-white/80 text-slate-400 hover:text-slate-600 shadow-sm",
+        indigo: "bg-indigo-600 text-white hover:bg-indigo-700",
+        danger: "bg-red-500 text-white hover:bg-red-600",
+        yellow: "bg-yellow-400 text-white hover:bg-yellow-500",
+        blue: "bg-blue-600 text-white hover:bg-blue-700"
+      },
+      size: {
+        xs: "p-0.5",
+        sm: "p-1",
+        md: "p-2",
+        lg: "p-3"
+      },
+      rounded: {
+        true: "rounded-full",
+        false: "rounded-md"
+      }
+    },
+    defaultVariants: {
+      variant: "slate",
+      size: "sm",
+      rounded: true
+    }
+  }
+)
+
+export interface IconButtonProps
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof iconButtonVariants> {}
 
 export function IconButton({
   children,
-  rounded = true,
-  size = "sm",
-  variant = "slate",
-  className = "",
+  variant,
+  size,
+  rounded,
+  className,
   ...props
 }: IconButtonProps) {
-  const baseStyles = "inline-flex items-center justify-center transition-all focus:outline-none"
-  const shapeStyle = rounded ? "rounded-full" : "rounded-md"
-
-  const sizes = {
-    xs: "p-0.5",
-    sm: "p-1",
-    md: "p-2",
-    lg: "p-3",
-  }
-
-  const variants = {
-    slate: "bg-slate-800 text-white hover:bg-slate-700",
-    white: "bg-white/80 text-slate-400 hover:text-slate-600 shadow-sm",
-    indigo: "bg-indigo-600 text-white hover:bg-indigo-700",
-    danger: "bg-red-500 text-white hover:bg-red-600",
-    yellow: "bg-yellow-400 text-white hover:bg-yellow-500",
-    blue: "bg-blue-600 text-white hover:bg-blue-700",
-  }
-
   return (
     <button
-      className={`${baseStyles} ${shapeStyle} ${sizes[size]} ${variants[variant]} ${className}`}
-      {...props}
-    >
+      className={cn(iconButtonVariants({ variant, size, rounded, className }))}
+      {...props}>
       {children}
     </button>
   )


### PR DESCRIPTION
# Walkthrough: Button/IconButton CVA Refactoring (Issue #1386)

This Pull Request resolves issue #1386 by refactoring the basic atom components, `Button` and `IconButton`, to use `class-variance-authority` (CVA) and the project's styling utility `cn` (harnessing `clsx` and `tailwind-merge`). This guarantees consistent variant management and correctly merges external `className` overrides to prevent chaotic CSS rule conflicts.

## Changes

### 1. `Button` Component Refactoring
- File: [src/components/atoms/Button.tsx](file:///C:/Users/oculus/Desktop/worktrees/1386-cva-buttons/src/components/atoms/Button.tsx)
- Replaced the manual style mapping object with a typed CVA variant configuration.
- Configured style variants for:
  - `variant`: `primary`, `secondary`, `ghost`, `danger`, `outline`
  - `size`: `xs`, `sm`, `md`, `lg`, `icon`
  - `fullWidth`: `true` / `false`
- Integrated `cn()` wrapper to properly merge styling overrides.

### 2. `IconButton` Component Refactoring
- File: [src/components/atoms/IconButton.tsx](file:///C:/Users/oculus/Desktop/worktrees/1386-cva-buttons/src/components/atoms/IconButton.tsx)
- Replaced the manual style mapping with CVA.
- Configured variants for:
  - `variant`: `slate`, `white`, `indigo`, `danger`, `yellow`, `blue`
  - `size`: `xs`, `sm`, `md`, `lg`
  - `rounded`: `true` (rounded-full) / `false` (rounded-md)
- Integrated `cn()` wrapper for merging overrides.

## Verification Results

### Unit Tests
Ran the unit tests specifically targeting the Button and IconButton atoms:
```bash
npx vitest run tests/unit/components/atoms/Button.test.tsx tests/unit/components/atoms/IconButton.test.tsx
```
**Status: Passed (10/10 tests)**

### Linting
Executed linter to check for syntax or rule violations:
```bash
npm run lint
```
**Status: Passed (0 errors, only existing workspace warnings)**

### E2E Tests
Executed E2E tests to verify no regressions in functionality.
**Status: Passed (334 passed)**
