### PR TITLE
feat: resolve issue #1388 - CVA migration for decorative atom components

### DIFF
--- a/allowed-atoms.json
+++ b/allowed-atoms.json
@@ -1,5 +1,6 @@
 [
   "AdviceViewer.tsx",
+  "AdviceViewer.variants.ts",
   "AiStatusBadge.tsx",
   "AiStatusBadge.variants.ts",
   "Button.tsx",
@@ -8,11 +9,14 @@
   "IconButton.tsx",
   "IconButton.variants.ts",
   "ImageThumbnailItem.tsx",
+  "ImageThumbnailItem.variants.ts",
   "Input.tsx",
   "Input.variants.ts",
   "OpfsImage.tsx",
+  "OpfsImage.variants.ts",
   "RarityBadge.tsx",
   "RarityBadge.variants.ts",
   "Tooltip.tsx",
+  "Tooltip.variants.ts",
   "Tooltip.test.tsx"
 ]

--- a/docs/agent-component-catalog.md
+++ b/docs/agent-component-catalog.md
@@ -48,8 +48,8 @@ No description provided.
 | Prop        | Type                                                                                                     | Required | Default | Description |
 | ----------- | -------------------------------------------------------------------------------------------------------- | -------- | ------- | ----------- |
 | `content`   | `string`                                                                                                 | Yes      | `-`     | -           |
-| `position`  | `"top" \| "bottom" \| "left" \| "right" \| "top-left" \| "top-right" \| "bottom-left" \| "bottom-right"` | No       | `top`   | -           |
 | `className` | `string`                                                                                                 | No       | `-`     | -           |
+| `position`  | `"top" \| "bottom" \| "left" \| "right" \| "top-left" \| "top-right" \| "bottom-left" \| "bottom-right"` | No       | `top`   | -           |
 
 ## IconButton
 
@@ -115,5 +115,5 @@ No description provided.
 | Prop        | Type                                                                                                     | Required | Default | Description |
 | ----------- | -------------------------------------------------------------------------------------------------------- | -------- | ------- | ----------- |
 | `content`   | `string`                                                                                                 | Yes      | `-`     | -           |
-| `position`  | `"top" \| "bottom" \| "left" \| "right" \| "top-left" \| "top-right" \| "bottom-left" \| "bottom-right"` | No       | `top`   | -           |
 | `className` | `string`                                                                                                 | No       | `-`     | -           |
+| `position`  | `"top" \| "bottom" \| "left" \| "right" \| "top-left" \| "top-right" \| "bottom-left" \| "bottom-right"` | No       | `top`   | -           |

--- a/src/components/atoms/AdviceViewer.tsx
+++ b/src/components/atoms/AdviceViewer.tsx
@@ -1,18 +1,18 @@
 import React from "react"
 
+import { adviceViewerVariants } from "./AdviceViewer.variants"
+
 interface AdviceViewerProps {
   advice: string
 }
 
 export function AdviceViewer({ advice }: AdviceViewerProps) {
   return (
-    <div className="prose prose-invert max-w-none text-slate-700 dark:text-slate-300 space-y-2 font-sans">
+    <div className={adviceViewerVariants.container()}>
       {advice.split("\n").map((line, idx) => {
         if (line.startsWith("###")) {
           return (
-            <h4
-              key={idx}
-              className="font-bold text-slate-800 dark:text-indigo-300 text-[11px] pt-1.5 border-b border-slate-200/50 dark:border-indigo-950/30 pb-0.5 mb-1.5 first:pt-0">
+            <h4 key={idx} className={adviceViewerVariants.heading()}>
               {line.replace("###", "").trim()}
             </h4>
           )
@@ -22,9 +22,9 @@ export function AdviceViewer({ advice }: AdviceViewerProps) {
           const boldMatch = cleanLine.match(/^\*\*(.*?)\*\*(.*)$/)
           if (boldMatch) {
             return (
-              <div key={idx} className="pl-3.5 relative mb-1">
-                <span className="absolute left-1 top-1.5 w-1 h-1 rounded-full bg-indigo-500" />
-                <strong className="text-slate-800 dark:text-slate-200">
+              <div key={idx} className={adviceViewerVariants.listItem()}>
+                <span className={adviceViewerVariants.bullet()} />
+                <strong className={adviceViewerVariants.strong()}>
                   {boldMatch[1]}
                 </strong>
                 <span>{boldMatch[2]}</span>
@@ -32,14 +32,14 @@ export function AdviceViewer({ advice }: AdviceViewerProps) {
             )
           }
           return (
-            <div key={idx} className="pl-3.5 relative mb-1">
-              <span className="absolute left-1 top-1.5 w-1 h-1 rounded-full bg-indigo-500" />
+            <div key={idx} className={adviceViewerVariants.listItem()}>
+              <span className={adviceViewerVariants.bullet()} />
               <span>{cleanLine}</span>
             </div>
           )
         }
         return (
-          <p key={idx} className="mb-1">
+          <p key={idx} className={adviceViewerVariants.paragraph()}>
             {line}
           </p>
         )

--- a/src/components/atoms/AdviceViewer.variants.ts
+++ b/src/components/atoms/AdviceViewer.variants.ts
@@ -1,0 +1,14 @@
+import { cva } from "class-variance-authority"
+
+export const adviceViewerVariants = {
+  container: cva(
+    "prose prose-invert max-w-none text-slate-700 dark:text-slate-300 space-y-2 font-sans"
+  ),
+  heading: cva(
+    "font-bold text-slate-800 dark:text-indigo-300 text-[11px] pt-1.5 border-b border-slate-200/50 dark:border-indigo-950/30 pb-0.5 mb-1.5 first:pt-0"
+  ),
+  listItem: cva("pl-3.5 relative mb-1"),
+  bullet: cva("absolute left-1 top-1.5 w-1 h-1 rounded-full bg-indigo-500"),
+  strong: cva("text-slate-800 dark:text-slate-200"),
+  paragraph: cva("mb-1")
+}

--- a/src/components/atoms/AiStatusBadge.tsx
+++ b/src/components/atoms/AiStatusBadge.tsx
@@ -12,7 +12,10 @@ import { useLanguage } from "../../contexts/LanguageContext"
 import { useWebGpuCheck } from "../../hooks/useWebGpuCheck"
 import { useWebLlm } from "../../hooks/useWebLlm"
 import { cn, extractLayoutClasses } from "../../lib/utils"
-import { aiStatusBadgeVariants } from "./AiStatusBadge.variants"
+import {
+  aiStatusBadgeTooltipVariants,
+  aiStatusBadgeVariants
+} from "./AiStatusBadge.variants"
 
 export interface AiStatusBadgeProps
   extends
@@ -140,7 +143,7 @@ export function AiStatusBadge({
         <span>{config.badgeText}</span>
       </div>
       <div
-        className="absolute hidden group-hover:block group-focus-within:block bg-slate-900 dark:bg-slate-950 text-white text-[10px] font-normal rounded-lg p-2.5 shadow-xl w-56 z-[9999] pointer-events-none leading-relaxed transition-all animate-in fade-in duration-150 bottom-full left-1/2 -translate-x-1/2 mb-2 after:content-[''] after:absolute after:top-full after:left-1/2 after:-translate-x-1/2 after:border-4 after:border-transparent after:border-t-slate-900 dark:after:border-t-slate-950"
+        className={cn(aiStatusBadgeTooltipVariants())}
         data-testid="ai-status-badge-tooltip">
         {config.tooltipText}
       </div>

--- a/src/components/atoms/AiStatusBadge.variants.ts
+++ b/src/components/atoms/AiStatusBadge.variants.ts
@@ -20,3 +20,7 @@ export const aiStatusBadgeVariants = cva(
     }
   }
 )
+
+export const aiStatusBadgeTooltipVariants = cva(
+  "absolute hidden group-hover:block group-focus-within:block bg-slate-900 dark:bg-slate-950 text-white text-[10px] font-normal rounded-lg p-2.5 shadow-xl w-56 z-[9999] pointer-events-none leading-relaxed transition-all animate-in fade-in duration-150 bottom-full left-1/2 -translate-x-1/2 mb-2 after:content-[''] after:absolute after:top-full after:left-1/2 after:-translate-x-1/2 after:border-4 after:border-transparent after:border-t-slate-900 dark:after:border-t-slate-950"
+)

--- a/src/components/atoms/HelpTooltip.tsx
+++ b/src/components/atoms/HelpTooltip.tsx
@@ -1,19 +1,15 @@
+import { type VariantProps } from "class-variance-authority"
 import { HelpCircle } from "lucide-react"
 import React from "react"
 
 import { cn } from "../../lib/utils"
+import { tooltipContentVariants } from "./Tooltip.variants"
 
-interface HelpTooltipProps {
+interface HelpTooltipProps extends Omit<
+  VariantProps<typeof tooltipContentVariants>,
+  "variant"
+> {
   content: string
-  position?:
-    | "top"
-    | "bottom"
-    | "left"
-    | "right"
-    | "top-left"
-    | "top-right"
-    | "bottom-left"
-    | "bottom-right"
   className?: string
 }
 
@@ -22,23 +18,6 @@ export const HelpTooltip: React.FC<HelpTooltipProps> = ({
   position = "top",
   className
 }) => {
-  const positionClasses = {
-    top: "bottom-full left-1/2 -translate-x-1/2 mb-2 after:content-[''] after:absolute after:top-full after:left-1/2 after:-translate-x-1/2 after:border-4 after:border-transparent after:border-t-slate-900",
-    bottom:
-      "top-full left-1/2 -translate-x-1/2 mt-2 after:content-[''] after:absolute after:bottom-full after:left-1/2 after:-translate-x-1/2 after:border-4 after:border-transparent after:border-b-slate-900",
-    left: "right-full top-1/2 -translate-y-1/2 mr-2 after:content-[''] after:absolute after:left-full after:top-1/2 after:-translate-y-1/2 after:border-4 after:border-transparent after:border-l-slate-900",
-    right:
-      "left-full top-1/2 -translate-y-1/2 ml-2 after:content-[''] after:absolute after:right-full after:top-1/2 after:-translate-y-1/2 after:border-4 after:border-transparent after:border-r-slate-900",
-    "top-left":
-      "bottom-full left-0 mb-2 after:content-[''] after:absolute after:top-full after:left-1.5 after:border-4 after:border-transparent after:border-t-slate-900",
-    "top-right":
-      "bottom-full right-0 mb-2 after:content-[''] after:absolute after:top-full after:right-1.5 after:border-4 after:border-transparent after:border-t-slate-900",
-    "bottom-left":
-      "top-full left-0 mt-2 after:content-[''] after:absolute after:bottom-full after:left-1.5 after:border-4 after:border-transparent after:border-b-slate-900",
-    "bottom-right":
-      "top-full right-0 mt-2 after:content-[''] after:absolute after:bottom-full after:right-1.5 after:border-4 after:border-transparent after:border-b-slate-900"
-  }
-
   return (
     <div
       className={cn(
@@ -54,10 +33,7 @@ export const HelpTooltip: React.FC<HelpTooltipProps> = ({
       </button>
       <div
         data-testid="help-tooltip-content"
-        className={cn(
-          "absolute hidden group-hover:block group-focus-within:block bg-slate-900 text-white text-xs font-normal rounded-lg p-2.5 shadow-xl w-56 z-[9999] pointer-events-none leading-relaxed transition-all animate-in fade-in duration-150",
-          positionClasses[position]
-        )}>
+        className={cn(tooltipContentVariants({ position, variant: "help" }))}>
         {content}
       </div>
     </div>

--- a/src/components/atoms/ImageThumbnailItem.tsx
+++ b/src/components/atoms/ImageThumbnailItem.tsx
@@ -1,8 +1,18 @@
+import { type VariantProps } from "class-variance-authority"
 import { CheckCircle2 } from "lucide-react"
 import React from "react"
 import iconUrl from "url:../../../assets/icon.png"
 
-export interface ImageThumbnailItemProps {
+import { cn } from "../../lib/utils"
+import {
+  imageThumbnailBadgeVariants,
+  imageThumbnailItemVariants
+} from "./ImageThumbnailItem.variants"
+
+export interface ImageThumbnailItemProps
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
+    Omit<VariantProps<typeof imageThumbnailItemVariants>, "selected"> {
   imgUrl: string
   alt: string
   isSelected: boolean
@@ -15,23 +25,25 @@ export const ImageThumbnailItem: React.FC<ImageThumbnailItemProps> = ({
   alt,
   isSelected,
   orderLabel,
-  onClick
+  onClick,
+  className,
+  ...props
 }) => {
   return (
     <div
       onClick={onClick}
-      className={`relative aspect-square cursor-pointer overflow-hidden rounded-lg border-2 transition-all ${
-        isSelected
-          ? "border-blue-500 ring-2 ring-blue-100 shadow-md"
-          : "border-slate-200 hover:border-slate-400"
-      }`}>
+      className={cn(
+        imageThumbnailItemVariants({ selected: isSelected }),
+        className
+      )}
+      {...props}>
       <img
         src={imgUrl === "assets/icon.png" ? iconUrl : imgUrl}
         className="w-full h-full object-cover"
         alt={alt}
       />
       {isSelected && (
-        <div className="absolute top-1.5 left-1.5 bg-blue-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded shadow flex items-center gap-1">
+        <div className={cn(imageThumbnailBadgeVariants())}>
           <CheckCircle2 className="w-3 h-3" />
           <span>{orderLabel}</span>
         </div>

--- a/src/components/atoms/ImageThumbnailItem.variants.ts
+++ b/src/components/atoms/ImageThumbnailItem.variants.ts
@@ -1,0 +1,20 @@
+import { cva } from "class-variance-authority"
+
+export const imageThumbnailItemVariants = cva(
+  "relative aspect-square cursor-pointer overflow-hidden rounded-lg border-2 transition-all",
+  {
+    variants: {
+      selected: {
+        true: "border-blue-500 ring-2 ring-blue-100 shadow-md",
+        false: "border-slate-200 hover:border-slate-400"
+      }
+    },
+    defaultVariants: {
+      selected: false
+    }
+  }
+)
+
+export const imageThumbnailBadgeVariants = cva(
+  "absolute top-1.5 left-1.5 bg-blue-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded shadow flex items-center gap-1"
+)

--- a/src/components/atoms/OpfsImage.tsx
+++ b/src/components/atoms/OpfsImage.tsx
@@ -1,8 +1,15 @@
 import { useOpfsImage } from "@/hooks/useOpfsImage"
+import { cn } from "@/lib/utils"
+import { type VariantProps } from "class-variance-authority"
 import React, { useEffect, useRef, useState } from "react"
 import iconUrl from "url:../../../assets/icon.png"
 
-interface OpfsImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+import { opfsImageVariants } from "./OpfsImage.variants"
+
+interface OpfsImageProps
+  extends
+    React.ImgHTMLAttributes<HTMLImageElement>,
+    Omit<VariantProps<typeof opfsImageVariants>, "loading"> {
   src?: string
   alt: string
 }
@@ -69,7 +76,7 @@ export function OpfsImage({ src, alt, className, ...props }: OpfsImageProps) {
       ref={imgRef}
       src={finalSrc || iconUrl}
       alt={alt}
-      className={`${className || ""} ${isLoading ? "animate-pulse" : ""}`}
+      className={cn(opfsImageVariants({ loading: isLoading }), className)}
       {...props}
     />
   )

--- a/src/components/atoms/OpfsImage.variants.ts
+++ b/src/components/atoms/OpfsImage.variants.ts
@@ -1,0 +1,13 @@
+import { cva } from "class-variance-authority"
+
+export const opfsImageVariants = cva("", {
+  variants: {
+    loading: {
+      true: "animate-pulse",
+      false: ""
+    }
+  },
+  defaultVariants: {
+    loading: false
+  }
+})

--- a/src/components/atoms/Tooltip.tsx
+++ b/src/components/atoms/Tooltip.tsx
@@ -1,18 +1,14 @@
+import { type VariantProps } from "class-variance-authority"
 import React from "react"
 
 import { cn } from "../../lib/utils"
+import { tooltipContentVariants } from "./Tooltip.variants"
 
-interface TooltipProps {
+interface TooltipProps extends Omit<
+  VariantProps<typeof tooltipContentVariants>,
+  "variant"
+> {
   content: string
-  position?:
-    | "top"
-    | "bottom"
-    | "left"
-    | "right"
-    | "top-left"
-    | "top-right"
-    | "bottom-left"
-    | "bottom-right"
   children: React.ReactNode
   className?: string
 }
@@ -23,23 +19,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
   children,
   className
 }) => {
-  const positionClasses = {
-    top: "bottom-full left-1/2 -translate-x-1/2 mb-2 after:content-[''] after:absolute after:top-full after:left-1/2 after:-translate-x-1/2 after:border-4 after:border-transparent after:border-t-slate-900",
-    bottom:
-      "top-full left-1/2 -translate-x-1/2 mt-2 after:content-[''] after:absolute after:bottom-full after:left-1/2 after:-translate-x-1/2 after:border-4 after:border-transparent after:border-b-slate-900",
-    left: "right-full top-1/2 -translate-y-1/2 mr-2 after:content-[''] after:absolute after:left-full after:top-1/2 after:-translate-y-1/2 after:border-4 after:border-transparent after:border-l-slate-900",
-    right:
-      "left-full top-1/2 -translate-y-1/2 ml-2 after:content-[''] after:absolute after:right-full after:top-1/2 after:-translate-y-1/2 after:border-4 after:border-transparent after:border-r-slate-900",
-    "top-left":
-      "bottom-full left-0 mb-2 after:content-[''] after:absolute after:top-full after:left-1.5 after:border-4 after:border-transparent after:border-t-slate-900",
-    "top-right":
-      "bottom-full right-0 mb-2 after:content-[''] after:absolute after:top-full after:right-1.5 after:border-4 after:border-transparent after:border-t-slate-900",
-    "bottom-left":
-      "top-full left-0 mt-2 after:content-[''] after:absolute after:bottom-full after:left-1.5 after:border-4 after:border-transparent after:border-b-slate-900",
-    "bottom-right":
-      "top-full right-0 mt-2 after:content-[''] after:absolute after:bottom-full after:right-1.5 after:border-4 after:border-transparent after:border-b-slate-900"
-  }
-
   return (
     <div
       className={cn(
@@ -50,8 +29,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
       <div
         data-testid="tooltip-content"
         className={cn(
-          "absolute hidden group-hover:block group-focus-within:block bg-slate-900 text-white text-xs font-normal rounded-lg px-2.5 py-1.5 shadow-xl w-max max-w-xs z-[9999] pointer-events-none leading-relaxed transition-all animate-in fade-in duration-150 whitespace-nowrap",
-          positionClasses[position]
+          tooltipContentVariants({ position, variant: "default" })
         )}>
         {content}
       </div>

--- a/src/components/atoms/Tooltip.variants.ts
+++ b/src/components/atoms/Tooltip.variants.ts
@@ -1,0 +1,33 @@
+import { cva } from "class-variance-authority"
+
+export const tooltipContentVariants = cva(
+  "absolute hidden group-hover:block group-focus-within:block bg-slate-900 text-white text-xs font-normal rounded-lg shadow-xl z-[9999] pointer-events-none leading-relaxed transition-all animate-in fade-in duration-150",
+  {
+    variants: {
+      position: {
+        top: "bottom-full left-1/2 -translate-x-1/2 mb-2 after:content-[''] after:absolute after:top-full after:left-1/2 after:-translate-x-1/2 after:border-4 after:border-transparent after:border-t-slate-900",
+        bottom:
+          "top-full left-1/2 -translate-x-1/2 mt-2 after:content-[''] after:absolute after:bottom-full after:left-1/2 after:-translate-x-1/2 after:border-4 after:border-transparent after:border-b-slate-900",
+        left: "right-full top-1/2 -translate-y-1/2 mr-2 after:content-[''] after:absolute after:left-full after:top-1/2 after:-translate-y-1/2 after:border-4 after:border-transparent after:border-l-slate-900",
+        right:
+          "left-full top-1/2 -translate-y-1/2 ml-2 after:content-[''] after:absolute after:right-full after:top-1/2 after:-translate-y-1/2 after:border-4 after:border-transparent after:border-r-slate-900",
+        "top-left":
+          "bottom-full left-0 mb-2 after:content-[''] after:absolute after:top-full after:left-1.5 after:border-4 after:border-transparent after:border-t-slate-900",
+        "top-right":
+          "bottom-full right-0 mb-2 after:content-[''] after:absolute after:top-full after:right-1.5 after:border-4 after:border-transparent after:border-t-slate-900",
+        "bottom-left":
+          "top-full left-0 mt-2 after:content-[''] after:absolute after:bottom-full after:left-1.5 after:border-4 after:border-transparent after:border-b-slate-900",
+        "bottom-right":
+          "top-full right-0 mt-2 after:content-[''] after:absolute after:bottom-full after:right-1.5 after:border-4 after:border-transparent after:border-b-slate-900"
+      },
+      variant: {
+        default: "px-2.5 py-1.5 w-max max-w-xs whitespace-nowrap",
+        help: "p-2.5 w-56"
+      }
+    },
+    defaultVariants: {
+      position: "top",
+      variant: "default"
+    }
+  }
+)


### PR DESCRIPTION
# Walkthrough - Decorative Atom Components CVA Migration

Resolves #1388

This PR refactors several decorative/helper atom components to use `class-variance-authority` (CVA) for variant and style management. Ad-hoc inline styles have been cleaned up and consolidated into dedicated `.variants.ts` files according to the project design system.

## Changes

### 1. Tooltip & HelpTooltip CVA Integration
- Created [Tooltip.variants.ts](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/Tooltip.variants.ts) to define `tooltipContentVariants` supporting multiple positions and sizes (e.g. default tooltip vs. help tooltip).
- Refactored [Tooltip.tsx](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/Tooltip.tsx) and [HelpTooltip.tsx](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/HelpTooltip.tsx) to consume this unified variants configuration.

### 2. AdviceViewer
- Created [AdviceViewer.variants.ts](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/AdviceViewer.variants.ts) specifying typography tokens for markdown blocks, headings, lists, strong elements, etc.
- Refactored [AdviceViewer.tsx](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/AdviceViewer.tsx) to use these variants instead of inline Tailwind classes.

### 3. ImageThumbnailItem
- Created [ImageThumbnailItem.variants.ts](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/ImageThumbnailItem.variants.ts) managing selected states and badge styling.
- Refactored [ImageThumbnailItem.tsx](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/ImageThumbnailItem.tsx) to apply the new variants.

### 4. OpfsImage
- Created [OpfsImage.variants.ts](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/OpfsImage.variants.ts) encapsulating image loading state classes.
- Refactored [OpfsImage.tsx](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/OpfsImage.tsx) to bind CVA loading styles.

### 5. AiStatusBadge
- Added `aiStatusBadgeTooltipVariants` CVA styling to [AiStatusBadge.variants.ts](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/AiStatusBadge.variants.ts).
- Refactored [AiStatusBadge.tsx](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/src/components/atoms/AiStatusBadge.tsx) to apply this CVA definition to its tooltip wrapper.

### 6. Config Whitelist Update
- Registered new variants files in [allowed-atoms.json](file:///C:/Users/oculus/Desktop/worktrees/1388-cva-decorative/allowed-atoms.json) to pass lint rules.

## Verification

### Local Tests
- **Lint Verification**: Passed `npm run lint` cleanly.
- **Unit Tests**: Passed `npm run test` (102 tests passed across 18 suites).
- **E2E Tests**: Ran Playwright E2E verification test `tests/e2e/atom-components-cva.spec.ts` successfully.

### E2E Screenshot
Below is the captured screenshot demonstrating correct rendering of the updated atom components:

![Atom Components CVA E2E Screenshot](https://github.com/user-attachments/assets/cb3c1c38-89c0-4357-9d7a-d46ad5d8e785)
