### PR TITLE
feat: implement image clip/zoom adjustment on minting preview (#1599)

### DIFF
--- a/memory-bank/userJourneys.json
+++ b/memory-bank/userJourneys.json
@@ -888,6 +888,22 @@
         "src/features/settings/components/NotionSettingsSection.tsx",
         "src/lib/notion/client.ts"
       ]
+    },
+    {
+      "id": "@J-MINT-CLIP-ADJUSTER-01",
+      "name": "画像をクリップ調整",
+      "description": "ミントプレビュー画面で画像のズームと表示オフセット位置を調整する",
+      "steps": [
+        "ミント画面で画像プレビューをクリック",
+        "ClipAdjuster モーダルでスライダーをドラッグしてズームを調整",
+        "画像をドラッグしてオフセット位置を調整",
+        "「適用」ボタンを押下して設定を反映"
+      ],
+      "nextJourneys": ["@J-MINT-EXPERT-01"],
+      "viewComponents": [
+        "src/features/minting/components/ClipAdjuster.tsx",
+        "src/features/minting/components/MintingView/MintingViewContent.tsx"
+      ]
     }
   ]
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -67,7 +67,9 @@ export default defineConfig({
     /* Capture screenshot after each test. */
     screenshot: "on",
     /* Record video only when a test fails. */
-    video: "off"
+    video: "off",
+    /* Enforce English locale for test UI consistency */
+    locale: "en-US"
   },
 
   /* Configure projects for major browsers */

--- a/src/components/organisms/ExpertModeView/ExpertModeOverlayManager.tsx
+++ b/src/components/organisms/ExpertModeView/ExpertModeOverlayManager.tsx
@@ -15,6 +15,8 @@ function MintingOverlay({ minting }: { minting: any }) {
       setIsSrefHidden={minting.setIsSrefHidden}
       isPHidden={minting.isPHidden}
       setIsPHidden={minting.setIsPHidden}
+      clipSettings={minting.clipSettings}
+      setClipSettings={minting.setClipSettings}
       onCancelMinting={() => {
         minting.setMintingItem(null)
         minting.setVariationBase(null)

--- a/src/features/minting/components/ClipAdjuster.tsx
+++ b/src/features/minting/components/ClipAdjuster.tsx
@@ -1,0 +1,167 @@
+/* eslint-disable max-lines-per-function, react/forbid-elements */
+import React, { useEffect, useRef, useState } from "react"
+
+import { Button } from "~components/atoms/Button"
+import type { ClipSettings } from "~shared/lib/db-schema"
+
+interface ClipAdjusterProps {
+  imageUrl: string
+  clipSettings?: ClipSettings
+  onChange: (clip: ClipSettings) => void
+  onClose: () => void
+}
+
+export function ClipAdjuster({
+  imageUrl,
+  clipSettings,
+  onChange,
+  onClose
+}: ClipAdjusterProps) {
+  const [zoom, setZoom] = useState(clipSettings?.zoom ?? 1.0)
+  const [xOffset, setXOffset] = useState(clipSettings?.xOffset ?? 0.0)
+  const [yOffset, setYOffset] = useState(clipSettings?.yOffset ?? 0.0)
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const isDragging = useRef(false)
+  const startPos = useRef({ x: 0, y: 0 })
+  const startOffset = useRef({ x: 0, y: 0 })
+
+  const handleZoomChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const nextZoom = parseFloat(e.target.value)
+    setZoom(nextZoom)
+  }
+
+  const handleStart = (clientX: number, clientY: number) => {
+    isDragging.current = true
+    startPos.current = { x: clientX, y: clientY }
+    startOffset.current = { x: xOffset, y: yOffset }
+  }
+
+  const handleMove = (clientX: number, clientY: number) => {
+    if (!isDragging.current || !containerRef.current) return
+
+    const rect = containerRef.current.getBoundingClientRect()
+    const dx = clientX - startPos.current.x
+    const dy = clientY - startPos.current.y
+
+    // ズームレベルに応じた感度調整
+    let nextX = startOffset.current.x - dx / (rect.width * zoom)
+    let nextY = startOffset.current.y - dy / (rect.height * zoom)
+
+    if (nextX < -0.5) nextX = -0.5
+    if (nextX > 0.5) nextX = 0.5
+    if (nextY < -0.5) nextY = -0.5
+    if (nextY > 0.5) nextY = 0.5
+
+    setXOffset(nextX)
+    setYOffset(nextY)
+  }
+
+  useEffect(() => {
+    const handleMouseUp = () => {
+      isDragging.current = false
+    }
+    window.addEventListener("mouseup", handleMouseUp)
+    window.addEventListener("touchend", handleMouseUp)
+    return () => {
+      window.removeEventListener("mouseup", handleMouseUp)
+      window.removeEventListener("touchend", handleMouseUp)
+    }
+  }, [])
+
+  const handleSave = () => {
+    onChange({
+      zoom,
+      xOffset,
+      yOffset
+    })
+    onClose()
+  }
+
+  const previewStyle: React.CSSProperties = {
+    transform: `scale(${zoom}) translate(${-xOffset * 100}%, ${-yOffset * 100}%)`,
+    transition: isDragging.current ? "none" : "transform 0.1s ease-out",
+    transformOrigin: "center center"
+  }
+
+  return (
+    <div className="fixed inset-0 bg-slate-900/80 backdrop-blur-sm z-50 flex flex-col justify-end sm:justify-center p-4">
+      <div className="bg-white rounded-2xl shadow-xl max-w-md w-full mx-auto overflow-hidden flex flex-col">
+        <div className="p-4 border-b flex justify-between items-center bg-slate-50">
+          <h3 className="font-bold text-slate-800">画像をクリップ調整</h3>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 text-xl font-bold p-1"
+            aria-label="Close">
+            &times;
+          </button>
+        </div>
+
+        <div
+          ref={containerRef}
+          className="relative w-full aspect-square bg-slate-950 overflow-hidden cursor-move touch-none"
+          onMouseDown={(e) => {
+            e.preventDefault()
+            handleStart(e.clientX, e.clientY)
+          }}
+          onMouseMove={(e) => {
+            if (isDragging.current) {
+              e.preventDefault()
+              handleMove(e.clientX, e.clientY)
+            }
+          }}
+          onTouchStart={(e) => {
+            if (e.touches.length === 1) {
+              handleStart(e.touches[0].clientX, e.touches[0].clientY)
+            }
+          }}
+          onTouchMove={(e) => {
+            if (isDragging.current && e.touches.length === 1) {
+              handleMove(e.touches[0].clientX, e.touches[0].clientY)
+            }
+          }}>
+          <img
+            src={imageUrl}
+            alt="Adjust clip"
+            className="w-full h-full object-cover select-none pointer-events-none"
+            style={previewStyle}
+          />
+          <div className="absolute inset-0 border border-white/20 pointer-events-none flex items-center justify-center">
+            <div className="w-1/3 h-1/3 border border-dashed border-white/30"></div>
+          </div>
+        </div>
+
+        <div className="p-4 bg-slate-50 border-t flex flex-col gap-4">
+          <div className="flex items-center gap-4">
+            <span className="text-xs font-bold text-slate-500 w-12">
+              ズーム
+            </span>
+            <input
+              type="range"
+              min="1.0"
+              max="3.0"
+              step="0.05"
+              value={zoom}
+              onChange={handleZoomChange}
+              className="flex-1 h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-indigo-600"
+            />
+            <span className="text-xs font-bold text-slate-600 w-10 text-right">
+              {zoom.toFixed(2)}x
+            </span>
+          </div>
+
+          <div className="text-xs text-slate-400 text-center">
+            画像をドラッグして位置調整、スライダーでズームを変更できます
+          </div>
+
+          <div className="flex gap-2 justify-end mt-2">
+            <Button variant="ghost" onClick={onClose}>
+              キャンセル
+            </Button>
+            <Button onClick={handleSave}>適用</Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/minting/components/MintingView.tsx
+++ b/src/features/minting/components/MintingView.tsx
@@ -7,7 +7,11 @@ import { useTutorial } from "~contexts/TutorialContext"
 import { useCategories } from "~hooks/useCategories"
 import { useHand } from "~hooks/useHand"
 import type { RarityTier } from "~lib/rarity-config"
-import type { HistoryItem, PromptSegment } from "~shared/lib/db-schema"
+import type {
+  ClipSettings,
+  HistoryItem,
+  PromptSegment
+} from "~shared/lib/db-schema"
 
 import { MintingViewContent } from "./MintingView/MintingViewContent"
 
@@ -40,6 +44,8 @@ interface MintingViewProps {
   detectedColorTags?: string[]
   mutationNote?: string
   setMutationNote?: (note: string) => void
+  clipSettings?: ClipSettings
+  setClipSettings?: (clip?: ClipSettings) => void
 }
 
 function MintingHeader({ t }: { t: any }) {

--- a/src/features/minting/components/MintingView/MintingViewContent.tsx
+++ b/src/features/minting/components/MintingView/MintingViewContent.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import React from "react"
 
 import { HelpTooltip } from "~components/atoms/HelpTooltip"
@@ -5,8 +6,13 @@ import { PromptBubble } from "~components/molecules/PromptBubble"
 import { RaritySelector } from "~components/molecules/RaritySelector"
 import { PromptBubbleEditor } from "~components/organisms/PromptBubbleEditor"
 import type { RarityTier } from "~lib/rarity-config"
-import type { HistoryItem, PromptSegment } from "~shared/lib/db-schema"
+import type {
+  ClipSettings,
+  HistoryItem,
+  PromptSegment
+} from "~shared/lib/db-schema"
 
+import { ClipAdjuster } from "../ClipAdjuster"
 import { CardIdentitySection } from "./CardIdentitySection"
 
 interface MintingViewProps {
@@ -35,6 +41,8 @@ interface MintingViewProps {
   detectedColorTags?: string[]
   mutationNote?: string
   setMutationNote?: (note: string) => void
+  clipSettings?: ClipSettings
+  setClipSettings?: (clip?: ClipSettings) => void
 }
 
 function PromptSegmentsSection({
@@ -127,15 +135,66 @@ export function MintingViewContent({
   toggleKeyword,
   advanceIfStep
 }: MintingViewContentProps) {
+  const [showAdjuster, setShowAdjuster] = React.useState(false)
+
   if (!props.mintingItem) {
     return null
   }
+
+  const clip = props.clipSettings
+  const previewStyle: React.CSSProperties | undefined = clip
+    ? {
+        transform: `scale(${clip.zoom}) translate(${-clip.xOffset * 100}%, ${-clip.yOffset * 100}%)`,
+        transformOrigin: "center center",
+        transition: "transform 0.2s ease-out"
+      }
+    : undefined
+
   return (
     <>
-      <img
-        src={props.mintingItem.imageUrl}
-        className="w-full h-auto rounded-lg mb-4 shadow-md"
-      />
+      <div
+        onClick={() => setShowAdjuster(true)}
+        className="relative w-full aspect-square bg-slate-900 rounded-lg mb-4 shadow-md overflow-hidden cursor-pointer group"
+        data-testid="minting-preview-container">
+        <img
+          src={props.mintingItem.imageUrl}
+          className="w-full h-full object-cover transition-transform duration-200"
+          style={previewStyle}
+          alt="Card Preview"
+        />
+        <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
+          <span className="text-white text-sm font-bold bg-slate-900/80 px-3 py-1.5 rounded-full flex items-center gap-1.5 shadow-lg border border-white/10">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="lucide lucide-crop">
+              <path d="M6 2v14a2 2 0 0 0 2 2h14" />
+              <path d="M18 22V8a2 2 0 0 0-2-2H2" />
+            </svg>
+            画像を調整
+          </span>
+        </div>
+      </div>
+
+      {showAdjuster && (
+        <ClipAdjuster
+          imageUrl={props.mintingItem.imageUrl}
+          clipSettings={props.clipSettings}
+          onChange={(newClip) => {
+            if (props.setClipSettings) {
+              props.setClipSettings(newClip)
+            }
+          }}
+          onClose={() => setShowAdjuster(false)}
+        />
+      )}
 
       <CardIdentitySection
         props={props}

--- a/src/hooks/useMinting.ts
+++ b/src/hooks/useMinting.ts
@@ -11,6 +11,7 @@ import {
 import { extractKeywords } from "../lib/nlp-utils"
 import type { RarityTier } from "../lib/rarity-config"
 import type {
+  ClipSettings,
   HistoryItem,
   PromptSegment,
   StyleCard
@@ -79,6 +80,7 @@ export interface SaveMintedCardParams {
   dispatchState: React.Dispatch<React.SetStateAction<MintingState>>
   setActiveTab: (tab: "history" | "library" | "workbench") => void
   setAlertType?: (type: AlertType) => void
+  clipSettings?: ClipSettings
 }
 
 export function useSaveMintedCard(p: SaveMintedCardParams) {
@@ -103,7 +105,8 @@ export function useSaveMintedCard(p: SaveMintedCardParams) {
         p.isPHidden,
         thumbnailData,
         p.meta,
-        p.colors
+        p.colors,
+        p.clipSettings
       )
       const newCard = buildMintedCard(buildParams)
       await db.styleCards.put(newCard)
@@ -112,7 +115,8 @@ export function useSaveMintedCard(p: SaveMintedCardParams) {
         ...s,
         mintingItem: null,
         isSrefHidden: false,
-        isPHidden: false
+        isPHidden: false,
+        clipSettings: undefined
       }))
       p.setActiveTab("library")
     } catch (err) {
@@ -130,6 +134,7 @@ export interface MintingState {
   isSrefHidden: boolean
   isPHidden: boolean
   selectedRarity: RarityTier
+  clipSettings?: ClipSettings
 }
 
 export const INITIAL_MINTING_STATE: MintingState = {
@@ -138,7 +143,8 @@ export const INITIAL_MINTING_STATE: MintingState = {
   editedSegments: [],
   isSrefHidden: false,
   isPHidden: false,
-  selectedRarity: "Common"
+  selectedRarity: "Common",
+  clipSettings: undefined
 }
 
 export function createMintingHandlers(
@@ -153,10 +159,22 @@ export function createMintingHandlers(
       setState((s) => ({ ...s, isPHidden: hidden })),
     setSelectedRarity: (rarity: RarityTier) =>
       setState((s) => ({ ...s, selectedRarity: rarity })),
+    setClipSettings: (clip?: ClipSettings) =>
+      setState((s) => ({ ...s, clipSettings: clip })),
     handleStartMinting: (item: HistoryItem) =>
-      setState((s) => ({ ...s, mintingItem: item, variationBase: null })),
+      setState((s) => ({
+        ...s,
+        mintingItem: item,
+        variationBase: null,
+        clipSettings: undefined
+      })),
     handleStartVariationMinting: (base: VariationBase) =>
-      setState((s) => ({ ...s, variationBase: base, mintingItem: null })),
+      setState((s) => ({
+        ...s,
+        variationBase: base,
+        mintingItem: null,
+        clipSettings: undefined
+      })),
     setMintingItem: (item: HistoryItem | null) =>
       setState((s) => ({ ...s, mintingItem: item })),
     setVariationBase: (base: VariationBase | null) =>

--- a/src/lib/export/draw-helpers.ts
+++ b/src/lib/export/draw-helpers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function, sonarjs/cognitive-complexity */
 import type { StyleCard } from "../../shared/lib/db-schema"
 import { compressCardData, generateQRCodeUrl } from "../../shared/lib/qr-utils"
 import { drawRoundedRect, loadImage, resolveLocalImageSource } from "./helpers"
@@ -97,7 +98,8 @@ export function drawArtworkGrid(
   artX: number,
   artY: number,
   artW: number,
-  artH: number
+  artH: number,
+  card?: StyleCard
 ) {
   if (loadedImages.length === 4) {
     const halfW = artW / 2
@@ -124,7 +126,54 @@ export function drawArtworkGrid(
     ctx.drawImage(loadedImages[0], artX, artY, halfW, artH)
     ctx.drawImage(loadedImages[1], artX + halfW, artY, halfW, artH)
   } else if (loadedImages.length === 1) {
-    ctx.drawImage(loadedImages[0], artX, artY, artW, artH)
+    const img = loadedImages[0]
+    const clip = card?.clipSettings
+
+    let zoom = clip?.zoom !== undefined ? clip.zoom : 1.0
+    if (zoom < 1.0) zoom = 1.0
+    if (zoom > 3.0) zoom = 3.0
+
+    let xOffset = clip?.xOffset !== undefined ? clip.xOffset : 0.0
+    if (xOffset < -0.5) xOffset = -0.5
+    if (xOffset > 0.5) xOffset = 0.5
+
+    let yOffset = clip?.yOffset !== undefined ? clip.yOffset : 0.0
+    if (yOffset < -0.5) yOffset = -0.5
+    if (yOffset > 0.5) yOffset = 0.5
+
+    const targetRatio = artW / artH
+    const imgRatio = img.width / img.height
+
+    let sw = img.width
+    let sh = img.height
+
+    if (imgRatio > targetRatio) {
+      sw = img.height * targetRatio
+      sh = img.height
+    } else {
+      sw = img.width
+      sh = img.width / targetRatio
+    }
+
+    const swZoomed = sw / zoom
+    const shZoomed = sh / zoom
+
+    const dx = img.width * xOffset
+    const dy = img.height * yOffset
+
+    const cx = img.width / 2 + dx
+    const cy = img.height / 2 + dy
+
+    let sxNew = cx - swZoomed / 2
+    let syNew = cy - shZoomed / 2
+
+    if (sxNew < 0) sxNew = 0
+    if (sxNew > img.width - swZoomed) sxNew = img.width - swZoomed
+
+    if (syNew < 0) syNew = 0
+    if (syNew > img.height - shZoomed) syNew = img.height - shZoomed
+
+    ctx.drawImage(img, sxNew, syNew, swZoomed, shZoomed, artX, artY, artW, artH)
   } else {
     ctx.fillStyle = "#475569"
     ctx.font = "24px sans-serif"

--- a/src/lib/export/draw.ts
+++ b/src/lib/export/draw.ts
@@ -36,7 +36,7 @@ export async function drawArtwork(
       iconUrl,
       objectUrlsToRevoke
     )
-    drawArtworkGrid(ctx, loadedImages, artX, artY, artW, artH)
+    drawArtworkGrid(ctx, loadedImages, artX, artY, artW, artH, card)
   } catch (err: any) {
     throw new Error(`Failed to draw artwork to canvas: ${err.message || err}`, {
       cause: err

--- a/src/lib/minting-helper.ts
+++ b/src/lib/minting-helper.ts
@@ -1,4 +1,5 @@
 import type {
+  ClipSettings,
   HistoryItem,
   PromptSegment,
   StyleCard
@@ -30,6 +31,7 @@ export interface BuildCardParams {
   isSrefHidden: boolean
   isPHidden: boolean
   mutationNote?: string
+  clipSettings?: ClipSettings
 }
 
 export function resolveCardName(
@@ -139,7 +141,8 @@ export function createBuildCardParams(
     detectedColorTags: string[]
     detectedDominantColor: string
     detectedAccentColor: string
-  }
+  },
+  clipSettings?: ClipSettings
 ): BuildCardParams {
   return {
     mintingItem,
@@ -156,7 +159,8 @@ export function createBuildCardParams(
     thumbnailData,
     isSrefHidden,
     isPHidden,
-    mutationNote: meta.mutationNote
+    mutationNote: meta.mutationNote,
+    clipSettings
   }
 }
 
@@ -176,7 +180,8 @@ export function buildMintedCard(params: BuildCardParams): StyleCard {
     thumbnailData,
     isSrefHidden,
     isPHidden,
-    mutationNote
+    mutationNote,
+    clipSettings
   } = params
 
   const { parameters, genealogy, images, selectedThumbnails } =
@@ -205,7 +210,8 @@ export function buildMintedCard(params: BuildCardParams): StyleCard {
     jobId: mintingItem ? mintingItem.id : undefined,
     associatedJobIds: mintingItem ? [mintingItem.id] : [],
     images,
-    selectedThumbnails
+    selectedThumbnails,
+    clipSettings
   }
 }
 

--- a/tests/e2e/mint-expert.spec.ts
+++ b/tests/e2e/mint-expert.spec.ts
@@ -1,9 +1,25 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import path from "path"
 import { expect, test } from "@playwright/test"
 
 test.describe("Style Atelier Sandbox E2E Tests - Expert Minting", () => {
   test.beforeEach(async ({ page }) => {
+    // Force Expert Mode and enable all features for these tests
+    await page.addInitScript(() => {
+      localStorage.setItem("style-atelier-easy-mode", "false")
+      localStorage.setItem(
+        "style-atelier-expert-features",
+        JSON.stringify({
+          stack: true,
+          slot: true,
+          rarity: true,
+          tags: true,
+          categories: true,
+          multiCard: true,
+          cardEditing: true,
+          multiImage: true
+        })
+      )
+    })
     page.on("console", (msg) => {
       console.log(`[BROWSER CONSOLE] ${msg.type()}: ${msg.text()}`)
     })
@@ -33,7 +49,10 @@ test.describe("Style Atelier Sandbox E2E Tests - Expert Minting", () => {
 
     // 1. Skip welcome dialog
     const skipButton = spFrame.locator("#welcome-skip-btn")
-    if (await skipButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await skipButton
+      .waitFor({ state: "visible", timeout: 10000 })
+      .catch(() => {})
+    if (await skipButton.isVisible()) {
       await skipButton.click()
     }
 
@@ -146,8 +165,144 @@ test.describe("Style Atelier Sandbox E2E Tests - Expert Minting", () => {
       path: path.join(screenshotsDir, "mint-expert-detail-verify.png")
     })
 
-    // Close the detail view
     const closeDetailBtn = detailView.locator("button").first()
     await closeDetailBtn.click()
+  })
+
+  test("should allow adjusting clip settings on minting preview and save card (@J-MINT-CLIP-ADJUSTER-01)", async ({
+    page
+  }) => {
+    const screenshotsDir = path.join(__dirname, "../../tests/screenshots")
+    console.log("Navigating to sandbox page for Clip Adjuster E2E test...")
+    await page.goto("/tests/sandbox/index.html")
+
+    const spFrame = page.frameLocator("#sidepanel-frame")
+
+    // 1. Skip welcome dialog
+    const skipButton = spFrame.locator("#welcome-skip-btn")
+    await skipButton
+      .waitFor({ state: "visible", timeout: 10000 })
+      .catch(() => {})
+    if (await skipButton.isVisible()) {
+      await skipButton.click()
+    }
+
+    // 2. Seed database with mock history item
+    await spFrame.locator("body").evaluate(async () => {
+      const database = (window as any).db
+      await database.historyItems.clear()
+      await database.historyItems.add({
+        id: "mock-history-item-to-clip",
+        fullCommand: "a beautiful cyberpunk warrior --ar 1:1",
+        imageUrl: "/tests/fixtures/midjourney/index_files/0_0_640_N.webp",
+        timestamp: Date.now()
+      })
+      await database.categories.clear()
+      await database.categories.add({
+        id: "category-expert-1",
+        name: "Cyberpunk Tech",
+        iconEmoji: "🦾"
+      })
+    })
+
+    // 3. Switch to History tab and open Minting View
+    const historyTabButton = spFrame.locator("button:has-text('History')")
+    await expect(historyTabButton).toBeVisible()
+    await historyTabButton.click()
+
+    const mintCardBtn = spFrame.locator("button:has-text('Mint Card')").first()
+    await expect(mintCardBtn).toBeVisible({ timeout: 10000 })
+    await mintCardBtn.click()
+
+    // 4. Verify Minting View is open
+    const mintingView = spFrame.locator(
+      "[data-testid='minting-view-container']"
+    )
+    await expect(mintingView).toBeVisible({ timeout: 10000 })
+
+    // 5. Click the image preview to open ClipAdjuster
+    const previewContainer = spFrame.locator(
+      "[data-testid='minting-preview-container']"
+    )
+    await expect(previewContainer).toBeVisible()
+    await previewContainer.click()
+
+    // 6. Verify ClipAdjuster modal is open
+    const adjusterModal = spFrame.locator("h3:has-text('画像をクリップ調整')")
+    await expect(adjusterModal).toBeVisible({ timeout: 5000 })
+
+    // Take screenshot of ClipAdjuster Modal
+    await page.screenshot({
+      path: path.join(screenshotsDir, "clip-adjuster-modal-open.png")
+    })
+
+    // 7. Adjust Zoom via range input
+    const zoomInput = spFrame.locator("input[type='range']")
+    await expect(zoomInput).toBeVisible()
+    await zoomInput.evaluate((el: HTMLInputElement) => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value"
+      )?.set
+      if (nativeInputValueSetter) {
+        nativeInputValueSetter.call(el, "2.5")
+      } else {
+        el.value = "2.5"
+      }
+      el.dispatchEvent(new Event("input", { bubbles: true }))
+      el.dispatchEvent(new Event("change", { bubbles: true }))
+    })
+
+    // 8. Drag image to adjust offset
+    const dragImg = spFrame.locator("img[alt='Adjust clip']")
+    const boundingBox = await dragImg.boundingBox()
+    if (boundingBox) {
+      const startX = boundingBox.x + boundingBox.width / 2
+      const startY = boundingBox.y + boundingBox.height / 2
+      await page.mouse.move(startX, startY)
+      await page.mouse.down()
+      await page.mouse.move(startX - 30, startY + 40) // drag left/down slightly
+      await page.mouse.up()
+    }
+
+    // Take screenshot of ClipAdjuster Modal after adjustment
+    await page.screenshot({
+      path: path.join(screenshotsDir, "clip-adjuster-modal-adjusted.png")
+    })
+
+    // 9. Apply adjustment
+    const applyBtn = spFrame.locator("button:has-text('適用')")
+    await expect(applyBtn).toBeVisible()
+    await applyBtn.evaluate((el: HTMLElement) => el.click())
+
+    // 10. Verify ClipAdjuster is closed
+    await expect(adjusterModal).not.toBeVisible({ timeout: 5000 })
+
+    // 11. Enter custom name & save card
+    const nameInput = spFrame.locator("input[placeholder='Add details...']")
+    await nameInput.fill("Clip Test Warrior")
+
+    const saveCardBtn = spFrame.locator(
+      "button:has-text('Save Card'), button:has-text('カードを保存')"
+    )
+    await expect(saveCardBtn).toBeVisible()
+    await saveCardBtn.click()
+
+    // 12. Verify card is saved and DB has correct clipSettings
+    await expect(mintingView).not.toBeVisible({ timeout: 10000 })
+
+    const savedCards = await spFrame.locator("body").evaluate(async () => {
+      const database = (window as any).db
+      return await database.styleCards.toArray()
+    })
+
+    const targetCard = savedCards.find((c: any) =>
+      c.name.includes("Clip Test Warrior")
+    )
+    expect(targetCard).toBeDefined()
+    expect(targetCard.clipSettings).toBeDefined()
+    expect(targetCard.clipSettings.zoom).toBeCloseTo(2.5, 1)
+    expect(targetCard.clipSettings.xOffset).not.toBe(0)
+    expect(targetCard.clipSettings.yOffset).not.toBe(0)
   })
 })

--- a/tests/mocks/db.ts
+++ b/tests/mocks/db.ts
@@ -404,6 +404,42 @@ export class MockStyleAtelierDatabase {
   clearRecipeHistory = vi.fn().mockImplementation(async () => {
     await this.recipeHistory.clear()
   })
+
+  getUserSettings = vi
+    .fn()
+    .mockImplementation(async (): Promise<UserSettings> => {
+      const all = await this.userSettings.toArray()
+      if (all.length > 0) {
+        return all[0]
+      }
+      const defaultSettings: UserSettings = {
+        userId: "default-user",
+        isPro: false,
+        unlockedSkins: [],
+        branding: {
+          enabled: false,
+          socialDisplayType: "none"
+        }
+      }
+      await this.userSettings.add(defaultSettings)
+      return defaultSettings
+    })
+
+  updateUserSettings = vi
+    .fn()
+    .mockImplementation(
+      async (changes: Partial<UserSettings>): Promise<void> => {
+        const current = await this.getUserSettings()
+        await this.userSettings.put({
+          ...current,
+          ...changes,
+          branding: {
+            ...current.branding,
+            ...changes.branding
+          }
+        })
+      }
+    )
 }
 
 export const db = new MockStyleAtelierDatabase()


### PR DESCRIPTION
## Overview
This PR implements the image clipping and zoom adjustment functionality on the style card minting preview as requested in #1599.

### Key Changes
1. **Core Canvas Clipping & Zoom Logic**:
   - Updated drawArtwork and drawArtworkGrid to apply ClipSettings.
2. **State & Database Persistence**:
   - Saved clipSettings to the database schema.
3. **ClipAdjuster Modal Component**:
   - Created ClipAdjuster modal with drag-to-pan and zoom slider.
4. **E2E Testing & Stability Fixes**:
   - Added @J-MINT-CLIP-ADJUSTER-01 and solved destructuring ReferenceError.

### Verification
All E2E tests under mint-expert.spec.ts passed successfully.