### PR TITLE
fix(ci): skip Cloudflare deploy if credentials are not configured

### DIFF
--- a/.github/workflows/deploy-signaling.yml
+++ b/.github/workflows/deploy-signaling.yml
@@ -42,9 +42,22 @@ jobs:
       - name: Run signaling tests
         run: npm run test --prefix signaling
 
+      - name: Check Cloudflare Credentials
+        id: check-creds
+        run: |
+          if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ] || [ -z "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" ]; then
+            echo "::warning::Cloudflare credentials (CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID) are not set. Skipping deploy."
+            echo "has_creds=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_creds=true" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
       - name: Deploy to Cloudflare Workers
+        if: steps.check-creds.outputs.has_creds == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: 'signaling'
+


### PR DESCRIPTION
## Description\nCloudflare Workers deploy workflow fails in environments without secrets (e.g. initial template setups or forks).\nThis PR adds a credential validation step to check if \CLOUDFLARE_API_TOKEN\ and \CLOUDFLARE_ACCOUNT_ID\ are set before running Wrangler, skipping deployment gracefully with a warning annotation if they are missing.\n\n## Testing\n- Verified on local that workflow file is valid.\n- Test proof is generated and pushed.