### PR TITLE
feat: implement Notion API error handler with exponential backoff and Retry-After support

### DIFF
--- a/src/lib/notion/client.ts
+++ b/src/lib/notion/client.ts
@@ -4,6 +4,94 @@ import {
   buildSegmentString
 } from "../../shared/lib/prompt-utils"
 
+export const retryConfig = {
+  sleep: (ms: number): Promise<void> => {
+    if (typeof process !== "undefined" && process.env.NODE_ENV === "test") {
+      return Promise.resolve()
+    }
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  },
+  recordedDelays: [] as number[]
+}
+
+function calculateDelay(attempt: number, response?: Response): number {
+  const defaultDelay = Math.pow(2, attempt) * 1000
+
+  if (response?.status === 429) {
+    const retryAfterHeader = response.headers?.get
+      ? response.headers.get("Retry-After")
+      : null
+    if (retryAfterHeader) {
+      const seconds = parseInt(retryAfterHeader, 10)
+      if (!isNaN(seconds)) {
+        return seconds * 1000
+      }
+      const dateMs = Date.parse(retryAfterHeader)
+      if (!isNaN(dateMs)) {
+        const diff = dateMs - Date.now()
+        return diff > 0 ? diff : 0
+      }
+    }
+  }
+
+  return defaultDelay
+}
+
+async function handleRetry(
+  attempt: number,
+  maxRetries: number,
+  errorOrResponse: any,
+  isNetworkError: boolean
+): Promise<void> {
+  const response = isNetworkError ? undefined : (errorOrResponse as Response)
+  const delayMs = calculateDelay(attempt, response)
+
+  const errorMsg = isNetworkError
+    ? `network error (${errorOrResponse instanceof Error ? errorOrResponse.message : String(errorOrResponse)})`
+    : response?.status === 429
+      ? "429 Too Many Requests"
+      : `server error (${response?.status})`
+
+  console.warn(
+    `Notion API ${errorMsg}. Retrying in ${delayMs}ms (attempt ${attempt + 1}/${maxRetries})...`
+  )
+  retryConfig.recordedDelays.push(delayMs)
+  await retryConfig.sleep(delayMs)
+}
+
+async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  maxRetries: number = 5
+): Promise<Response> {
+  let attempt = 0
+  while (true) {
+    try {
+      const response = await fetch(input, init)
+
+      if (
+        response.status === 429 ||
+        (response.status >= 500 && response.status < 600)
+      ) {
+        if (attempt >= maxRetries) {
+          return response
+        }
+        await handleRetry(attempt, maxRetries, response, false)
+        attempt++
+        continue
+      }
+
+      return response
+    } catch (error) {
+      if (attempt >= maxRetries) {
+        throw error
+      }
+      await handleRetry(attempt, maxRetries, error, true)
+      attempt++
+    }
+  }
+}
+
 export interface NotionClientCredentials {
   apiKey: string
   databaseId: string
@@ -81,7 +169,7 @@ export async function validateNotionConnection(
     return false
   }
   try {
-    const response = await fetch(
+    const response = await fetchWithRetry(
       `https://api.notion.com/v1/databases/${credentials.databaseId}`,
       {
         method: "GET",
@@ -155,7 +243,7 @@ export async function sendCardToNotion(
 
   const properties = mapCardToNotionProperties(card)
 
-  const response = await fetch("https://api.notion.com/v1/pages", {
+  const response = await fetchWithRetry("https://api.notion.com/v1/pages", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${creds.apiKey}`,
@@ -199,17 +287,20 @@ export async function updateCardInNotion(
 
   const properties = mapCardToNotionProperties(card)
 
-  const response = await fetch(`https://api.notion.com/v1/pages/${pageId}`, {
-    method: "PATCH",
-    headers: {
-      Authorization: `Bearer ${creds.apiKey}`,
-      "Notion-Version": "2022-06-28",
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify({
-      properties
-    })
-  })
+  const response = await fetchWithRetry(
+    `https://api.notion.com/v1/pages/${pageId}`,
+    {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${creds.apiKey}`,
+        "Notion-Version": "2022-06-28",
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        properties
+      })
+    }
+  )
 
   if (!response.ok) {
     const errorText = await response.text()

--- a/tests/unit/lib/notion/client.test.ts
+++ b/tests/unit/lib/notion/client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import * as notionClient from "../../../../src/lib/notion/client"
 import {
   getNotionCredentials,
   sendCardToNotion,
@@ -13,6 +14,7 @@ describe("Notion API Client", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     vi.spyOn(global, "fetch").mockImplementation(vi.fn() as any)
+    notionClient.retryConfig.recordedDelays = []
   })
 
   afterEach(() => {
@@ -321,6 +323,169 @@ describe("Notion API Client", () => {
       await expect(
         updateCardInNotion("page-789", mockCard, mockCredentials)
       ).rejects.toThrow("Notion API error (400): Bad Request")
+    })
+  })
+
+  describe("Retry Resilience", () => {
+    const mockCard: StyleCard = {
+      id: "card-123",
+      name: "Cyber Punk Cat",
+      createdAt: 123456,
+      updatedAt: 123456,
+      promptSegments: [
+        { type: "text", value: "a cool cat" },
+        { type: "text", value: "neon lights" }
+      ],
+      parameters: {
+        ar: "16:9",
+        stylize: 250
+      },
+      masking: {
+        isSrefHidden: false,
+        isPHidden: false
+      },
+      tier: "Rare",
+      isFavorite: false,
+      usageCount: 0,
+      tags: ["cyberpunk", "animal"],
+      frameId: "default",
+      dominantColor: "#000000",
+      genealogy: {
+        generation: 1,
+        parentIds: [],
+        mutationNote: "First Gen"
+      },
+      thumbnailPath: "images/cards/card-123.png",
+      images: ["https://example.com/image.png"]
+    }
+
+    const mockCredentials = {
+      apiKey: "secret-key",
+      databaseId: "db-id"
+    }
+
+    it("should retry with exponential backoff on 429 if Retry-After header is missing", async () => {
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers: new Headers(),
+          text: vi.fn().mockResolvedValue("Rate limit exceeded")
+        } as any)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers: new Headers(),
+          text: vi.fn().mockResolvedValue("Rate limit exceeded")
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ id: "page-789" })
+        } as any)
+
+      const result = await sendCardToNotion(mockCard, mockCredentials)
+      expect(result).toEqual({ pageId: "page-789" })
+      expect(global.fetch).toHaveBeenCalledTimes(3)
+
+      expect(notionClient.retryConfig.recordedDelays).toEqual([1000, 2000])
+    })
+
+    it("should retry using Retry-After header seconds on 429", async () => {
+      const headers = new Headers()
+      headers.set("Retry-After", "3")
+
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers,
+          text: vi.fn().mockResolvedValue("Rate limit exceeded")
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ id: "page-789" })
+        } as any)
+
+      const result = await sendCardToNotion(mockCard, mockCredentials)
+      expect(result).toEqual({ pageId: "page-789" })
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+
+      expect(notionClient.retryConfig.recordedDelays).toEqual([3000])
+    })
+
+    it("should retry using Retry-After header HTTP-date on 429", async () => {
+      const futureDate = new Date(Date.now() + 5000)
+      const headers = new Headers()
+      headers.set("Retry-After", futureDate.toUTCString())
+
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers,
+          text: vi.fn().mockResolvedValue("Rate limit exceeded")
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ id: "page-789" })
+        } as any)
+
+      const result = await sendCardToNotion(mockCard, mockCredentials)
+      expect(result).toEqual({ pageId: "page-789" })
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+
+      expect(notionClient.retryConfig.recordedDelays.length).toBe(1)
+      const sleepArg = notionClient.retryConfig.recordedDelays[0]
+      expect(sleepArg).toBeGreaterThanOrEqual(4000)
+      expect(sleepArg).toBeLessThanOrEqual(6000)
+    })
+
+    it("should retry on 5xx temporary server errors", async () => {
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          text: vi.fn().mockResolvedValue("Service Unavailable")
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ id: "page-789" })
+        } as any)
+
+      const result = await sendCardToNotion(mockCard, mockCredentials)
+      expect(result).toEqual({ pageId: "page-789" })
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+      expect(notionClient.retryConfig.recordedDelays).toEqual([1000])
+    })
+
+    it("should retry on network type errors", async () => {
+      vi.mocked(global.fetch)
+        .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ id: "page-789" })
+        } as any)
+
+      const result = await sendCardToNotion(mockCard, mockCredentials)
+      expect(result).toEqual({ pageId: "page-789" })
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+      expect(notionClient.retryConfig.recordedDelays).toEqual([1000])
+    })
+
+    it("should throw error if retry count exceeds max limit", async () => {
+      for (let i = 0; i < 6; i++) {
+        vi.mocked(global.fetch).mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers: new Headers(),
+          text: vi.fn().mockResolvedValue("Rate limit exceeded")
+        } as any)
+      }
+
+      await expect(sendCardToNotion(mockCard, mockCredentials)).rejects.toThrow(
+        "Notion API error (429): Rate limit exceeded"
+      )
+      expect(global.fetch).toHaveBeenCalledTimes(6)
     })
   })
 })


### PR DESCRIPTION
### Description

Implemented an error handler wrapper etchWithRetry for Notion API requests to handle rate limits and server errors gracefully.

### Key Changes
- **Retry Mechanism**: Automatically retries on 429 Too Many Requests, 5xx Server Errors, and network failures up to a maximum of 5 attempts.
- **Retry-After Support**: Parses Retry-After header (both integer seconds and UTC HTTP-date) to dynamically adjust retry wait time, falling back to exponential backoff (1s, 2s, 4s, 8s, 16s) if absent.
- **Refactoring & Code Quality**: Separated logic into calculateDelay and handleRetry to keep functions small and satisfy ESLint complexity / line limit rules.
- **Tests Added**: Wrote comprehensive unit tests verifying retry behaviors under diverse conditions (exponential backoff, retry-after seconds, retry-after date, 5xx server issues, type errors, max retry limit exceeded).
- **No UX Changes**: Since this is a backend refactoring task, no UX changes were made (E2E tests / screenshots are not applicable).

Closes #1497.