### PR TITLE
refactor: CVA Migration for Input component and call sites

### DIFF
--- a/docs/agent-component-catalog.md
+++ b/docs/agent-component-catalog.md
@@ -83,7 +83,10 @@ No description provided.
 
 ### Props
 
-No custom props.
+| Prop      | Type                                 | Required | Default | Description |
+| --------- | ------------------------------------ | -------- | ------- | ----------- |
+| `variant` | `"default" \| "error" \| "unstyled"` | No       | `-`     | -           |
+| `size`    | `"xs" \| "sm" \| "md" \| "lg"`       | No       | `-`     | -           |
 
 ## OpfsImage
 

--- a/src/components/atoms/Input.tsx
+++ b/src/components/atoms/Input.tsx
@@ -6,22 +6,24 @@ import { inputVariants } from "./Input.variants"
 
 /**
  * 汎用的なテキスト入力フィールドを提供するAtomコンポーネント。
- *
- * @param {Object} props
- * @param {string} [props.className=''] - 追加のカスタムクラス
  */
 export interface InputProps
   extends
-    React.InputHTMLAttributes<HTMLInputElement>,
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
     VariantProps<typeof inputVariants> {}
 
-export function Input({ width, className = "", ...props }: InputProps) {
-  const layoutClassName = extractLayoutClasses(className)
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ variant, size, width, className = "", ...props }, ref) => {
+    const layoutClassName = extractLayoutClasses(className)
 
-  return (
-    <input
-      className={cn(inputVariants({ width }), layoutClassName)}
-      {...props}
-    />
-  )
-}
+    return (
+      <input
+        ref={ref}
+        className={cn(inputVariants({ variant, size, width }), layoutClassName)}
+        {...props}
+      />
+    )
+  }
+)
+
+Input.displayName = "Input"

--- a/src/components/atoms/Input.variants.ts
+++ b/src/components/atoms/Input.variants.ts
@@ -1,15 +1,31 @@
 import { cva } from "class-variance-authority"
 
 export const inputVariants = cva(
-  "px-3 py-2 text-sm bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-700 text-slate-900 dark:text-slate-100 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-slate-50 dark:disabled:bg-slate-900 disabled:text-slate-500 dark:disabled:text-slate-400",
+  "transition-all duration-200 outline-none focus:outline-none disabled:bg-slate-50 dark:disabled:bg-slate-900 disabled:text-slate-500 dark:disabled:text-slate-400 disabled:opacity-50 font-sans",
   {
     variants: {
+      variant: {
+        default:
+          "bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-700 text-slate-900 dark:text-slate-100 rounded-md shadow-sm focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500",
+        error:
+          "bg-white dark:bg-slate-800 border border-red-500 dark:border-red-500 text-slate-900 dark:text-slate-100 rounded-md shadow-sm focus:ring-1 focus:ring-red-500 focus:border-red-500 placeholder-red-300",
+        unstyled:
+          "bg-transparent border-0 outline-none p-0 focus:ring-0 shadow-none rounded-none"
+      },
+      size: {
+        xs: "px-2 py-1 text-[10px] rounded",
+        sm: "px-2.5 py-1.5 text-xs rounded-lg",
+        md: "px-3 py-2 text-sm rounded-md",
+        lg: "px-3.5 py-2.5 text-sm rounded-xl"
+      },
       width: {
         full: "w-full",
         auto: "w-auto"
       }
     },
     defaultVariants: {
+      variant: "default",
+      size: "md",
       width: "full"
     }
   }

--- a/src/components/molecules/AspectRatioSelector.tsx
+++ b/src/components/molecules/AspectRatioSelector.tsx
@@ -1,7 +1,8 @@
-import React from "react"
 import { Hash } from "lucide-react"
-import { Input } from "../atoms/Input"
+import React from "react"
+
 import { cn } from "../../lib/utils"
+import { Input } from "../atoms/Input"
 
 const COMMON_ASPECT_RATIOS = ["1:1", "16:9", "9:16", "4:3", "3:2", "2:3"]
 
@@ -10,7 +11,10 @@ interface AspectRatioSelectorProps {
   onChange: (value: string) => void
 }
 
-export const AspectRatioSelector: React.FC<AspectRatioSelectorProps> = ({ value, onChange }) => {
+export const AspectRatioSelector: React.FC<AspectRatioSelectorProps> = ({
+  value,
+  onChange
+}) => {
   return (
     <div className="space-y-2">
       <label className="text-[10px] font-bold text-slate-500 uppercase flex items-center gap-1">
@@ -26,17 +30,18 @@ export const AspectRatioSelector: React.FC<AspectRatioSelectorProps> = ({ value,
               value === ratio
                 ? "bg-blue-600 border-blue-600 text-white"
                 : "bg-white border-slate-200 text-slate-600 hover:border-blue-400"
-            )}
-          >
+            )}>
             {ratio}
           </button>
         ))}
         <div className="ml-auto w-20">
           <Input
-            value={COMMON_ASPECT_RATIOS.includes(value || "") ? "" : value || ""}
+            value={
+              COMMON_ASPECT_RATIOS.includes(value || "") ? "" : value || ""
+            }
             onChange={(e) => onChange(e.target.value)}
             placeholder="Custom"
-            className="h-6 text-[10px] bg-white px-2"
+            size="xs"
           />
         </div>
       </div>

--- a/src/components/molecules/ParameterArrayEditor.tsx
+++ b/src/components/molecules/ParameterArrayEditor.tsx
@@ -167,7 +167,7 @@ export const ParameterArrayEditor: React.FC<ParameterArrayEditorProps> = ({
             onKeyDown={handleKeyDown}
             onFocus={() => setIsOpen(true)}
             placeholder={placeholder}
-            className="h-8 text-xs w-full"
+            size="sm"
           />
           {options.length > 0 && (
             <AutocompleteDropdown

--- a/src/components/molecules/TagEditor.tsx
+++ b/src/components/molecules/TagEditor.tsx
@@ -76,7 +76,7 @@ export const TagEditor: React.FC<TagEditorProps> = ({
           value={newTagInput}
           onChange={(e) => onNewTagInputChange(e.target.value)}
           placeholder={t.minting.tagsPlaceholder}
-          className="text-xs py-1"
+          size="sm"
         />
         <Button type="submit" size="xs" variant="secondary">
           {t.minting.add}

--- a/src/components/molecules/simple-minting/CustomNameInput.tsx
+++ b/src/components/molecules/simple-minting/CustomNameInput.tsx
@@ -29,7 +29,7 @@ export const CustomNameInput: React.FC<CustomNameInputProps> = ({
         advanceIfStep("title-input")
       }}
       placeholder={t.minting.enterCustomName}
-      className="h-9 text-xs focus-visible:ring-blue-600 rounded-xl"
+      size="sm"
     />
     <div className="mt-1.5 text-xs text-slate-500 font-medium">
       {t.minting.preview}:{" "}

--- a/src/components/organisms/CommandPalette.tsx
+++ b/src/components/organisms/CommandPalette.tsx
@@ -62,7 +62,8 @@ export function CommandPalette() {
           <Input
             ref={inputRef}
             type="text"
-            className="flex-1 bg-transparent border-0 outline-none text-slate-100 placeholder-slate-500 text-sm focus:ring-0 w-full"
+            variant="unstyled"
+            className="flex-1 text-slate-100 placeholder-slate-500 text-sm w-full"
             placeholder={
               t.commandPalette?.placeholder ||
               "Type a command or search style cards..."

--- a/src/components/organisms/LicenseSettingsSection.tsx
+++ b/src/components/organisms/LicenseSettingsSection.tsx
@@ -23,8 +23,7 @@ interface Feedback {
   message: string
 }
 
-const INPUT_CLASS =
-  "w-full pl-3 pr-10 py-2.5 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl text-xs text-text-primary placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 disabled:opacity-50 font-mono"
+const INPUT_CLASS = "pl-3 pr-10 font-mono"
 const ACTIVATE_BTN_CLASS =
   "flex-1 flex items-center justify-center gap-1.5 py-2.5 px-4 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white font-bold rounded-xl text-xs shadow-lg shadow-indigo-600/10 transition-all active:scale-99"
 const BUY_BTN_CLASS =
@@ -198,6 +197,7 @@ function LicenseInactiveForm({
             disabled={isLoading}
             placeholder={t.settings.license.placeholder}
             className={INPUT_CLASS}
+            size="sm"
             id="license-key-input"
           />
           <div className="absolute right-3.5 top-1/2 -translate-y-1/2 text-slate-400">

--- a/src/components/organisms/OnboardingGuide/TitleIllustration.tsx
+++ b/src/components/organisms/OnboardingGuide/TitleIllustration.tsx
@@ -18,7 +18,7 @@ export const TitleIllustration: React.FC<IllustrationProps> = ({ t }) => {
           type="text"
           readOnly
           value={mockT.neonCyberpunkSamurai}
-          className="w-full focus:outline-none"
+          size="sm"
         />
         <span className="absolute right-2 top-2 text-[10px] text-purple-400 font-bold animate-pulse">
           {mockT.title}

--- a/src/components/organisms/PremiumBrandingPanel.tsx
+++ b/src/components/organisms/PremiumBrandingPanel.tsx
@@ -112,6 +112,7 @@ function LogoUploader({ customLogo, onUpdateBranding }: LogoUploaderProps) {
       data-testid="logo-dropzone">
       <Input
         type="file"
+        variant="unstyled"
         accept="image/*"
         onChange={(e) => {
           setIsDragging(false)
@@ -152,6 +153,7 @@ function SocialLinkInput({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className="flex-1"
+        size="sm"
         data-testid={testId}
       />
     </div>

--- a/src/features/card-detail/components/CardDetailView/IdentitySection.tsx
+++ b/src/features/card-detail/components/CardDetailView/IdentitySection.tsx
@@ -42,7 +42,8 @@ function CardNameInput({
         value={name}
         onChange={(e) => setName(e.target.value)}
         placeholder={t.cardDetail.cardNamePlaceholder}
-        className="font-bold text-slate-800 text-sm"
+        className="font-bold text-slate-800"
+        size="md"
         disabled={!expertFeatures.cardEditing}
       />
     </div>

--- a/src/features/category-manager/components/CategoryManagerModal/CategoryForm.tsx
+++ b/src/features/category-manager/components/CategoryManagerModal/CategoryForm.tsx
@@ -52,7 +52,7 @@ function CategoryNameField({
         value={name}
         onChange={(e) => setName(e.target.value)}
         placeholder={t.placeholderName}
-        className="text-xs"
+        size="sm"
       />
     </div>
   )
@@ -150,7 +150,8 @@ function EmojiInput({
         value={emoji}
         onChange={(e) => handleEmojiChange(e.target.value)}
         placeholder={t.placeholderEmoji}
-        className="text-xs text-center"
+        className="text-center"
+        size="sm"
         disabled={disabled}
       />
     </div>

--- a/src/features/minting/components/MintingView/CardIdentitySubSections.tsx
+++ b/src/features/minting/components/MintingView/CardIdentitySubSections.tsx
@@ -55,7 +55,7 @@ function TagInputField({
         type="text"
         id="custom-tag-input"
         placeholder={t.minting.pressEnterToAdd}
-        className="text-xs py-1"
+        size="sm"
         onKeyDown={(e) => {
           if (e.key === "Enter") {
             e.preventDefault()

--- a/tests/e2e/atom-components-cva.spec.ts
+++ b/tests/e2e/atom-components-cva.spec.ts
@@ -54,7 +54,19 @@ test.describe("Style Atelier E2E Tests - Atom Components CVA @J-ATOM-CVA", () =>
     )
     await expect(accordionHeaders.first()).toBeVisible()
 
-    // Take a screenshot of the settings tab containing CVA components
+    // 8. Verify License input component (which uses Input CVA size="sm")
+    const licenseAccordionHeader = spFrame.locator(
+      "#settings-accordion-license"
+    )
+    await expect(licenseAccordionHeader).toBeVisible()
+    await licenseAccordionHeader.click()
+
+    const licenseInput = spFrame.locator("#license-key-input")
+    await expect(licenseInput).toBeVisible()
+    await licenseInput.fill("TEST-CVA-INPUT-KEY")
+    await expect(licenseInput).toHaveValue("TEST-CVA-INPUT-KEY")
+
+    // Take a screenshot of the settings tab containing CVA components including Input
     await page.screenshot({
       path: path.join(screenshotsDir, "atom-components-cva.png")
     })


### PR DESCRIPTION
# ワークスルー - Issue #1387 フォーム系のCVA化と全画面置換

## 1. 概要
`Input` コンポーネントに `class-variance-authority` (CVA) を導入し、インラインで個別に記述されていたフォーカス状態、エラー状態、通常状態、サイズ等のスタイリングを標準的なバリアントへ置き換えました。
あわせて、コードベース内のすべての `Input` コンポーネントの呼び出し元をリファクタリングし、一貫性のあるデザインシステムへの移行を行いました。

## 2. 変更内容
### `src/components/atoms/Input.tsx` / `Input.variants.ts`
- CVAバリアントの定義を追加しました。
  - `variant`: `default` (標準枠線とフォーカスリング付き), `error` (赤枠と赤フォーカスリング), `unstyled` (枠線、背景、影、リングなし)
  - `size`: `xs` (極小), `sm` (小/標準), `md` (中), `lg` (大)
  - `width`: `full` (100%幅), `auto` (自動幅)
- `React.forwardRef` を適用し、呼び出し側から `ref` が利用できるよう改善しました。
- HTMLの標準 `size` 属性との競合を避けるため、`Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">` を適用しました。

### 呼び出し元のリファクタリング (全10箇所)
- **`CustomNameInput.tsx`**: `size="sm"` を指定し、インラインスタイルを破棄。
- **`LicenseSettingsSection.tsx`**: レイアウト固有の padding とフォント以外のインラインボーダー・背景等の指定を破棄し、`size="sm"` に置き換え。
- **`CommandPalette.tsx`**: `variant="unstyled"` を指定し、インラインでのリセット処理を破棄。
- **`OnboardingGuide/TitleIllustration.tsx`**: インラインスタイルを破棄し、`size="sm"` を指定。
- **`CategoryForm.tsx`**: インラインの `text-xs` を破棄し、`size="sm"` を指定。
- **`CardIdentitySubSections.tsx`**: インラインの `text-xs py-1` を破棄し、`size="sm"` を指定。
- **`AspectRatioSelector.tsx`**: インラインスタイルを破棄し、`size="xs"` を指定。
- **`ParameterArrayEditor.tsx`**: インラインスタイルを破棄し、`size="sm"` を指定。
- **`TagEditor.tsx`**: インラインスタイルを破棄し、`size="sm"` を指定。
- **`IdentitySection.tsx`**: フォントスタイルのみを残し、`size="md"` を指定。

## 3. テストと検証結果
### ユニットテスト (`npm run test`)
- 137件のテストファイル、1259件의テストすべてが正常にパスしました。

### E2Eテスト (`tests/e2e/atom-components-cva.spec.ts`)
- CVA化された `Input` の挙動を検証するため、E2Eテストにライセンスキー入力フィールドへのインタラクションを追加。
- Playwright E2E テストが無事にパスしました。

#### CVAコンポーネント検証時のE2Eスクリーンショット
![Atom Components CVA E2E Screenshot](atom-components-cva.png)
