### PR TITLE
refactor: move hooks and helpers out of components/organisms to separate concerns #1382

### DIFF
--- a/src/components/organisms/Workbench.tsx
+++ b/src/components/organisms/Workbench.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react"
 
+import { useWorkbenchCore } from "../../hooks/useWorkbenchCore"
 import { type AlertType } from "../molecules/ConnectionAlert"
-import { useWorkbenchCore } from "./useWorkbenchCore"
 import { WorkbenchView } from "./WorkbenchView"
 
 interface WorkbenchProps {

--- a/src/hooks/useWorkbenchCore.ts
+++ b/src/hooks/useWorkbenchCore.ts
@@ -1,16 +1,13 @@
 import { useCallback, useMemo, useState } from "react"
 
-import { useLanguage } from "../../contexts/LanguageContext"
-import { useSettings } from "../../contexts/SettingsContext"
-import { useChromeTabConnection } from "../../hooks/useChromeTabConnection"
-import { useEvolution } from "../../hooks/useEvolution"
-import { usePromptSegmentsSync } from "../../hooks/usePromptSegmentsSync"
-import { useWorkbench } from "../../hooks/useWorkbench"
-import type {
-  PromptSegment,
-  RecipeHistoryItem
-} from "../../shared/lib/db-schema"
-import { type AlertType } from "../molecules/ConnectionAlert"
+import { type AlertType } from "../components/molecules/ConnectionAlert"
+import { useLanguage } from "../contexts/LanguageContext"
+import { useSettings } from "../contexts/SettingsContext"
+import type { PromptSegment, RecipeHistoryItem } from "../shared/lib/db-schema"
+import { useChromeTabConnection } from "./useChromeTabConnection"
+import { useEvolution } from "./useEvolution"
+import { usePromptSegmentsSync } from "./usePromptSegmentsSync"
+import { useWorkbench } from "./useWorkbench"
 import { useWorkbenchHandlers } from "./useWorkbenchHandlers"
 
 export interface WorkbenchProps {

--- a/src/hooks/useWorkbenchHandlers.ts
+++ b/src/hooks/useWorkbenchHandlers.ts
@@ -1,14 +1,14 @@
 import { useCallback } from "react"
 
-import { usePromptInjector } from "../../hooks/usePromptInjector"
-import type { PromptSegment } from "../../shared/lib/db-schema"
-import { type AlertType } from "../molecules/ConnectionAlert"
+import { type AlertType } from "../components/molecules/ConnectionAlert"
 import {
   evolveTargetCard,
   extractPortion,
   mintVariation,
   sendToWorkbench
-} from "./workbench-helpers"
+} from "../lib/workbench-helpers"
+import type { PromptSegment } from "../shared/lib/db-schema"
+import { usePromptInjector } from "./usePromptInjector"
 
 export interface UseHandlersOptions {
   workbenchCards: any[]

--- a/src/lib/workbench-helpers.ts
+++ b/src/lib/workbench-helpers.ts
@@ -1,4 +1,4 @@
-import type { PromptSegment } from "../../shared/lib/db-schema"
+import type { PromptSegment } from "../shared/lib/db-schema"
 
 export async function sendToWorkbench(
   value: string,


### PR DESCRIPTION
# Refactor: Separate Business Logic from Components Directory (#1382)

## Overview
This PR addresses issue #1382 by relocating business logic (Hooks and Helper functions) from the UI components directory `src/components/organisms` to their appropriate designated directories. This restores proper Separation of Concerns (SoC) across the codebase.

## Changes Made

### 1. File Relocations (using `git mv`)
- **Hooks**:
  - `src/components/organisms/useWorkbenchCore.ts` -> `src/hooks/useWorkbenchCore.ts`
  - `src/components/organisms/useWorkbenchHandlers.ts` -> `src/hooks/useWorkbenchHandlers.ts`
- **Helpers**:
  - `src/components/organisms/workbench-helpers.ts` -> `src/lib/workbench-helpers.ts`

### 2. Import Path Corrections
Updated all affected relative imports to ensure they reference the new locations:
- [src/components/organisms/Workbench.tsx](file:///c:/Users/oculus/Desktop/worktrees/1382-refactor-components-logic/src/components/organisms/Workbench.tsx)
- [src/hooks/useWorkbenchCore.ts](file:///c:/Users/oculus/Desktop/worktrees/1382-refactor-components-logic/src/hooks/useWorkbenchCore.ts)
- [src/hooks/useWorkbenchHandlers.ts](file:///c:/Users/oculus/Desktop/worktrees/1382-refactor-components-logic/src/hooks/useWorkbenchHandlers.ts)
- [src/lib/workbench-helpers.ts](file:///c:/Users/oculus/Desktop/worktrees/1382-refactor-components-logic/src/lib/workbench-helpers.ts)

## Verification
- **Linter**: `npm run lint` completed successfully with 0 errors.
- **Unit Tests**: `npm run test` succeeded with all 1,219 test cases passing.
- **E2E/UX Requirements**: This is a pure backend-structure refactoring with no UI or functional behavior changes. Therefore, no new E2E tests or UI screenshots were necessary.
