### PR TITLE
feat: resolve issue #1487

### DIFF
--- a/src/lib/db-setup.ts
+++ b/src/lib/db-setup.ts
@@ -4,6 +4,7 @@ import type {
   CustomCategory,
   HistoryItem,
   ImageSyncState,
+  NotionSyncState,
   ParameterAlias,
   ParameterFolder,
   RecipeHistoryItem,
@@ -30,6 +31,7 @@ export class StyleAtelierDatabaseBase extends Dexie {
   parameterFolders!: Table<ParameterFolder, string>
   imageSyncStates!: Table<ImageSyncState, string>
   recipeHistory!: Table<RecipeHistoryItem, string>
+  notionSyncStates!: Table<NotionSyncState, string>
 
   constructor() {
     super("StyleAtelierDatabase")

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -13,6 +13,7 @@ export function setupMigrations(db: Dexie) {
   setupVersions5To9(db)
   setupVersions10To13(db)
   setupVersions14OrHigher(db)
+  setupVersions17OrHigher(db)
 }
 function setupVersions5To9(db: Dexie) {
   // Version 5: Previous version
@@ -153,6 +154,23 @@ function setupVersions14OrHigher(db: Dexie) {
       imageSyncStates: "filePath, cardId, categoryId, syncStatus"
     })
     .upgrade(upgradeToVersion16)
+}
+
+function setupVersions17OrHigher(db: Dexie) {
+  // Version 17: Add notionSyncStates table for Notion sync metadata
+  db.version(17).stores({
+    styleCards:
+      "id, name, createdAt, tier, isFavorite, isPinned, jobId, category, *associatedJobIds, isDeleted",
+    historyItems: "id, timestamp",
+    userSettings: "userId",
+    categories: "id, name, createdAt, isDeleted, parentId",
+    slotHistory: "label",
+    parameterAliases: "id, paramType, value, alias, folderId",
+    parameterFolders: "id, name, parentId",
+    recipeHistory: "id, timestamp",
+    imageSyncStates: "filePath, cardId, categoryId, syncStatus",
+    notionSyncStates: "cardId, notionPageId, lastSyncedAt"
+  })
 }
 
 export function upgradeToVersion6(tx: any) {

--- a/src/shared/lib/db-schema.ts
+++ b/src/shared/lib/db-schema.ts
@@ -174,3 +174,10 @@ export interface RecipeHistoryItem {
   }
   slotValues?: Record<string, string>
 }
+
+export interface NotionSyncState {
+  cardId: string
+  notionPageId: string
+  lastSyncedAt: number
+  lastSyncedHash: string
+}

--- a/tests/unit/lib/db/migrations.test.ts
+++ b/tests/unit/lib/db/migrations.test.ts
@@ -34,6 +34,7 @@ describe("setupMigrations", () => {
     expect(mockVersion).toHaveBeenCalledWith(14)
     expect(mockVersion).toHaveBeenCalledWith(15)
     expect(mockVersion).toHaveBeenCalledWith(16)
+    expect(mockVersion).toHaveBeenCalledWith(17)
   })
 })
 


### PR DESCRIPTION
# PR Walkthrough - [Task] [Notion Sync] ローカルDB（Dexie）の同期メタデータフィールドの追加とマイグレーション

This Pull Request implements the database schema updates and type definitions required to track Notion synchronization metadata. It adds a dedicated table `notionSyncStates` to Dexie database.

## Changes

### 1. Type Definition (`src/shared/lib/db-schema.ts`)
- Added `NotionSyncState` interface to hold the synchronization metadata for style cards.
  - `cardId` (Primary key, relates to `StyleCard.id`)
  - `notionPageId` (The Notion Page ID associated with the synced card)
  - `lastSyncedAt` (Timestamp of the last successful synchronization)
  - `lastSyncedHash` (Hash of the card content at the time of sync to detect local/remote changes)

### 2. Database Setup (`src/lib/db-setup.ts`)
- Imported `NotionSyncState` interface.
- Added `notionSyncStates` property definition (typed as `Table<NotionSyncState, string>`) to `StyleAtelierDatabaseBase` class.

### 3. Migrations (`src/lib/db/migrations.ts`)
- Configured version 17 migration schema in Dexie database.
- Added the `notionSyncStates` table with keys `cardId`, `notionPageId`, and `lastSyncedAt`.

### 4. Tests (`tests/unit/lib/db/migrations.test.ts`)
- Added validation for version 17 database structure registrations.

## Verification

### Unit Tests
Ran vitest unit tests:
```bash
npm run test tests/unit/lib/db/migrations.test.ts
```
Result: All tests passed successfully.
